### PR TITLE
Pixel scale calibration UI and scale bar

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -14,3 +14,4 @@ export * from "./api/instance_segmentation";
 export * from "./api/members";
 export * from "./api/reviews";
 export * from "./api/admin";
+export * from "./api/scale";

--- a/src/api/scale.js
+++ b/src/api/scale.js
@@ -1,0 +1,87 @@
+/**
+ * API client functions for image pixel-scale endpoints.
+ *
+ * All fetch() calls live here — never in components or stores (RULE: api/ layer
+ * is the single point of contact with the backend for scale operations).
+ */
+import { getAuthHeaders, handleApiError } from "./util";
+import { API_BASE_URL } from "./config";
+
+/**
+ * Fetch the current physical scale stored for an image.
+ *
+ * @param {number} imageId
+ * @returns {Promise<{scale_x: number, scale_y: number, unit: string}>}
+ */
+export const getPixelScale = async (imageId) => {
+  const response = await fetch(`${API_BASE_URL}/scale/get_pixel_scale/${imageId}`, {
+    headers: getAuthHeaders(),
+  });
+  return handleApiError(response);
+};
+
+/**
+ * Manually set the physical scale for a single image.
+ *
+ * @param {number} imageId
+ * @param {number} scaleX  Physical size of one pixel along x (in `unit` units).
+ * @param {number} scaleY  Physical size of one pixel along y (in `unit` units).
+ * @param {string} unit    Length unit string, e.g. "mm" or "µm".
+ * @returns {Promise<{message: string, scale_x: number, scale_y: number, unit: string}>}
+ */
+export const setPixelScale = async (imageId, scaleX, scaleY, unit) => {
+  const response = await fetch(`${API_BASE_URL}/scale/set_pixel_scale`, {
+    method: "POST",
+    headers: getAuthHeaders({ "Content-Type": "application/json" }),
+    body: JSON.stringify({ image_id: imageId, scale_x: scaleX, scale_y: scaleY, unit }),
+  });
+  return handleApiError(response);
+};
+
+/**
+ * Compute and store the physical scale from a user-drawn calibration line.
+ *
+ * The user draws a line between two known points on the image (pixel coordinates,
+ * NOT normalised 0-1 fractions) and provides the real-world distance between them.
+ *
+ * @param {number} imageId
+ * @param {{x: number, y: number}} p1  First point in image pixels.
+ * @param {{x: number, y: number}} p2  Second point in image pixels.
+ * @param {number} knownDistance       Real-world distance between p1 and p2.
+ * @param {string} unit                Unit of knownDistance, e.g. "mm".
+ * @returns {Promise<{message: string, scale_x: number, scale_y: number, unit: string, pixel_distance: number}>}
+ */
+export const setPixelScaleViaDrawnLine = async (imageId, p1, p2, knownDistance, unit) => {
+  const response = await fetch(`${API_BASE_URL}/scale/set_pixel_scale_via_drawn_line`, {
+    method: "POST",
+    headers: getAuthHeaders({ "Content-Type": "application/json" }),
+    body: JSON.stringify({
+      image_id: imageId,
+      x1: p1.x,
+      y1: p1.y,
+      x2: p2.x,
+      y2: p2.y,
+      known_distance: knownDistance,
+      unit,
+    }),
+  });
+  return handleApiError(response);
+};
+
+/**
+ * Apply the same physical scale to every image in a dataset.
+ *
+ * @param {number} datasetId
+ * @param {number} scaleX
+ * @param {number} scaleY
+ * @param {string} unit
+ * @returns {Promise<{message: string, images_updated: number, images_total: number, scale_x: number, scale_y: number, unit: string}>}
+ */
+export const applyScaleToDataset = async (datasetId, scaleX, scaleY, unit) => {
+  const response = await fetch(`${API_BASE_URL}/scale/apply_to_dataset`, {
+    method: "POST",
+    headers: getAuthHeaders({ "Content-Type": "application/json" }),
+    body: JSON.stringify({ dataset_id: datasetId, scale_x: scaleX, scale_y: scaleY, unit }),
+  });
+  return handleApiError(response);
+};

--- a/src/components/annotationPage/canvas/AIPromptCanvas.jsx
+++ b/src/components/annotationPage/canvas/AIPromptCanvas.jsx
@@ -407,6 +407,7 @@ const AIPromptCanvas = ({ width, height, renderBackground = true }) => {
         </div>
       )}
 
+      {containerSize.width > 0 && containerSize.height > 0 && (
       <Stage
         ref={stageRef}
         width={containerSize.width}
@@ -491,6 +492,7 @@ const AIPromptCanvas = ({ width, height, renderBackground = true }) => {
           )}
         </Layer>
       </Stage>
+      )}
 
       {focusModeWarning && (
         <div className="absolute top-4 left-1/2 transform -translate-x-1/2 z-50">

--- a/src/components/annotationPage/canvas/CanvasContainer.jsx
+++ b/src/components/annotationPage/canvas/CanvasContainer.jsx
@@ -12,6 +12,8 @@ import ObjectContextMenu from './ObjectContextMenu';
 import FocusOverlay from './FocusOverlay';
 import RefinementOverlay from './RefinementOverlay';
 import EditableContourOverlay from './EditableContourOverlay';
+import ScaleCalibrationOverlay from './ScaleCalibrationOverlay';
+import ScaleBarIndicator from './ScaleBarIndicator';
 import useAIAnnotationShortcuts from '../../../hooks/useAIAnnotationShortcuts';
 import useAISegmentation from '../../../hooks/useAISegmentation';
 import useFocusModeEscape from '../../../hooks/useFocusModeEscape';
@@ -207,6 +209,12 @@ const CanvasContainer = ({ imageObject, currentImage, zoomLevel, panOffset, isDr
 
       {/* Edit mode overlay (shows draggable control points for contour editing) */}
       <EditableContourOverlay canvasRef={canvasRef} zoomLevel={zoomLevel} panOffset={panOffset} />
+
+      {/* Scale calibration overlay — active only when set_scale tool is selected */}
+      <ScaleCalibrationOverlay canvasRef={canvasRef} zoomLevel={zoomLevel} panOffset={panOffset} />
+
+      {/* Scale bar — shown in bottom-right whenever a real-world scale is set */}
+      <ScaleBarIndicator canvasRef={canvasRef} zoomLevel={zoomLevel} />
 
       {/* Context menu for object labeling */}
       <ObjectContextMenu />

--- a/src/components/annotationPage/canvas/ScaleBarIndicator.jsx
+++ b/src/components/annotationPage/canvas/ScaleBarIndicator.jsx
@@ -1,0 +1,94 @@
+import React, { useMemo } from 'react';
+import { useImageScale, useImageObject } from '../../../stores/selectors/annotationSelectors';
+
+/**
+ * A map-style scale bar shown in the bottom-right corner of the canvas.
+ * Only renders when a real-world scale has been set (unit !== 'px').
+ *
+ * Props:
+ *   canvasRef {object}   Ref to the <img> element to compute rendered display bounds.
+ *   zoomLevel {number}   Current canvas zoom level (for computing displayed bar width).
+ */
+const ScaleBarIndicator = ({ canvasRef, zoomLevel = 1 }) => {
+  const scale = useImageScale();
+  const imageObject = useImageObject();
+
+  const barInfo = useMemo(() => {
+    if (!scale || scale.unit === 'px' || !scale.scaleX || scale.scaleX <= 0) return null;
+
+    // Calculate actual rendered CSS pixel width of the image inside container (object-contain)
+    let displayRatio = 1; // natural image pixels per rendered CSS screen pixel
+    if (canvasRef?.current && imageObject) {
+      const container = canvasRef.current.parentElement;
+      if (container) {
+        const containerWidth = container.offsetWidth;
+        const containerHeight = container.offsetHeight;
+        const imgW = imageObject.width || imageObject.naturalWidth || 0;
+        const imgH = imageObject.height || imageObject.naturalHeight || 0;
+
+        if (imgW > 0 && imgH > 0 && containerWidth > 0 && containerHeight > 0) {
+          const imageAspect = imgW / imgH;
+          const containerAspect = containerWidth / containerHeight;
+          const renderedWidth = imageAspect > containerAspect
+            ? containerWidth
+            : containerHeight * imageAspect;
+          displayRatio = imgW / renderedWidth;
+        }
+      }
+    }
+
+    // Target bar width on screen: ~130px for better visibility
+    const targetScreenPx = 130;
+    // Physical units per CSS screen pixel at current zoomLevel
+    const realPerScreenPx = (scale.scaleX * displayRatio) / zoomLevel;
+    const rawRealWidth = targetScreenPx * realPerScreenPx;
+
+    // Round to a "nice" number (1, 2, 5, 10, 20, 50, 100, ...)
+    const magnitude = Math.pow(10, Math.floor(Math.log10(rawRealWidth)));
+    const fraction = rawRealWidth / magnitude;
+    let nice;
+    if (fraction < 1.5) nice = 1;
+    else if (fraction < 3.5) nice = 2;
+    else if (fraction < 7.5) nice = 5;
+    else nice = 10;
+    const niceRealWidth = nice * magnitude;
+
+    // Convert back to screen pixels
+    const barScreenPx = niceRealWidth / realPerScreenPx;
+
+    // Format label: use integer if whole number, otherwise up to 3 sig figs
+    const label = Number.isInteger(niceRealWidth)
+      ? `${niceRealWidth} ${scale.unit}`
+      : `${parseFloat(niceRealWidth.toPrecision(3))} ${scale.unit}`;
+
+    return { barScreenPx, label };
+  }, [scale, zoomLevel, canvasRef, imageObject]);
+
+  if (!barInfo) return null;
+
+  return (
+    <div
+      className="absolute bottom-5 right-5 pointer-events-none select-none"
+      style={{ zIndex: 50 }}
+      aria-label={`Scale bar: ${barInfo.label}`}
+    >
+      <div className="bg-slate-900/85 backdrop-blur-md border border-slate-700/60 shadow-xl rounded-xl px-3.5 py-2 text-white flex flex-col items-center gap-1.5 transition-all">
+        {/* Bar */}
+        <div className="flex items-center gap-0">
+          <div className="w-0.5 h-3.5 bg-white rounded-full shadow-xs" />
+          <div
+            style={{ width: `${barInfo.barScreenPx}px`, height: '2.5px' }}
+            className="bg-white rounded-full shadow-xs"
+          />
+          <div className="w-0.5 h-3.5 bg-white rounded-full shadow-xs" />
+        </div>
+        {/* Label */}
+        <span className="text-xs font-bold tracking-wider leading-none text-slate-100 drop-shadow-xs">
+          {barInfo.label}
+        </span>
+      </div>
+    </div>
+  );
+};
+
+export default ScaleBarIndicator;

--- a/src/components/annotationPage/canvas/ScaleCalibrationOverlay.jsx
+++ b/src/components/annotationPage/canvas/ScaleCalibrationOverlay.jsx
@@ -1,0 +1,274 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import ReactDOM from 'react-dom';
+import { setPixelScaleViaDrawnLine } from '../../../api/scale';
+import {
+  useCalibrationPoints,
+  useCancelCalibration,
+  useCurrentImageId,
+  useImageObject,
+  useIsCalibrating,
+  useSetCalibrationPoint,
+  useSetImageScale,
+} from '../../../stores/selectors/annotationSelectors';
+import ScaleInputModal from '../modals/ScaleInputModal';
+
+/**
+ * SVG overlay that handles drawing the two-point calibration line.
+ *
+ * The overlay is rendered outside the zoom/pan transform (identical to
+ * SegmentationOverlay) so it occupies the full canvas container and uses the
+ * same imageDimensions geometry to convert between container-relative clicks
+ * and image-pixel coordinates.
+ *
+ * Props:
+ *   canvasRef      ref to the <img> element (for getBoundingClientRect)
+ *   zoomLevel      current zoom level
+ *   panOffset      { x, y } current pan
+ *   imageObject    the loaded Image object (for naturalWidth/naturalHeight)
+ */
+const ScaleCalibrationOverlay = ({ canvasRef, zoomLevel, panOffset }) => {
+  const isCalibrating = useIsCalibrating();
+  const calibrationPoints = useCalibrationPoints();
+  const setCalibrationPoint = useSetCalibrationPoint();
+  const cancelCalibration = useCancelCalibration();
+  const setImageScale = useSetImageScale();
+  const imageObject = useImageObject();
+  const currentImageId = useCurrentImageId();
+
+  const containerRef = useRef(null);
+  const [imageDimensions, setImageDimensions] = useState(null);
+  const [mousePos, setMousePos] = useState(null); // live cursor position during drawing
+  const [showModal, setShowModal] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  // Mirror the imageDimensions calculation used in SegmentationOverlay
+  useEffect(() => {
+    if (!containerRef.current || !imageObject) return;
+
+    const updateDimensions = () => {
+      const container = containerRef.current;
+      if (!container) return;
+      const containerWidth = container.offsetWidth;
+      const containerHeight = container.offsetHeight;
+      const imgW = imageObject.width || imageObject.naturalWidth || 0;
+      const imgH = imageObject.height || imageObject.naturalHeight || 0;
+      if (!imgW || !imgH) return;
+      const imageAspect = imgW / imgH;
+      const containerAspect = containerWidth / containerHeight;
+      let renderedWidth, renderedHeight, x, y;
+      if (imageAspect > containerAspect) {
+        renderedWidth = containerWidth;
+        renderedHeight = containerWidth / imageAspect;
+        x = 0;
+        y = (containerHeight - renderedHeight) / 2;
+      } else {
+        renderedWidth = containerHeight * imageAspect;
+        renderedHeight = containerHeight;
+        x = (containerWidth - renderedWidth) / 2;
+        y = 0;
+      }
+      setImageDimensions({ width: renderedWidth, height: renderedHeight, x, y });
+    };
+
+    updateDimensions();
+    const ro = new ResizeObserver(updateDimensions);
+    ro.observe(containerRef.current);
+    const el = containerRef.current;
+    return () => { ro.unobserve(el); ro.disconnect(); };
+  }, [imageObject]);
+
+  /**
+   * Convert a container-relative point (from a mouse event) to image-pixel
+   * coordinates, accounting for zoom/pan.
+   */
+  const containerToImagePx = useCallback((containerX, containerY) => {
+    // The image is centered inside the container with object-contain layout.
+    // The zoom/pan transform is applied on the inner div, not this overlay.
+    // We read the actual rendered image rect from canvasRef for accuracy.
+    if (!canvasRef?.current) return null;
+    const rect = canvasRef.current.getBoundingClientRect();
+    // rect is in viewport coordinates; containerRef is also in viewport coords
+    const containerRect = containerRef.current.getBoundingClientRect();
+    const relX = containerX + containerRect.left - rect.left;
+    const relY = containerY + containerRect.top - rect.top;
+    const imgW = imageObject?.width || imageObject?.naturalWidth || 1;
+    const imgH = imageObject?.height || imageObject?.naturalHeight || 1;
+    const scaleX = imgW / rect.width;
+    const scaleY = imgH / rect.height;
+    return { x: relX * scaleX, y: relY * scaleY };
+  }, [canvasRef, imageObject]);
+
+  const handleMouseMove = useCallback((e) => {
+    if (!isCalibrating) return;
+    const rect = containerRef.current.getBoundingClientRect();
+    setMousePos({ x: e.clientX - rect.left, y: e.clientY - rect.top });
+  }, [isCalibrating]);
+
+  const handleClick = useCallback((e) => {
+    if (!isCalibrating) return;
+    const rect = containerRef.current.getBoundingClientRect();
+    const containerX = e.clientX - rect.left;
+    const containerY = e.clientY - rect.top;
+    const imgPx = containerToImagePx(containerX, containerY);
+    if (!imgPx) return;
+
+    const hasP1 = calibrationPoints?.p1 != null;
+    if (!hasP1) {
+      // Record first point — store container coords for SVG display + image px for backend
+      setCalibrationPoint({ x: imgPx.x, y: imgPx.y, _cx: containerX, _cy: containerY }, 0);
+    } else {
+      // Second click — record and show modal
+      setCalibrationPoint({ x: imgPx.x, y: imgPx.y, _cx: containerX, _cy: containerY }, 1);
+      setShowModal(true);
+    }
+  }, [isCalibrating, calibrationPoints, setCalibrationPoint, containerToImagePx]);
+
+  const handleKeyDown = useCallback((e) => {
+    if (e.key === 'Escape' && isCalibrating) {
+      cancelCalibration();
+      setShowModal(false);
+      setMousePos(null);
+    }
+  }, [isCalibrating, cancelCalibration]);
+
+  useEffect(() => {
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [handleKeyDown]);
+
+  const handleConfirm = async ({ knownDistance, unit }) => {
+    if (!calibrationPoints?.p1 || !calibrationPoints?.p2) return;
+    setSaving(true);
+    try {
+      const result = await setPixelScaleViaDrawnLine(
+        currentImageId,
+        { x: calibrationPoints.p1.x, y: calibrationPoints.p1.y },
+        { x: calibrationPoints.p2.x, y: calibrationPoints.p2.y },
+        knownDistance,
+        unit,
+      );
+      setImageScale(result.scale_x, result.scale_y, result.unit);
+      setShowModal(false);
+      cancelCalibration();
+    } catch (err) {
+      console.error('Failed to set scale:', err);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleModalCancel = () => {
+    setShowModal(false);
+    cancelCalibration();
+    setMousePos(null);
+  };
+
+  if (!isCalibrating && !showModal) return null;
+
+  // --- SVG drawing helpers ---
+  const p1 = calibrationPoints?.p1;
+  const p2 = calibrationPoints?.p2;
+  // Use container coords (_cx, _cy) for drawing — image-px are only for the backend
+  const cx1 = p1?._cx;
+  const cy1 = p1?._cy;
+  const cx2 = p2?._cx ?? mousePos?.x;
+  const cy2 = p2?._cy ?? mousePos?.y;
+
+  const pixelDistance = p1 && p2
+    ? Math.sqrt((p2.x - p1.x) ** 2 + (p2.y - p1.y) ** 2)
+    : null;
+
+  return (
+    <>
+      {/* SVG overlay for the calibration line */}
+      {isCalibrating && (
+        <div
+          ref={containerRef}
+          className="absolute inset-0"
+          style={{ zIndex: 80, cursor: p1 ? 'crosshair' : 'crosshair' }}
+          onClick={handleClick}
+          onMouseMove={handleMouseMove}
+        >
+          <svg className="absolute inset-0 w-full h-full pointer-events-none">
+            <defs>
+              <filter id="cal-glow">
+                <feGaussianBlur stdDeviation="3" result="coloredBlur" />
+                <feMerge>
+                  <feMergeNode in="coloredBlur" />
+                  <feMergeNode in="SourceGraphic" />
+                </feMerge>
+              </filter>
+            </defs>
+
+            {/* Line from p1 to cursor / p2 */}
+            {cx1 != null && cx2 != null && (
+              <line
+                x1={cx1} y1={cy1} x2={cx2} y2={cy2}
+                stroke="#f59e0b"
+                strokeWidth="2"
+                strokeDasharray="8,4"
+                filter="url(#cal-glow)"
+              />
+            )}
+
+            {/* P1 dot */}
+            {cx1 != null && (
+              <>
+                <circle cx={cx1} cy={cy1} r="7" fill="rgba(245,158,11,0.2)" stroke="#f59e0b" strokeWidth="2" />
+                <circle cx={cx1} cy={cy1} r="3" fill="#f59e0b" />
+              </>
+            )}
+
+            {/* P2 dot */}
+            {p2 && cx2 != null && (
+              <>
+                <circle cx={cx2} cy={cy2} r="7" fill="rgba(245,158,11,0.2)" stroke="#f59e0b" strokeWidth="2" />
+                <circle cx={cx2} cy={cy2} r="3" fill="#f59e0b" />
+              </>
+            )}
+
+            {/* Pixel distance label */}
+            {cx1 != null && cx2 != null && (
+              <text
+                x={(cx1 + cx2) / 2}
+                y={(cy1 + cy2) / 2 - 10}
+                fill="#f59e0b"
+                fontSize="12"
+                fontWeight="600"
+                textAnchor="middle"
+                style={{ filter: 'drop-shadow(0 1px 2px rgba(0,0,0,0.6))' }}
+              >
+                {pixelDistance ? `${Math.round(pixelDistance)}px` : ''}
+              </text>
+            )}
+          </svg>
+
+          {/* Instruction banner */}
+          <div className="absolute top-4 left-1/2 -translate-x-1/2 z-10 pointer-events-none">
+            <div className="flex items-center gap-2 px-4 py-2 rounded-full bg-amber-500/95 text-white text-sm font-medium shadow-lg">
+              <span>
+                {!p1
+                  ? '📏 Click the first point on the image'
+                  : '📏 Click the second point to complete the line'}
+              </span>
+              <span className="text-white/70 text-xs ml-2">ESC to cancel</span>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Scale input modal — portalled to body so it escapes the transform */}
+      {showModal && ReactDOM.createPortal(
+        <ScaleInputModal
+          pixelDistance={pixelDistance}
+          onConfirm={handleConfirm}
+          onCancel={handleModalCancel}
+          saving={saving}
+        />,
+        document.body,
+      )}
+    </>
+  );
+};
+
+export default ScaleCalibrationOverlay;

--- a/src/components/annotationPage/canvas/ScaleCalibrationOverlay.jsx
+++ b/src/components/annotationPage/canvas/ScaleCalibrationOverlay.jsx
@@ -8,6 +8,7 @@ import {
   useImageObject,
   useIsCalibrating,
   useSetCalibrationPoint,
+  useSetCurrentTool,
   useSetImageScale,
 } from '../../../stores/selectors/annotationSelectors';
 import ScaleInputModal from '../modals/ScaleInputModal';
@@ -31,6 +32,7 @@ const ScaleCalibrationOverlay = ({ canvasRef, zoomLevel, panOffset }) => {
   const calibrationPoints = useCalibrationPoints();
   const setCalibrationPoint = useSetCalibrationPoint();
   const cancelCalibration = useCancelCalibration();
+  const setCurrentTool = useSetCurrentTool();
   const setImageScale = useSetImageScale();
   const imageObject = useImageObject();
   const currentImageId = useCurrentImageId();
@@ -126,10 +128,11 @@ const ScaleCalibrationOverlay = ({ canvasRef, zoomLevel, panOffset }) => {
   const handleKeyDown = useCallback((e) => {
     if (e.key === 'Escape' && isCalibrating) {
       cancelCalibration();
+      setCurrentTool('ai_annotation');
       setShowModal(false);
       setMousePos(null);
     }
-  }, [isCalibrating, cancelCalibration]);
+  }, [isCalibrating, cancelCalibration, setCurrentTool]);
 
   useEffect(() => {
     document.addEventListener('keydown', handleKeyDown);
@@ -150,6 +153,7 @@ const ScaleCalibrationOverlay = ({ canvasRef, zoomLevel, panOffset }) => {
       setImageScale(result.scale_x, result.scale_y, result.unit);
       setShowModal(false);
       cancelCalibration();
+      setCurrentTool('ai_annotation');
     } catch (err) {
       console.error('Failed to set scale:', err);
     } finally {
@@ -160,6 +164,7 @@ const ScaleCalibrationOverlay = ({ canvasRef, zoomLevel, panOffset }) => {
   const handleModalCancel = () => {
     setShowModal(false);
     cancelCalibration();
+    setCurrentTool('ai_annotation');
     setMousePos(null);
   };
 

--- a/src/components/annotationPage/canvas/ScaleControl.jsx
+++ b/src/components/annotationPage/canvas/ScaleControl.jsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { Ruler } from 'lucide-react';
+import {
+  useImageScale,
+  useCurrentTool,
+  useSetCurrentTool,
+  useIsCalibrating,
+  useStartCalibration,
+  useCancelCalibration,
+} from '../../../stores/selectors/annotationSelectors';
+
+/**
+ * Pixel Scale Calibration header control.
+ * Displays current scale badge and provides a button to trigger scale calibration,
+ * styled to match the main teal/cyan UI theme.
+ */
+const ScaleControl = () => {
+  const scale = useImageScale();
+  const currentTool = useCurrentTool();
+  const setCurrentTool = useSetCurrentTool();
+  const isCalibrating = useIsCalibrating();
+  const startCalibration = useStartCalibration();
+  const cancelCalibration = useCancelCalibration();
+
+  const isScaleActive = isCalibrating || currentTool === 'set_scale';
+
+  const handleToggleScale = () => {
+    if (isScaleActive) {
+      cancelCalibration();
+      setCurrentTool('ai_annotation');
+    } else {
+      setCurrentTool('set_scale');
+      startCalibration();
+    }
+  };
+
+  const isCalibrated = scale?.unit && scale.unit !== 'px' && scale.scaleX > 0;
+
+  return (
+    <div className="flex items-center space-x-2 bg-white/90 backdrop-blur-sm rounded-lg p-1.5 shadow-lg border border-gray-100">
+      {/* Scale status pill */}
+      <div className={`flex items-center gap-1.5 px-2.5 py-1 rounded text-xs font-semibold transition-colors ${
+        isCalibrated
+          ? 'bg-teal-50 text-teal-700 border border-teal-200/60'
+          : 'bg-gray-100 text-gray-500'
+      }`}>
+        <Ruler className={`w-3.5 h-3.5 ${isCalibrated ? 'text-teal-600' : 'text-gray-400'}`} />
+        <span>
+          {isCalibrated
+            ? `1px = ${scale.scaleX.toFixed(4)} ${scale.unit}`
+            : 'Uncalibrated'}
+        </span>
+      </div>
+
+      {/* Set Scale Calibration button */}
+      <button
+        type="button"
+        id="header-set-scale-button"
+        onClick={handleToggleScale}
+        className={`px-3 py-1 rounded text-xs font-semibold flex items-center gap-1.5 ${
+          isScaleActive
+            ? 'bg-teal-600 text-white shadow-sm'
+            : 'bg-gray-100 hover:bg-teal-50 hover:text-teal-700 text-gray-700 border border-transparent hover:border-teal-200'
+        }`}
+        title={isScaleActive ? 'Cancel calibration mode (ESC)' : 'Draw a ruler line on the image to set physical scale'}
+      >
+        <span>{isScaleActive ? 'Cancel Calibration' : 'Set Scale'}</span>
+      </button>
+    </div>
+  );
+};
+
+export default ScaleControl;

--- a/src/components/annotationPage/canvas/prompts/PromptModeToolbar.jsx
+++ b/src/components/annotationPage/canvas/prompts/PromptModeToolbar.jsx
@@ -1,8 +1,14 @@
 import React from 'react';
-import { MousePointerClick, Square, Hexagon, Spline } from 'lucide-react';
+import { MousePointerClick, Square, Hexagon, Spline, Ruler } from 'lucide-react';
 import {
   usePromptMode,
   useSetPromptMode,
+  useCurrentTool,
+  useSetCurrentTool,
+  useStartCalibration,
+  useCancelCalibration,
+  useIsCalibrating,
+  useImageScale,
 } from '../../../../stores/selectors/annotationSelectors';
 
 /**
@@ -24,6 +30,22 @@ const MODES = [
 const PromptModeToolbar = ({ supportedTypes, shiftDown = false }) => {
   const promptMode = usePromptMode();
   const setPromptMode = useSetPromptMode();
+  const currentTool = useCurrentTool();
+  const setCurrentTool = useSetCurrentTool();
+  const startCalibration = useStartCalibration();
+  const cancelCalibration = useCancelCalibration();
+  const isCalibrating = useIsCalibrating();
+  const scale = useImageScale();
+
+  const handleToggleScale = () => {
+    if (currentTool === 'set_scale' || isCalibrating) {
+      cancelCalibration();
+      setCurrentTool('ai_annotation');
+    } else {
+      setCurrentTool('set_scale');
+      startCalibration();
+    }
+  };
 
   // Normalize the model's advertised prompt types to canonical singular keys.
   const declared = Array.isArray(supportedTypes) ? supportedTypes : [];
@@ -80,6 +102,32 @@ const PromptModeToolbar = ({ supportedTypes, shiftDown = false }) => {
           </button>
         );
       })}
+
+      <div className="w-px h-4 bg-gray-200 mx-0.5" />
+
+      {/* Set Scale Button */}
+      <button
+        type="button"
+        id="set-scale-canvas-toolbar-button"
+        onClick={handleToggleScale}
+        title={
+          scale?.unit !== 'px'
+            ? `Calibrated: 1px = ${scale?.scaleX?.toFixed(4)} ${scale?.unit}`
+            : 'Draw a ruler line to set scale'
+        }
+        className={`flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs font-medium transition-colors ${
+          currentTool === 'set_scale' || isCalibrating
+            ? 'bg-amber-500 text-white shadow-sm'
+            : scale?.unit !== 'px'
+            ? 'bg-emerald-50 text-emerald-700 hover:bg-emerald-100'
+            : 'text-gray-600 hover:bg-gray-100'
+        }`}
+      >
+        <Ruler className="w-3.5 h-3.5" />
+        <span className="hidden sm:inline">
+          {scale?.unit !== 'px' ? scale?.unit : 'Scale'}
+        </span>
+      </button>
     </div>
   );
 };

--- a/src/components/annotationPage/layout/ImageHeader.jsx
+++ b/src/components/annotationPage/layout/ImageHeader.jsx
@@ -10,6 +10,7 @@ import {
 } from '../../../stores/selectors/annotationSelectors';
 import ZoomControls from '../canvas/ZoomControls';
 import { getCoarseStatus } from '../../../utils/imageStatus';
+import ScaleControl from '../canvas/ScaleControl';
 
 const ImageHeader = () => {
   const navigate = useNavigate();
@@ -68,7 +69,10 @@ const ImageHeader = () => {
               </span>
             </div>
           </div>
-          <div className="flex items-center space-x-4">
+          <div className="flex items-center space-x-3">
+            {/* Pixel Scale Calibration Control */}
+            <ScaleControl />
+
             {/* Zoom Controls */}
             <ZoomControls />
             

--- a/src/components/annotationPage/modals/ScaleInputModal.jsx
+++ b/src/components/annotationPage/modals/ScaleInputModal.jsx
@@ -1,0 +1,134 @@
+import React, { useState } from 'react';
+import { Ruler, X, CheckCircle } from 'lucide-react';
+
+const SUPPORTED_UNITS = [
+  { value: 'cm', label: 'cm (centimetres)' },
+  { value: 'mm', label: 'mm (millimetres)' },
+  { value: 'µm', label: 'µm (micrometres)' },
+];
+
+/**
+ * Modal that appears after the user draws a calibration line.
+ * Asks for the real-world distance and unit, then calls onConfirm.
+ *
+ * Props:
+ *   pixelDistance {number}   Pixel length of the drawn line (display only).
+ *   onConfirm({ knownDistance, unit }) Called when the user confirms.
+ *   onCancel()               Called when the user cancels / closes.
+ */
+const ScaleInputModal = ({ pixelDistance, onConfirm, onCancel }) => {
+  const [knownDistance, setKnownDistance] = useState('');
+  const [unit, setUnit] = useState('cm');
+  const [error, setError] = useState('');
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    const parsed = parseFloat(knownDistance);
+    if (!knownDistance || isNaN(parsed) || parsed <= 0) {
+      setError('Please enter a positive number.');
+      return;
+    }
+    setError('');
+    onConfirm({ knownDistance: parsed, unit });
+  };
+
+  return (
+    <div
+      className="fixed inset-0 flex items-center justify-center bg-black/60 z-[9999]"
+      onClick={(e) => { if (e.target === e.currentTarget) onCancel(); }}
+    >
+      <div className="bg-white rounded-2xl shadow-2xl border border-gray-100 w-full max-w-md mx-4 overflow-hidden">
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 py-4 bg-gradient-to-r from-teal-500 to-cyan-600">
+          <div className="flex items-center gap-2 text-white">
+            <Ruler className="w-5 h-5" />
+            <h2 className="text-base font-semibold">Set Image Scale</h2>
+          </div>
+          <button
+            onClick={onCancel}
+            className="text-white/80 hover:text-white transition-colors rounded-full p-1 hover:bg-white/10"
+            aria-label="Close"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+
+        {/* Body */}
+        <form onSubmit={handleSubmit} className="p-6 space-y-5">
+          {/* Drawn line info */}
+          <div className="flex items-center gap-3 p-3 bg-teal-50 border border-teal-100 rounded-xl text-sm text-teal-800">
+            <div className="w-8 h-8 rounded-full bg-teal-100 flex items-center justify-center flex-shrink-0">
+              <Ruler className="w-4 h-4 text-teal-600" />
+            </div>
+            <div>
+              <p className="font-medium">Line drawn</p>
+              <p className="text-teal-600">
+                {pixelDistance ? `${Math.round(pixelDistance)} pixels` : '—'}
+              </p>
+            </div>
+          </div>
+
+          {/* Real-world distance input */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1.5">
+              Real-world length of this line
+            </label>
+            <div className="flex gap-2">
+              <input
+                id="scale-distance-input"
+                type="number"
+                min="0.000001"
+                step="any"
+                value={knownDistance}
+                onChange={(e) => { setKnownDistance(e.target.value); setError(''); }}
+                placeholder="e.g. 100"
+                autoFocus
+                className="flex-1 px-3 py-2.5 border border-gray-300 rounded-xl text-sm focus:outline-none focus:ring-2 focus:ring-teal-500 focus:border-transparent transition-all"
+              />
+              <select
+                id="scale-unit-select"
+                value={unit}
+                onChange={(e) => setUnit(e.target.value)}
+                className="px-3 py-2.5 border border-gray-300 rounded-xl text-sm bg-white focus:outline-none focus:ring-2 focus:ring-teal-500 focus:border-transparent transition-all"
+              >
+                {SUPPORTED_UNITS.map(u => (
+                  <option key={u.value} value={u.value}>{u.label}</option>
+                ))}
+              </select>
+            </div>
+            {error && <p className="mt-1.5 text-xs text-red-600">{error}</p>}
+            {knownDistance && !error && pixelDistance && (
+              <p className="mt-1.5 text-xs text-gray-500">
+                Scale:{' '}
+                <span className="font-medium text-teal-700">
+                  {(parseFloat(knownDistance) / pixelDistance).toFixed(6)} {unit}/px
+                </span>
+              </p>
+            )}
+          </div>
+
+          {/* Actions */}
+          <div className="flex justify-end gap-2 pt-1">
+            <button
+              type="button"
+              onClick={onCancel}
+              className="px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 rounded-xl transition-colors font-medium"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              id="scale-confirm-button"
+              className="flex items-center gap-1.5 px-5 py-2 text-sm text-white bg-gradient-to-r from-teal-500 to-cyan-600 rounded-xl font-medium hover:shadow-lg transition-all"
+            >
+              <CheckCircle className="w-4 h-4" />
+              Confirm Scale
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default ScaleInputModal;

--- a/src/components/annotationPage/sidebar/Services.jsx
+++ b/src/components/annotationPage/sidebar/Services.jsx
@@ -169,6 +169,7 @@ const Services = () => {
                     </div>
                     <p className="text-xs text-gray-500 ml-8">AI-powered models for segmentation</p>
                 </div>
+
                 {services.map((service, index) => (
                     <ServiceCard
                         key={service.name}

--- a/src/components/annotationPage/sidebar/ToolsSection.jsx
+++ b/src/components/annotationPage/sidebar/ToolsSection.jsx
@@ -1,11 +1,14 @@
 import React from 'react';
-import { MousePointer, Pencil, Sparkles, CheckCircle } from 'lucide-react';
+import { MousePointer, Pencil, Sparkles, CheckCircle, Ruler } from 'lucide-react';
 import { 
   useCurrentTool, 
   useSetCurrentTool, 
   useLeftSidebarCollapsed,
   useInstantSegmentation,
   useToggleInstantSegmentation,
+  useStartCalibration,
+  useCancelCalibration,
+  useImageScale,
 } from '../../../stores/selectors/annotationSelectors';
 import ModelSelectors from './ModelSelectors';
 
@@ -15,12 +18,43 @@ const ToolsSection = () => {
   const leftSidebarCollapsed = useLeftSidebarCollapsed();
   const instantSegmentation = useInstantSegmentation();
   const toggleInstantSegmentation = useToggleInstantSegmentation();
+  const startCalibration = useStartCalibration();
+  const cancelCalibration = useCancelCalibration();
+  const scale = useImageScale();
+
+  const handleToolChange = (toolId) => {
+    if (toolId === 'set_scale') {
+      if (currentTool === 'set_scale') {
+        // Toggle off: exit calibration mode and return to previous tool
+        cancelCalibration();
+        setCurrentTool('ai_annotation');
+      } else {
+        setCurrentTool('set_scale');
+        startCalibration();
+      }
+      return;
+    }
+    // Switching away from scale tool: cancel any active calibration
+    if (currentTool === 'set_scale') {
+      cancelCalibration();
+    }
+    setCurrentTool(toolId);
+  };
 
   const tools = [
     { id: 'selection', name: 'Selection', icon: MousePointer, description: 'Select and manipulate objects', disabled: false },
     { id: 'manual_drawing', name: 'Manual Drawing', icon: Pencil, description: 'Draw polygon or freehand annotations by hand', disabled: false },
     { id: 'ai_annotation', name: 'AI assisted Annotation', icon: Sparkles, description: 'Use AI models for automatic segmentation', disabled: false },
     { id: 'suggestion', name: 'Annotation Suggestion', icon: CheckCircle, description: 'Automatically detect new objects given one or multiple examples', disabled: true },
+    {
+      id: 'set_scale',
+      name: 'Set Scale',
+      icon: Ruler,
+      description: scale?.unit !== 'px'
+        ? `Calibrated: 1px = ${scale.scaleX.toFixed(4)} ${scale.unit}`
+        : 'Draw a line to set the real-world scale',
+      disabled: false,
+    },
   ];
 
   if (leftSidebarCollapsed) {
@@ -36,7 +70,7 @@ const ToolsSection = () => {
             return (
               <button
                 key={tool.id}
-                onClick={() => !isDisabled && setCurrentTool(tool.id)}
+                onClick={() => !isDisabled && handleToolChange(tool.id)}
                 disabled={isDisabled}
                 className={`w-full p-2 rounded transition-colors flex items-center justify-center ${
                   isDisabled
@@ -68,7 +102,7 @@ const ToolsSection = () => {
           return (
             <button
               key={tool.id}
-              onClick={() => !isDisabled && setCurrentTool(tool.id)}
+              onClick={() => !isDisabled && handleToolChange(tool.id)}
               disabled={isDisabled}
               className={`w-full flex items-center space-x-2.5 p-2 rounded-lg transition-all text-left ${
                 isDisabled

--- a/src/hooks/useCanvasInteractions.js
+++ b/src/hooks/useCanvasInteractions.js
@@ -18,13 +18,29 @@ export const useCanvasInteractions = (containerRef) => {
   // Pan mode state (controlled by spacebar)
   const [isPanMode, setIsPanMode] = useState(false);
 
-  // Mouse wheel zoom handler
+  // Mouse wheel zoom handler with cursor-focal zoom math
   const handleWheel = useCallback((e) => {
     e.preventDefault();
+    if (!containerRef.current) return;
+
     const delta = e.deltaY > 0 ? 0.9 : 1.1; // Zoom out or in
-    const newZoomLevel = Math.max(0.1, Math.min(10, zoomLevel * delta));
+    const oldZoomLevel = zoomLevel;
+    const newZoomLevel = Math.max(0.1, Math.min(10, oldZoomLevel * delta));
+
+    if (newZoomLevel === oldZoomLevel) return;
+
+    // Calculate mouse position relative to container center
+    const rect = containerRef.current.getBoundingClientRect();
+    const mx = e.clientX - (rect.left + rect.width / 2);
+    const my = e.clientY - (rect.top + rect.height / 2);
+
+    // Adjust pan offset so the image pixel under the cursor remains stationary
+    const newPanX = panOffset.x + mx * (1 / newZoomLevel - 1 / oldZoomLevel);
+    const newPanY = panOffset.y + my * (1 / newZoomLevel - 1 / oldZoomLevel);
+
     setZoomLevel(newZoomLevel);
-  }, [zoomLevel, setZoomLevel]);
+    setPanOffset({ x: newPanX, y: newPanY });
+  }, [containerRef, zoomLevel, panOffset, setZoomLevel, setPanOffset]);
 
   // Mouse drag panning handlers
   const [isDragging, setIsDragging] = useState(false);

--- a/src/hooks/useImageLoader.js
+++ b/src/hooks/useImageLoader.js
@@ -6,9 +6,11 @@ import {
   useSetImageObject,
   useSetImageLoading,
   useSetImageError,
-  useResetImageState
+  useResetImageState,
+  useSetImageScale,
 } from '../stores/selectors/annotationSelectors';
 import { getImageById } from '../api/images';
+import { getPixelScale } from '../api/scale';
 
 export const useImageLoader = (currentImage) => {
   const imageObject = useImageObject();
@@ -19,6 +21,7 @@ export const useImageLoader = (currentImage) => {
   const setImageLoading = useSetImageLoading();
   const setImageError = useSetImageError();
   const resetImageState = useResetImageState();
+  const setImageScale = useSetImageScale();
 
   const loadImage = useCallback(async (image) => {
     if (!image || !image.id) {
@@ -49,6 +52,16 @@ export const useImageLoader = (currentImage) => {
       });
 
       setImageObject(imgObject);
+
+      // Load persisted scale for this image from the backend.
+      // Done after image loads so scale bar appears immediately.
+      // Failure is non-fatal: scale simply stays at the default px value.
+      try {
+        const scaleData = await getPixelScale(image.id);
+        setImageScale(scaleData.scale_x, scaleData.scale_y, scaleData.unit);
+      } catch (scaleErr) {
+        console.warn('Could not load image scale (will default to px):', scaleErr);
+      }
       
     } catch (error) {
       console.error('Error loading image:', error);
@@ -57,7 +70,7 @@ export const useImageLoader = (currentImage) => {
     } finally {
       setImageLoading(false);
     }
-  }, [setImageObject, setImageLoading, setImageError]);
+  }, [setImageObject, setImageLoading, setImageError, setImageScale]);
 
   // Load image when currentImage changes
   useEffect(() => {

--- a/src/stores/initialState.js
+++ b/src/stores/initialState.js
@@ -83,6 +83,15 @@ export const initialState = {
     // Zoom and pan state
     zoomLevel: 1,
     panOffset: { x: 0, y: 0 },
+    // Physical scale calibration for the current image
+    scale: {
+      scaleX: 1,
+      scaleY: 1,
+      unit: 'px',          // 'px' means no real-world scale has been set yet
+      isCalibrating: false, // true while user is drawing a calibration line
+      // { p1: {x, y}, p2: {x, y} } in image-pixel coordinates, or null
+      calibrationPoints: null,
+    },
   },
   
   // Model State

--- a/src/stores/selectors/annotationSelectors.js
+++ b/src/stores/selectors/annotationSelectors.js
@@ -213,3 +213,14 @@ export const useUpdateDraftPoint = () => useAnnotationStore(state => state.updat
 export const useResetDraft = () => useAnnotationStore(state => state.resetDraft);
 export const useSyncEditModeDraftFromRefinement = () => useAnnotationStore(state => state.syncEditModeDraftFromRefinement);
 export const useExitEditMode = () => useAnnotationStore(state => state.exitEditMode);
+
+// Scale selectors
+export const useImageScale = () => useAnnotationStore(state => state.images.scale);
+export const useIsCalibrating = () => useAnnotationStore(state => state.images.scale.isCalibrating);
+export const useCalibrationPoints = () => useAnnotationStore(state => state.images.scale.calibrationPoints);
+
+// Scale action selectors
+export const useSetImageScale = () => useAnnotationStore(state => state.setImageScale);
+export const useStartCalibration = () => useAnnotationStore(state => state.startCalibration);
+export const useSetCalibrationPoint = () => useAnnotationStore(state => state.setCalibrationPoint);
+export const useCancelCalibration = () => useAnnotationStore(state => state.cancelCalibration);

--- a/src/stores/slices/imagesSlice.js
+++ b/src/stores/slices/imagesSlice.js
@@ -70,11 +70,55 @@ export const createImagesSlice = (set) => ({
     state.images.imageError = null;
     state.images.zoomLevel = 1;
     state.images.panOffset = { x: 0, y: 0 };
+    state.images.scale = { scaleX: 1, scaleY: 1, unit: 'px', isCalibrating: false, calibrationPoints: null };
     
     // Clear focus mode when resetting image state
     state.focusMode.active = false;
     state.focusMode.objectId = null;
     state.focusMode.objectMask = null;
+  }),
+
+  // ---------------------------------------------------------------------------
+  // Scale actions
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Overwrite the stored scale for the current image (called after a successful
+   * API response). Does NOT make any network call — that lives in the component/hook.
+   */
+  setImageScale: (scaleX, scaleY, unit) => set((state) => {
+    state.images.scale.scaleX = scaleX;
+    state.images.scale.scaleY = scaleY;
+    state.images.scale.unit = unit;
+  }),
+
+  /** Enter draw-line calibration mode. Clears any previous calibration points. */
+  startCalibration: () => set((state) => {
+    state.images.scale.isCalibrating = true;
+    state.images.scale.calibrationPoints = null;
+  }),
+
+  /**
+   * Record a calibration point (0 = first click, 1 = second click).
+   * @param {{x: number, y: number}} point  Image-pixel coordinates.
+   * @param {0|1} index
+   */
+  setCalibrationPoint: (point, index) => set((state) => {
+    if (!state.images.scale.calibrationPoints) {
+      state.images.scale.calibrationPoints = { p1: null, p2: null };
+    }
+    if (index === 0) {
+      state.images.scale.calibrationPoints.p1 = point;
+      state.images.scale.calibrationPoints.p2 = null; // reset second point on first click
+    } else {
+      state.images.scale.calibrationPoints.p2 = point;
+    }
+  }),
+
+  /** Exit calibration mode and clear the drawn line. */
+  cancelCalibration: () => set((state) => {
+    state.images.scale.isCalibrating = false;
+    state.images.scale.calibrationPoints = null;
   }),
 });
 

--- a/src/stores/slices/imagesSlice.js
+++ b/src/stores/slices/imagesSlice.js
@@ -31,6 +31,11 @@ export const createImagesSlice = (set) => ({
       state.editMode.originalCoordinates = null;
       state.editMode.draftCoordinates = null;
       state.editMode.isDirty = false;
+
+      // Reset calibration/tool state for the new image so the scale button
+      // shows "Set Scale" instead of "Cancel Calibration".
+      state.images.scale = { scaleX: 1, scaleY: 1, unit: 'px', isCalibrating: false, calibrationPoints: null };
+      state.ui.currentTool = 'ai_annotation';
     }
   }),
   


### PR DESCRIPTION
- Adds scale calibration controls in the annotation toolbar and image header.
- Implements a two-point line calibration overlay with real-world distance input.
- Displays a dynamic scale bar in the canvas when a real-world scale is set.
- Loads persisted scale per image from the backend.
- Resets calibration mode when navigating to another image or cancelling.

Related backend PR: https://github.com/Iquana-tool/backend/pull/94

I merged the most recent `dev` commit and ran the tool. Everything seems to work.