### PR TITLE
Feature/reviews

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,6 +3,7 @@ import { BrowserRouter as Router, Routes, Route, Navigate } from "react-router-d
 import { AuthProvider } from "./contexts/AuthContext";
 import { DatasetProvider } from "./contexts/DatasetContext";
 import { ToastProvider } from "./contexts/ToastContext";
+import { CorrectionProvider } from "./contexts/CorrectionContext";
 import ProtectedRoute from "./components/auth/ProtectedRoute";
 import Login from "./components/auth/Login";
 import LandingPage from "./pages/LandingPage";
@@ -17,6 +18,8 @@ import AcceptInvitePage from "./pages/AcceptInvitePage";
 import AnnotationViewerPage from "./pages/AnnotationViewerPage";
 import DatasetAccessPage from "./pages/DatasetAccessPage";
 import AdminUsersPage from "./pages/AdminUsersPage";
+import ReviewPage from "./pages/ReviewPage";
+import CorrectionPage from "./pages/CorrectionPage";
 
 function App() {
   return (
@@ -24,6 +27,7 @@ function App() {
       <ToastProvider>
       <DatasetProvider>
         <Router basename={process.env.PUBLIC_URL || ""}>
+          <CorrectionProvider>
           <Routes>
             <Route path="/login" element={<Login />} />
             <Route path="/" element={<LandingPage />} />
@@ -115,6 +119,26 @@ function App() {
                 </ProtectedRoute>
               }
             />
+            {/* Review queue: pick a granularity, then work through the pending
+                annotations item by item. */}
+            <Route
+              path="/dataset/:datasetId/review"
+              element={
+                <ProtectedRoute>
+                  <ReviewPage />
+                </ProtectedRoute>
+              }
+            />
+            {/* Correction queue: launch a session that walks the annotator through
+                every sent-back instance in the editor, one at a time. */}
+            <Route
+              path="/dataset/:datasetId/correct"
+              element={
+                <ProtectedRoute>
+                  <CorrectionPage />
+                </ProtectedRoute>
+              }
+            />
             <Route
               path="/dataset/:datasetId/quantifications"
               element={
@@ -142,6 +166,7 @@ function App() {
             {/* Catch-all route - redirect unknown routes to landing page */}
             <Route path="*" element={<Navigate to="/" replace />} />
           </Routes>
+          </CorrectionProvider>
         </Router>
       </DatasetProvider>
       </ToastProvider>

--- a/src/api.js
+++ b/src/api.js
@@ -13,4 +13,5 @@ export * from "./api/automatic_segmentation";
 export * from "./api/instance_segmentation";
 export * from "./api/members";
 export * from "./api/reviews";
+export * from "./api/annotation_queue";
 export * from "./api/admin";

--- a/src/api/annotation_queue.js
+++ b/src/api/annotation_queue.js
@@ -1,0 +1,73 @@
+/**
+ * Annotation-queue endpoints: the persisted order an annotator works images in.
+ *
+ * Unlike the review queue (a per-session snapshot), an annotation queue is saved
+ * per (dataset, user): the builder on the Annotation card writes it, and the
+ * editor's loader applies it so next/previous follow that order. See
+ * `app.services.annotation_queue` on the backend for the ordering registry (where
+ * active-learning orderings plug in).
+ */
+import { handleApiError, getAuthHeaders } from "./util";
+import { API_BASE_URL } from "./config";
+
+const jsonHeaders = () => getAuthHeaders({ "Content-Type": "application/json" });
+
+/**
+ * The dataset's annotation workload plus the caller's saved-queue state.
+ *
+ * Backs the Annotation card's "x in progress, y not started" subcaption and the
+ * queue builder's ordering options / resume prompt.
+ *
+ * @param {number|string} datasetId
+ * @returns {Promise<{success: boolean, summary: {
+ *   not_started: number, in_progress: number, finished: number, total: number,
+ *   has_saved_queue: boolean, saved_strategy: string|null,
+ *   strategies: Array<{key: string, label: string, description: string, available: boolean}>,
+ * }}>}
+ */
+export const fetchAnnotationQueueSummary = async (datasetId) => {
+    const response = await fetch(
+        `${API_BASE_URL}/annotation-queue/datasets/${datasetId}/summary`,
+        { headers: getAuthHeaders() }
+    );
+    return handleApiError(response);
+};
+
+/**
+ * The caller's saved queue for a dataset, or `queue: null` if none was built.
+ *
+ * @param {number|string} datasetId
+ * @returns {Promise<{success: boolean, queue: {
+ *   strategy: string, image_ids: number[], total: number, updated_at: string|null,
+ * }|null}>}
+ */
+export const fetchAnnotationQueue = async (datasetId) => {
+    const response = await fetch(
+        `${API_BASE_URL}/annotation-queue/datasets/${datasetId}`,
+        { headers: getAuthHeaders() }
+    );
+    return handleApiError(response);
+};
+
+/**
+ * Build the image order for a strategy and persist it, overwriting any earlier
+ * queue for this dataset + user.
+ *
+ * @param {number|string} datasetId
+ * @param {Object} options
+ * @param {string} options.strategy - A key from the summary's `strategies` (must be `available`).
+ * @returns {Promise<{success: boolean, queue: {
+ *   strategy: string, image_ids: number[], total: number, updated_at: string|null,
+ * }}>}
+ */
+export const buildAnnotationQueue = async (datasetId, { strategy }) => {
+    const response = await fetch(
+        `${API_BASE_URL}/annotation-queue/datasets/${datasetId}`,
+        {
+            method: "POST",
+            headers: jsonHeaders(),
+            body: JSON.stringify({ strategy }),
+        }
+    );
+    return handleApiError(response);
+};

--- a/src/api/reviews.js
+++ b/src/api/reviews.js
@@ -66,12 +66,20 @@ export const fetchMaskRejections = async (maskId, openOnly = false) => {
 
 /**
  * Mark one rejection as addressed.
+ *
  * @param {number} rejectionId
+ * @param {"fixed"|"wont_fix"|null} [resolution] - How it was closed. The correction
+ *   queue sends "fixed" for "Mark as done" and "wont_fix" for "Won't fix"; omit for
+ *   an unspecified resolve (e.g. the RejectionBanner's plain "Done").
  */
-export const resolveRejection = async (rejectionId) => {
+export const resolveRejection = async (rejectionId, resolution = null) => {
     const response = await fetch(
         `${API_BASE_URL}/reviews/rejections/${rejectionId}/resolve`,
-        { method: "PATCH", headers: getAuthHeaders() }
+        {
+            method: "PATCH",
+            headers: jsonHeaders(),
+            body: JSON.stringify({ resolution }),
+        }
     );
     return handleApiError(response);
 };
@@ -84,6 +92,140 @@ export const resolveAllMaskRejections = async (maskId) => {
     const response = await fetch(
         `${API_BASE_URL}/reviews/masks/${maskId}/rejections/resolve`,
         { method: "PATCH", headers: getAuthHeaders() }
+    );
+    return handleApiError(response);
+};
+
+/**
+ * How much review work a dataset holds, plus the available queue orderings.
+ *
+ * Backs the "There are x instances to review" line on the management card and
+ * the strategy dropdown on the review setup page.
+ *
+ * @param {number|string} datasetId
+ * @returns {Promise<{success: boolean, summary: {
+ *   pending_instances: number, pending_images: number, open_rejections: number,
+ *   strategies: Array<{key: string, label: string, description: string}>,
+ * }}>}
+ */
+export const fetchReviewSummary = async (datasetId) => {
+    const response = await fetch(
+        `${API_BASE_URL}/reviews/datasets/${datasetId}/summary`,
+        { headers: getAuthHeaders() }
+    );
+    return handleApiError(response);
+};
+
+/**
+ * Build the ordered work list for one review session.
+ *
+ * The queue is a snapshot, not a reservation: nothing is locked server-side, so
+ * an item someone else handles mid-session simply no-ops when acted on.
+ *
+ * @param {number|string} datasetId
+ * @param {Object} options
+ * @param {"images"|"hierarchy"|"custom"} options.granularity
+ * @param {string} [options.sortStrategy="hierarchy"] - A key from the summary's `strategies`.
+ * @param {"asc"|"desc"} [options.direction="asc"]
+ * @param {number[]} [options.labelIds] - Required for "custom" granularity.
+ * @param {boolean} [options.onlySubmitted=true] - Only masks submitted for review.
+ * @param {boolean} [options.includeReviewed=false] - Also queue instances other
+ *   reviewers approved, to add a second opinion. The caller's own approvals stay out.
+ */
+export const buildReviewQueue = async (
+    datasetId,
+    {
+        granularity,
+        sortStrategy = "hierarchy",
+        direction = "asc",
+        labelIds = null,
+        onlySubmitted = true,
+        includeReviewed = false,
+    }
+) => {
+    const response = await fetch(`${API_BASE_URL}/reviews/datasets/${datasetId}/queue`, {
+        method: "POST",
+        headers: jsonHeaders(),
+        body: JSON.stringify({
+            granularity,
+            sort_strategy: sortStrategy,
+            direction,
+            label_ids: labelIds,
+            only_submitted: onlySubmitted,
+            include_reviewed: includeReviewed,
+        }),
+    });
+    return handleApiError(response);
+};
+
+/**
+ * Approve every not-yet-reviewed contour of a mask at once — the image-level
+ * "Accept" of the review queue. The caller's own annotations are skipped
+ * (separation of duties) and returned in `skipped`.
+ *
+ * @param {number} maskId
+ * @param {Object} [options]
+ * @param {boolean} [options.includeReviewed=false] - Also add the caller's
+ *   approval on top of contours other reviewers already approved, matching a
+ *   queue built with the same flag.
+ * @returns {Promise<{success: boolean, approved: number[], skipped: number[]}>}
+ */
+export const approveMask = async (maskId, { includeReviewed = false } = {}) => {
+    const url = buildUrl(API_BASE_URL, `/reviews/masks/${maskId}/approve`, {
+        include_reviewed: includeReviewed,
+    });
+    const response = await fetch(url, {
+        method: "POST",
+        headers: getAuthHeaders(),
+    });
+    return handleApiError(response);
+};
+
+/**
+ * How much correction work a dataset holds — the count behind the "x instances
+ * sent back for correction" line on the Correct management card.
+ *
+ * @param {number|string} datasetId
+ * @returns {Promise<{success: boolean, summary: {
+ *   open_rejections: number, affected_instances: number, affected_images: number,
+ * }}>}
+ */
+export const fetchCorrectionSummary = async (datasetId) => {
+    const response = await fetch(
+        `${API_BASE_URL}/reviews/datasets/${datasetId}/correction-summary`,
+        { headers: getAuthHeaders() }
+    );
+    return handleApiError(response);
+};
+
+/**
+ * Build the ordered work list for one correction session: every open rejection in
+ * the dataset, grouped by image. The queue is a snapshot, not a reservation — an
+ * item someone else resolves mid-session simply no-ops when acted on.
+ *
+ * @param {number|string} datasetId
+ * @param {Object} [options]
+ * @param {"oldest"|"newest"} [options.order="oldest"]
+ * @param {string[]} [options.reasons] - Only these rejection reasons; omit for all.
+ * @returns {Promise<{success: boolean, queue: {
+ *   order: string, total: number, items: Array<{
+ *     rejection_id: number, mask_id: number, image_id: number, contour_id: number|null,
+ *     reason: string, reason_label: string, note: string|null,
+ *     created_by: string|null, created_at: string,
+ *   }>,
+ * }}>}
+ */
+export const buildCorrectionQueue = async (
+    datasetId,
+    { order = "oldest", reasons = null } = {}
+) => {
+    const response = await fetch(
+        `${API_BASE_URL}/reviews/datasets/${datasetId}/correction-queue`,
+        {
+            method: "POST",
+            headers: jsonHeaders(),
+            body: JSON.stringify({ order, reasons }),
+        }
     );
     return handleApiError(response);
 };

--- a/src/components/annotationPage/canvas/CanvasContainer.jsx
+++ b/src/components/annotationPage/canvas/CanvasContainer.jsx
@@ -12,6 +12,7 @@ import ObjectContextMenu from './ObjectContextMenu';
 import FocusOverlay from './FocusOverlay';
 import RefinementOverlay from './RefinementOverlay';
 import EditableContourOverlay from './EditableContourOverlay';
+import LineEditCanvas from './LineEditCanvas';
 import useAIAnnotationShortcuts from '../../../hooks/useAIAnnotationShortcuts';
 import useAISegmentation from '../../../hooks/useAISegmentation';
 import useFocusModeEscape from '../../../hooks/useFocusModeEscape';
@@ -27,6 +28,7 @@ import {
   useFetchAvailablePromptedModels,
   useRefinementModeActive, useSetPromptedModel,
   useFocusModeActive,
+  useLineEditActive,
 } from '../../../stores/selectors/annotationSelectors';
 
 const CanvasContainer = ({ imageObject, currentImage, zoomLevel, panOffset, isDragging }) => {
@@ -43,6 +45,7 @@ const CanvasContainer = ({ imageObject, currentImage, zoomLevel, panOffset, isDr
   const isSubmitting = useIsSubmitting();
   const refinementModeActive = useRefinementModeActive();
   const focusModeActive = useFocusModeActive();
+  const lineEditActive = useLineEditActive();
   const previousPromptsLengthRef = useRef(0);
   const previousRefinementModeRef = useRef(false);
   const refinementModeEnteredTimeRef = useRef(0);
@@ -207,6 +210,11 @@ const CanvasContainer = ({ imageObject, currentImage, zoomLevel, panOffset, isDr
 
       {/* Edit mode overlay (shows draggable control points for contour editing) */}
       <EditableContourOverlay canvasRef={canvasRef} zoomLevel={zoomLevel} panOffset={panOffset} />
+
+      {/* Line-edit mode: draw a line that gets merged into a contour (cut/add).
+          Mounted only while active so its viewport measures its container on the
+          first render (otherwise the stage stays 0-sized and eats clicks). */}
+      {lineEditActive && <LineEditCanvas />}
 
       {/* Context menu for object labeling */}
       <ObjectContextMenu />

--- a/src/components/annotationPage/canvas/EditableContourOverlay.jsx
+++ b/src/components/annotationPage/canvas/EditableContourOverlay.jsx
@@ -3,31 +3,67 @@ import { Stage, Layer, Circle, Line } from 'react-konva';
 import {
   useEditModeActive,
   useEditModeDraftCoordinates,
+  useEditModeVertices,
   useImageObject,
   useRefinementModeActive,
+  useMoveVertex,
+  useInsertVertex,
+  useDeleteVertex,
 } from '../../../stores/selectors/annotationSelectors';
 import { useContourEditing } from '../../../hooks/useContourEditing';
+import { nearestEdge } from '../../../utils/contourEditing';
 
 /**
- * EditableContourOverlay Component
- * Renders interactive control points on top of the contour being edited
- * Uses Konva for smooth dragging and rendering
+ * EditableContourOverlay
+ *
+ * Renders the manual contour editor: a smooth closed outline (the dense
+ * `draftCoordinates`) plus a handful of draggable **control vertices**. Drag a
+ * vertex to reshape, click the outline to add a vertex where you need finer
+ * control, double-click a vertex to remove it. All geometry is normalized [0,1].
  */
 const EditableContourOverlay = ({ canvasRef, zoomLevel = 1, panOffset = { x: 0, y: 0 } }) => {
   const editModeActive = useEditModeActive();
   const draftCoordinates = useEditModeDraftCoordinates();
+  const vertices = useEditModeVertices();
   const imageObject = useImageObject();
   const refinementModeActive = useRefinementModeActive();
-  
-  const { updatePoint, saveEditing, cancelEditing, resetChanges, isDirty, scheduleAutoSave, cancelAutoSave } = useContourEditing();
-  
+
+  const moveVertex = useMoveVertex();
+  const insertVertex = useInsertVertex();
+  const deleteVertex = useDeleteVertex();
+
+  const { cancelEditing, resetChanges, scheduleAutoSave, cancelAutoSave } = useContourEditing();
+
   const [imageDimensions, setImageDimensions] = useState({ width: 0, height: 0, x: 0, y: 0 });
   const [hoveredPoint, setHoveredPoint] = useState(null);
   const containerRef = useRef(null);
   const pointsWrapperRef = useRef(null);
-  
-  // Reduce control points to a manageable number (max ~30 handles)
-  const decimationFactor = Math.max(1, Math.floor((draftCoordinates?.x?.length || 0) / 30));
+  // Konva Stage nodes, so their backing-store resolution can track the zoom.
+  const singleStageRef = useRef(null);
+  const pointsStageRef = useRef(null);
+  const lineStageRef = useRef(null);
+
+  // Keep the overlay crisp when zoomed. The wrapper is CSS-scaled by `zoomLevel`,
+  // which would upscale (blur) a fixed-resolution canvas — so bump each Konva
+  // canvas's pixelRatio by the zoom to render at the displayed density instead.
+  useEffect(() => {
+    const pr = Math.min(4, (window.devicePixelRatio || 1) * (zoomLevel > 0 ? zoomLevel : 1));
+    const apply = (stage) => {
+      if (!stage) return;
+      try {
+        stage.getLayers().forEach((layer) => {
+          const canvas = layer.getCanvas();
+          if (canvas && canvas.getPixelRatio() !== pr) canvas.setPixelRatio(pr);
+        });
+        stage.batchDraw();
+      } catch {
+        /* stage torn down mid-update — nothing to do */
+      }
+    };
+    apply(singleStageRef.current);
+    apply(pointsStageRef.current);
+    apply(lineStageRef.current);
+  }, [zoomLevel, editModeActive, refinementModeActive]);
 
   // Calculate rendered image dimensions
   useEffect(() => {
@@ -39,7 +75,7 @@ const EditableContourOverlay = ({ canvasRef, zoomLevel = 1, panOffset = { x: 0, 
 
       const containerWidth = container.offsetWidth;
       const containerHeight = container.offsetHeight;
-      
+
       if (containerWidth === 0 || containerHeight === 0 || !imageObject.width || !imageObject.height) {
         return;
       }
@@ -174,49 +210,57 @@ const EditableContourOverlay = ({ canvasRef, zoomLevel = 1, panOffset = { x: 0, 
     }
   }, [forwardNativeEvent]);
 
-  if (!editModeActive || !draftCoordinates || !imageObject || imageDimensions.width === 0) {
+  if (!editModeActive || !draftCoordinates || !vertices || !imageObject || imageDimensions.width === 0) {
     return null;
   }
 
-  // Convert ALL coordinates to screen coordinates (for accurate line)
-  const allPointsInPixels = draftCoordinates.x.map((x, i) => ({
-    x: x * imageDimensions.width + imageDimensions.x,
-    y: draftCoordinates.y[i] * imageDimensions.height + imageDimensions.y,
-    index: i,
-  }));
-  
-  // Show fewer CONTROL HANDLES for cleaner UI (every Nth point)
-  const controlHandles = allPointsInPixels.filter((_, i) => i % decimationFactor === 0);
+  const toScreenX = (nx) => nx * imageDimensions.width + imageDimensions.x;
+  const toScreenY = (ny) => ny * imageDimensions.height + imageDimensions.y;
+  const toNormX = (sx) => (sx - imageDimensions.x) / imageDimensions.width;
+  const toNormY = (sy) => (sy - imageDimensions.y) / imageDimensions.height;
 
-  // Draw line with ALL points for accuracy (flat array: [x1, y1, x2, y2, ...])
-  const linePoints = allPointsInPixels.flatMap(p => [p.x, p.y]);
+  // The smooth outline: every dense draft point (straight segments between them
+  // trace the resampled Catmull-Rom curve).
+  const linePoints = draftCoordinates.x.flatMap((x, i) => [toScreenX(x), toScreenY(draftCoordinates.y[i])]);
+
+  // The handles: one per control vertex.
+  const handles = vertices.x.map((x, i) => ({ x: toScreenX(x), y: toScreenY(vertices.y[i]), index: i }));
+  const handleScreenXs = handles.map((h) => h.x);
+  const handleScreenYs = handles.map((h) => h.y);
 
   // Scale point sizes so they stay visually consistent regardless of zoom level.
-  // The outer div has CSS transform scale(zoomLevel), so dividing by zoomLevel
-  // keeps the on-screen pixel size constant at the base values.
   const safeZoom = zoomLevel > 0 ? zoomLevel : 1;
   const visiblePointRadius = Math.max(2, 5 / safeZoom);
-  const hoveredPointRadius = Math.max(2.5, 6 / safeZoom);
-  const hitboxRadius = Math.max(8, 20 / safeZoom);
+  const hoveredPointRadius = Math.max(2.5, 7 / safeZoom);
+  const hitboxRadius = Math.max(8, 18 / safeZoom);
+  // How close (on-screen px) a click must land to the outline to insert a vertex.
+  const insertThreshold = 16 / safeZoom;
 
-  // Handle point drag with smooth interpolation and auto-save scheduling
   const handlePointDragMove = (index, e) => {
     const stage = e.target.getStage();
     const pointerPos = stage.getPointerPosition();
-    
-    // Convert screen coordinates back to normalized (0-1)
-    const normalizedX = (pointerPos.x - imageDimensions.x) / imageDimensions.width;
-    const normalizedY = (pointerPos.y - imageDimensions.y) / imageDimensions.height;
-    
-    // Clamp to [0, 1]
-    const clampedX = Math.max(0, Math.min(1, normalizedX));
-    const clampedY = Math.max(0, Math.min(1, normalizedY));
-    
-    // Pass decimation factor for smooth interpolation between control points
-    updatePoint(index, clampedX, clampedY, decimationFactor);
+    const clampedX = Math.max(0, Math.min(1, toNormX(pointerPos.x)));
+    const clampedY = Math.max(0, Math.min(1, toNormY(pointerPos.y)));
+    moveVertex(index, clampedX, clampedY);
+    // Auto-save resets the idle timer on every drag; editing is fully auto-saved.
+    scheduleAutoSave();
+  };
 
-    // Schedule auto-save: resets the idle timer on every drag event.
-    // Editing is now fully auto-saved; there is no manual Save/Reset/Discard panel.
+  const handleDeleteVertex = (index) => {
+    if (vertices.x.length <= 3) return; // A closed shape needs at least three.
+    deleteVertex(index);
+    scheduleAutoSave();
+  };
+
+  // Click on empty canvas: if it lands on the outline, insert a vertex there.
+  const handleStageClick = (e) => {
+    if (e.target !== e.target.getStage()) return; // clicks on handles are theirs.
+    const stage = e.target.getStage();
+    const pointerPos = stage.getPointerPosition();
+    if (!pointerPos) return;
+    const { index, distance } = nearestEdge(handleScreenXs, handleScreenYs, pointerPos);
+    if (distance > insertThreshold) return; // clicked away from the outline — ignore.
+    insertVertex(index, toNormX(pointerPos.x), toNormY(pointerPos.y));
     scheduleAutoSave();
   };
 
@@ -232,62 +276,51 @@ const EditableContourOverlay = ({ canvasRef, zoomLevel = 1, panOffset = { x: 0, 
 
   const lineLayer = (
     <Layer listening={false}>
-      <Line
-        points={linePoints}
-        stroke="#3b82f6"
-        strokeWidth={2}
-        closed={true}
-        tension={0.4}
-      />
+      <Line points={linePoints} stroke="#3b82f6" strokeWidth={Math.max(1, 2 / safeZoom)} closed tension={0} />
     </Layer>
   );
 
-  const pointsLayer = (
-    <Layer>
-      {controlHandles.map((point) => {
-        const isHovered = hoveredPoint === point.index;
-        return (
-          <React.Fragment key={point.index}>
-            <Circle
-              x={point.x}
-              y={point.y}
-              radius={hitboxRadius}
-              fill="transparent"
-              draggable
-              onDragMove={(e) => handlePointDragMove(point.index, e)}
-              onMouseEnter={(e) => {
-                const container = e.target.getStage().container();
-                container.style.cursor = 'grab';
-                setHoveredPoint(point.index);
-              }}
-              onMouseLeave={(e) => {
-                const container = e.target.getStage().container();
-                container.style.cursor = 'default';
-                setHoveredPoint(null);
-              }}
-              onDragStart={(e) => {
-                const container = e.target.getStage().container();
-                container.style.cursor = 'grabbing';
-              }}
-              onDragEnd={(e) => {
-                const container = e.target.getStage().container();
-                container.style.cursor = 'grab';
-              }}
-            />
-            <Circle
-              x={point.x}
-              y={point.y}
-              radius={isHovered ? hoveredPointRadius : visiblePointRadius}
-              fill="#3b82f6"
-              stroke="#ffffff"
-              strokeWidth={Math.max(1, 2 / safeZoom)}
-              listening={false}
-            />
-          </React.Fragment>
-        );
-      })}
-    </Layer>
-  );
+  const renderHandle = (point) => {
+    const isHovered = hoveredPoint === point.index;
+    return (
+      <React.Fragment key={point.index}>
+        <Circle
+          x={point.x}
+          y={point.y}
+          radius={hitboxRadius}
+          fill="transparent"
+          draggable
+          onDragMove={(e) => handlePointDragMove(point.index, e)}
+          onDblClick={() => handleDeleteVertex(point.index)}
+          onMouseEnter={(e) => {
+            e.target.getStage().container().style.cursor = 'grab';
+            setHoveredPoint(point.index);
+          }}
+          onMouseLeave={(e) => {
+            e.target.getStage().container().style.cursor = 'default';
+            setHoveredPoint(null);
+          }}
+          onDragStart={(e) => {
+            e.target.getStage().container().style.cursor = 'grabbing';
+          }}
+          onDragEnd={(e) => {
+            e.target.getStage().container().style.cursor = 'grab';
+          }}
+        />
+        <Circle
+          x={point.x}
+          y={point.y}
+          radius={isHovered ? hoveredPointRadius : visiblePointRadius}
+          fill={isHovered ? '#2563eb' : '#3b82f6'}
+          stroke="#ffffff"
+          strokeWidth={Math.max(1, 2 / safeZoom)}
+          listening={false}
+        />
+      </React.Fragment>
+    );
+  };
+
+  const pointsLayer = <Layer>{handles.map(renderHandle)}</Layer>;
 
   // In refinement mode: line below (z-55, non-interactive) so prompt canvas (z-62) can receive clicks; points above (z-65) so they remain draggable
   if (refinementModeActive) {
@@ -298,7 +331,7 @@ const EditableContourOverlay = ({ canvasRef, zoomLevel = 1, panOffset = { x: 0, 
           className="absolute inset-0 pointer-events-none"
           style={{ ...transformStyle, zIndex: 55 }}
         >
-          <Stage {...stageProps} listening={false}>
+          <Stage {...stageProps} listening={false} ref={lineStageRef}>
             {lineLayer}
           </Stage>
         </div>
@@ -309,6 +342,7 @@ const EditableContourOverlay = ({ canvasRef, zoomLevel = 1, panOffset = { x: 0, 
         >
           <Stage
             {...stageProps}
+            ref={pointsStageRef}
             className="pointer-events-auto"
             onMouseDown={handlePointsStageMouseDown}
             onMouseMove={handlePointsStageMouseMove}
@@ -324,17 +358,26 @@ const EditableContourOverlay = ({ canvasRef, zoomLevel = 1, panOffset = { x: 0, 
   }
 
   return (
-    // Single overlay when not in refinement mode
-    <div
-      ref={containerRef}
-      className="absolute inset-0 pointer-events-none"
-      style={{ ...transformStyle, zIndex: 60 }}
-    >
-      <Stage {...stageProps} className="pointer-events-auto">
-        {lineLayer}
-        {pointsLayer}
-      </Stage>
-    </div>
+    <>
+      {/* Single overlay when not in refinement mode */}
+      <div
+        ref={containerRef}
+        className="absolute inset-0 pointer-events-none"
+        style={{ ...transformStyle, zIndex: 60 }}
+      >
+        <Stage {...stageProps} ref={singleStageRef} className="pointer-events-auto" onClick={handleStageClick} onTap={handleStageClick}>
+          {lineLayer}
+          {pointsLayer}
+        </Stage>
+      </div>
+
+      {/* Discoverability hint for the insert/delete gestures. */}
+      <div
+        className="absolute bottom-4 left-1/2 -translate-x-1/2 z-[62] pointer-events-none px-3 py-1.5 rounded-lg bg-gray-900/80 text-white text-xs font-medium shadow-lg backdrop-blur-sm"
+      >
+        Drag a point to reshape · Click the outline to add a point · Double-click a point to remove · Esc to discard
+      </div>
+    </>
   );
 };
 

--- a/src/components/annotationPage/canvas/LineEditCanvas.jsx
+++ b/src/components/annotationPage/canvas/LineEditCanvas.jsx
@@ -1,0 +1,294 @@
+import React, { useRef, useCallback, useEffect, useMemo } from 'react';
+import { Stage, Layer, Line } from 'react-konva';
+import { Hexagon, Spline, X } from 'lucide-react';
+import {
+  useImageObject,
+  useImageLoading,
+  useImageError,
+  useZoomLevel,
+  usePanOffset,
+  useSetZoomLevel,
+  useSetPanOffset,
+  useManualDrawMode,
+  useSetManualDrawMode,
+  useLineEditActive,
+  useLineEditObjectId,
+  useLineEditContourId,
+  useLineEditOriginal,
+  useStopLineEdit,
+  useUpdateObject,
+} from '../../../stores/selectors/annotationSelectors';
+import annotationSession from '../../../services/annotationSession';
+import { pixelArrayToNormalized } from '../../../utils/coordinateUtils';
+import { mergeLineIntoContour } from '../../../utils/contourEditing';
+import { useToast } from '../../../contexts/ToastContext';
+import useCanvasViewport from '../../../hooks/useCanvasViewport';
+import usePromptDrawing from '../../../hooks/usePromptDrawing';
+import DrawingPreview from './prompts/DrawingPreview';
+
+/**
+ * Line-edit Canvas
+ *
+ * Reshape a contour by drawing an open line near its boundary — freehand
+ * (press-drag) or polygon (click points, double-click / Enter to finish). On
+ * completion the line's ends snap to the closest points on the contour and the
+ * nearest boundary arc is replaced by the line (`mergeLineIntoContour`): draw just
+ * outside to add a region, just inside to cut one off. The result is saved via
+ * `modifyObject`. The faint dashed outline is the contour being reshaped.
+ *
+ * Rendered at full container resolution with zoom applied to coordinates (via
+ * `useCanvasViewport`), so the drawing stays crisp at any zoom. Only mounted while
+ * a line-edit session is active (mounting is gated by the parent so the viewport
+ * measures its container on first render).
+ */
+const MODES = [
+  { id: 'freehand', label: 'Freehand', icon: Spline, hotkey: 'F' },
+  { id: 'polygon', label: 'Polygon', icon: Hexagon, hotkey: 'G' },
+];
+
+const LineEditCanvas = () => {
+  const stageRef = useRef(null);
+  const active = useLineEditActive();
+  const objectId = useLineEditObjectId();
+  const contourId = useLineEditContourId();
+  const original = useLineEditOriginal();
+  const stopLineEdit = useStopLineEdit();
+  const updateObject = useUpdateObject();
+  const { addToast } = useToast();
+
+  const mode = useManualDrawMode();
+  const setMode = useSetManualDrawMode();
+
+  const imageObject = useImageObject();
+  const imageLoading = useImageLoading();
+  const imageError = useImageError();
+  const zoomLevel = useZoomLevel();
+  const panOffset = usePanOffset();
+  const setZoomLevel = useSetZoomLevel();
+  const setPanOffset = useSetPanOffset();
+
+  const {
+    containerRef,
+    containerSize,
+    imageDimensions,
+    isPanning,
+    isPanMode,
+    stageToImageCoords,
+    handlePanStart,
+    handlePanMove,
+    handlePanEnd,
+    handleWheel,
+  } = useCanvasViewport({ imageObject, zoomLevel, panOffset, setZoomLevel, setPanOffset, active });
+
+  const getScale = useCallback(
+    () => imageDimensions.baseScale * zoomLevel,
+    [imageDimensions.baseScale, zoomLevel]
+  );
+  const toStage = useCallback(
+    (pt) => {
+      const finalScale = imageDimensions.baseScale * zoomLevel;
+      return [
+        pt.x * finalScale + imageDimensions.displayX,
+        pt.y * finalScale + imageDimensions.displayY,
+      ];
+    },
+    [imageDimensions, zoomLevel]
+  );
+
+  // The contour being reshaped, in stage pixels, as a faint dashed reference.
+  const referencePoints = useMemo(() => {
+    if (!original || !imageObject || !imageDimensions.baseScale) return null;
+    const pts = [];
+    for (let i = 0; i < original.x.length; i++) {
+      const [sx, sy] = toStage({
+        x: original.x[i] * imageObject.width,
+        y: original.y[i] * imageObject.height,
+      });
+      pts.push(sx, sy);
+    }
+    return pts;
+  }, [original, imageObject, imageDimensions.baseScale, toStage]);
+
+  const handleDrawFinalize = useCallback(async (points, { freehand }) => {
+    if (!imageObject || points.length < 2 || contourId == null || !original) return;
+
+    // Merge in pixel space (avoids the x/y aspect skew of normalized coordinates).
+    const contourPixel = original.x.map((x, i) => ({
+      x: x * imageObject.width,
+      y: original.y[i] * imageObject.height,
+    }));
+    const linePixel = points.map((p) => ({ x: p.x, y: p.y }));
+    const merged = mergeLineIntoContour(contourPixel, linePixel);
+
+    if (merged === contourPixel || merged.length < 3) {
+      addToast({ type: 'error', message: 'Draw the line so its two ends sit near different parts of the outline.' });
+      return;
+    }
+
+    const normalized = pixelArrayToNormalized(
+      merged.map((p) => p.x),
+      merged.map((p) => p.y),
+      imageObject.width,
+      imageObject.height
+    );
+
+    if (!annotationSession.isReady()) {
+      addToast({ type: 'error', message: 'Session is not ready yet. Please wait for the image to load.' });
+      return;
+    }
+
+    // Optimistic: show the reshaped outline immediately, revert if the save fails.
+    updateObject(objectId, { x: normalized.x, y: normalized.y, path: null });
+    stopLineEdit();
+    try {
+      const response = await annotationSession.modifyObject(contourId, { x: normalized.x, y: normalized.y });
+      if (response && response.success === false) throw new Error(response.message || 'Save rejected');
+      addToast({ type: 'success', message: `Outline reshaped (${freehand ? 'freehand' : 'polygon'}).` });
+    } catch (err) {
+      updateObject(objectId, { x: original.x, y: original.y, path: null });
+      addToast({ type: 'error', message: err.message || 'Could not reshape the outline. Reverted.' });
+    }
+  }, [imageObject, contourId, objectId, original, updateObject, stopLineEdit, addToast]);
+
+  const {
+    polygonPoints,
+    cursorImagePt,
+    handleMouseDown: drawMouseDown,
+    handleMouseMove: drawMouseMove,
+    handleMouseUp: drawMouseUp,
+    handleDblClick: drawDblClick,
+    handleKeyDown: drawKeyDown,
+  } = usePromptDrawing({
+    mode,
+    stageToImageCoords,
+    getScale,
+    onFinalize: handleDrawFinalize,
+    minPoints: 2, // an open line needs only two points
+    closeOnFirst: false, // do not snap-close near the first point; it is not a loop
+  });
+
+  const handleMouseDown = useCallback((e) => {
+    if (!active) return;
+    if (e.evt.button === 1 || (e.evt.button === 0 && isPanMode)) {
+      handlePanStart(e);
+      return;
+    }
+    drawMouseDown(e);
+  }, [active, isPanMode, handlePanStart, drawMouseDown]);
+
+  const handleMouseMove = useCallback((e) => {
+    if (isPanning) {
+      handlePanMove(e);
+      return;
+    }
+    drawMouseMove(e);
+  }, [isPanning, handlePanMove, drawMouseMove]);
+
+  const handleMouseUp = useCallback((e) => {
+    if (isPanning) {
+      handlePanEnd();
+      return;
+    }
+    drawMouseUp(e);
+  }, [isPanning, handlePanEnd, drawMouseUp]);
+
+  const handleContextMenu = useCallback((e) => {
+    e.evt.preventDefault();
+  }, []);
+
+  useEffect(() => {
+    if (!active) return undefined;
+    const onKeyDown = (e) => {
+      if (drawKeyDown(e)) {
+        e.preventDefault();
+        e.stopPropagation();
+        return;
+      }
+      const typing = e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA' || e.target.isContentEditable;
+      if (typing || e.ctrlKey || e.metaKey || e.altKey) return;
+      const key = e.key.toLowerCase();
+      if (key === 'g') { e.preventDefault(); setMode('polygon'); }
+      else if (key === 'f') { e.preventDefault(); setMode('freehand'); }
+      else if (e.code === 'Escape') { e.preventDefault(); stopLineEdit(); }
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [active, drawKeyDown, setMode, stopLineEdit]);
+
+  if (!active) return null;
+  if (imageLoading || imageError || !imageObject) return null;
+
+  const cursor = isPanning ? 'grabbing' : isPanMode ? 'grab' : 'crosshair';
+
+  return (
+    <div ref={containerRef} className="absolute inset-0 z-[60]" style={{ cursor }}>
+      {/* Mode selector */}
+      <div className="absolute top-4 left-4 z-50 flex items-center gap-1 bg-white/95 backdrop-blur-sm border border-gray-200 rounded-xl shadow-lg p-1">
+        {MODES.map(({ id, label, icon: Icon, hotkey }) => {
+          const isActive = mode === id;
+          return (
+            <button
+              key={id}
+              type="button"
+              onClick={() => setMode(id)}
+              title={`${label} (${hotkey})`}
+              className={`flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs font-medium transition-colors ${
+                isActive ? 'bg-teal-500 text-white shadow-sm' : 'text-gray-600 hover:bg-gray-100'
+              }`}
+            >
+              <Icon className="w-3.5 h-3.5" />
+              <span className="hidden sm:inline">{label}</span>
+            </button>
+          );
+        })}
+        <div className="w-px h-5 bg-gray-200 mx-1" />
+        <button
+          type="button"
+          onClick={stopLineEdit}
+          title="Cancel (Esc)"
+          className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs font-medium text-gray-600 hover:bg-gray-100 transition-colors"
+        >
+          <X className="w-3.5 h-3.5" />
+          <span className="hidden sm:inline">Cancel</span>
+        </button>
+      </div>
+
+      {/* Instruction */}
+      <div className="absolute top-4 left-1/2 transform -translate-x-1/2 bg-gray-900/90 text-white px-3 py-1.5 rounded-full text-xs font-medium shadow-lg z-40 pointer-events-none text-center">
+        {mode === 'polygon'
+          ? 'Click a line across the boundary · double-click or Enter to finish · outside adds, inside cuts'
+          : 'Drag a line across the boundary · release to finish · outside adds a region, inside cuts one off'}
+      </div>
+
+      <Stage
+        ref={stageRef}
+        width={containerSize.width}
+        height={containerSize.height}
+        onDblClick={drawDblClick}
+        onMouseDown={handleMouseDown}
+        onMouseMove={handleMouseMove}
+        onMouseUp={handleMouseUp}
+        onMouseLeave={handleMouseUp}
+        onWheel={handleWheel}
+        onContextMenu={handleContextMenu}
+      >
+        <Layer listening={false}>
+          {referencePoints && (
+            <Line points={referencePoints} closed stroke="#f43f5e" strokeWidth={1.5} dash={[6, 5]} opacity={0.55} />
+          )}
+        </Layer>
+        <Layer>
+          <DrawingPreview
+            mode={mode}
+            polygonPoints={polygonPoints}
+            cursorImagePt={cursorImagePt}
+            toStage={toStage}
+            closed={false}
+          />
+        </Layer>
+      </Stage>
+    </div>
+  );
+};
+
+export default LineEditCanvas;

--- a/src/components/annotationPage/canvas/ObjectContextMenu.jsx
+++ b/src/components/annotationPage/canvas/ObjectContextMenu.jsx
@@ -20,6 +20,8 @@ import {
   useSuggestionModel,
   useWebSocketIsReady,
   useEnterEditMode,
+  useStartLineEdit,
+  useSelectObject,
 } from '../../../stores/selectors/annotationSelectors';
 import { useRefinementMode } from '../../../hooks/useRefinementMode';
 import { useZoomToObject } from '../../../hooks/useZoomToObject';
@@ -64,6 +66,8 @@ const ObjectContextMenu = () => {
   });
   const wsIsReady = useWebSocketIsReady();
   const enterEditMode = useEnterEditMode();
+  const startLineEdit = useStartLineEdit();
+  const selectObject = useSelectObject();
   const { currentDataset } = useDataset();
   const menuRef = useRef(null);
   
@@ -410,6 +414,44 @@ const ObjectContextMenu = () => {
     await runSuggestion(contourIds.length === 1 ? contourIds[0] : contourIds, labelId);
   };
 
+  const handleLineEditContour = () => {
+    if (isMultiSelect) return;
+    const targetObject = objectsList.find(obj => obj.id === targetObjectId);
+    if (!targetObject || targetObject.contour_id == null ||
+        !targetObject.x || targetObject.x.length === 0) {
+      hideContextMenu();
+      return;
+    }
+
+    if (focusModeActive) {
+      if (annotationSession.isReady()) {
+        annotationSession.unfocusImage().catch(() => {});
+      }
+      exitFocusMode();
+    }
+
+    selectObject(targetObject.id);
+    setCurrentTool('selection');
+    startLineEdit(targetObject.id, targetObject.contour_id, targetObject.x, targetObject.y);
+
+    // Frame the instance so there is room to draw the line.
+    if (imageObject && targetObject.x.length > 0) {
+      const container = menuRef.current?.parentElement;
+      if (container?.offsetWidth && container?.offsetHeight) {
+        const rendered = calculateRenderedImageDimensions(imageObject, container.offsetWidth, container.offsetHeight);
+        zoomToObject(
+          targetObject,
+          { width: imageObject.width, height: imageObject.height },
+          { width: container.offsetWidth, height: container.offsetHeight },
+          rendered,
+          { animateMs: 300, immediate: false }
+        );
+      }
+    }
+
+    hideContextMenu();
+  };
+
   const handleEditContour = () => {
     // Disable edit mode for multiple objects
     if (isMultiSelect) {
@@ -542,11 +584,25 @@ const ObjectContextMenu = () => {
         }
       />
 
+      {/* Reshape by Line Option - draw a line that is merged into the boundary */}
+      <ContextMenuItem
+        onClick={handleLineEditContour}
+        disabled={isMultiSelect}
+        title={isMultiSelect ? 'Reshape is disabled for multiple selections' : 'Draw a line across the boundary to cut off or add a region'}
+        className="hover:bg-teal-50 hover:text-teal-700"
+        label="Reshape by Line"
+        icon={
+          <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 20l6-6m0 0l4-4 6-6M10 14l4 4m-4-4l-2-2" />
+          </svg>
+        }
+      />
+
       {/* Edit Contour Option - Disabled for multi-select */}
       <ContextMenuItem
         onClick={handleEditContour}
         disabled={isMultiSelect}
-        title={isMultiSelect ? 'Edit contour is disabled for multiple selections' : 'Edit contour shape'}
+        title={isMultiSelect ? 'Edit contour is disabled for multiple selections' : 'Drag the existing outline’s control points'}
         className="hover:bg-blue-50 hover:text-blue-700"
         label="Edit Contour"
         icon={

--- a/src/components/annotationPage/canvas/prompts/DrawingPreview.jsx
+++ b/src/components/annotationPage/canvas/prompts/DrawingPreview.jsx
@@ -9,9 +9,12 @@ import { Line, Circle } from 'react-konva';
  * @param {Array<{x:number,y:number}>} props.polygonPoints - Vertices in image space
  * @param {{x:number,y:number}|null} props.cursorImagePt - Live cursor vertex (polygon only)
  * @param {Function} props.toStage - Maps an image-space point to [stageX, stageY]
+ * @param {boolean} [props.closed] - Override whether the preview line closes back
+ *   on itself. Defaults to closing only for freehand; pass false to draw an open line.
  */
-const DrawingPreview = ({ mode, polygonPoints, cursorImagePt, toStage }) => {
+const DrawingPreview = ({ mode, polygonPoints, cursorImagePt, toStage, closed }) => {
   if (!polygonPoints || polygonPoints.length === 0) return null;
+  const isClosed = closed ?? mode === 'freehand';
 
   const livePoints = [];
   polygonPoints.forEach((pt) => {
@@ -28,11 +31,11 @@ const DrawingPreview = ({ mode, polygonPoints, cursorImagePt, toStage }) => {
     <>
       <Line
         points={livePoints}
-        closed={mode === 'freehand'}
+        closed={isClosed}
         stroke="#0D9488"
         strokeWidth={2}
         dash={mode === 'polygon' ? [6, 4] : undefined}
-        fill={mode === 'freehand' ? 'rgba(20, 184, 166, 0.12)' : undefined}
+        fill={isClosed ? 'rgba(20, 184, 166, 0.12)' : undefined}
         lineJoin="round"
         lineCap="round"
       />

--- a/src/components/annotationPage/layout/DatasetLoader.jsx
+++ b/src/components/annotationPage/layout/DatasetLoader.jsx
@@ -1,12 +1,32 @@
 import React, { useEffect, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams, useLocation } from 'react-router-dom';
 import { useDataset } from '../../../contexts/DatasetContext';
 import { useSetImageList, useSetCurrentImage } from '../../../stores/selectors/annotationSelectors';
 import useAnnotationStore from '../../../stores/useAnnotationStore';
 import { fetchImages } from '../../../api/images';
+import { fetchAnnotationQueue } from '../../../api/annotation_queue';
+
+/**
+ * Reorder the image list to follow the annotation queue: ids in `queueIds` come
+ * first, in that order; images not in the queue (e.g. uploaded after the queue was
+ * built) keep their original order at the end. Next/previous walk this list, so
+ * this is what makes the queue define the annotation order.
+ */
+const orderImagesByQueue = (images, queueIds) => {
+  if (!queueIds || queueIds.length === 0) return images;
+  const rank = new Map(queueIds.map((id, index) => [id, index]));
+  const inQueue = [];
+  const rest = [];
+  images.forEach((img) => (rank.has(img.id) ? inQueue : rest).push(img));
+  inQueue.sort((a, b) => rank.get(a.id) - rank.get(b.id));
+  return [...inQueue, ...rest];
+};
+
+const isFinished = (img) => img?.status === 'finished' || img?.finished;
 
 const DatasetLoader = ({ children }) => {
   const navigate = useNavigate();
+  const location = useLocation();
   const { datasetId, imageId } = useParams();
   const { datasets, currentDataset, selectDataset, loading } = useDataset();
   const setImageList = useSetImageList();
@@ -100,21 +120,42 @@ const DatasetLoader = ({ children }) => {
           isFromAPI: true,
         }));
 
-        setImageList(apiImages);
+        // Apply the annotator's saved queue order. The queue ids are seeded from
+        // navigation state when we just came from the builder (avoids a reorder
+        // flash and a race with the just-saved row); on a refresh or a direct link
+        // there is no state, so fall back to re-reading the saved queue.
+        let orderedImages = apiImages;
+        try {
+          let queueIds = location.state?.queueImageIds;
+          if (!queueIds) {
+            const queueResponse = await fetchAnnotationQueue(dataset.id);
+            queueIds = queueResponse?.success && queueResponse.queue
+              ? queueResponse.queue.image_ids
+              : null;
+          }
+          orderedImages = orderImagesByQueue(apiImages, queueIds);
+        } catch (queueError) {
+          // No queue (or it failed to load) — keep upload order.
+          orderedImages = apiImages;
+        }
+
+        setImageList(orderedImages);
 
         // Set current image if imageId is provided
         if (imageId) {
           const imageIdNum = parseInt(imageId);
-          const targetImage = apiImages.find(img => img.id === imageIdNum);
+          const targetImage = orderedImages.find(img => img.id === imageIdNum);
           if (targetImage) {
             setCurrentImage(targetImage);
           } else {
             // Image not found, set first image as fallback
-            setCurrentImage(apiImages[0]);
+            setCurrentImage(orderedImages[0]);
           }
         } else {
-          // No specific image, set first image
-          setCurrentImage(apiImages[0]);
+          // No specific image: start at the first image still needing work, in
+          // queue order, so the annotator picks up where the queue left off.
+          const firstUnfinished = orderedImages.find(img => !isFinished(img));
+          setCurrentImage(firstUnfinished || orderedImages[0]);
         }
       } else {
         // Fallback to empty list

--- a/src/components/annotationPage/layout/MainLayout.jsx
+++ b/src/components/annotationPage/layout/MainLayout.jsx
@@ -3,6 +3,7 @@ import ImageHeader from './ImageHeader';
 import LeftSidebarWrapper from './LeftSidebarWrapper';
 import RightSidebarWrapper from './RightSidebarWrapper';
 import ReviewBar from './ReviewBar';
+import CorrectionBar from '../../correction/CorrectionBar';
 import MainCanvas from '../canvas/MainCanvas';
 import useAnnotationKeyboardShortcuts from '../../../hooks/useAnnotationKeyboardShortcuts';
 
@@ -13,6 +14,11 @@ const MainLayout = () => {
     <div>
       {/* Image Header */}
       <ImageHeader />
+
+      {/* Correction session driver. Renders nothing unless a correction session
+          is active; when it is, it walks the annotator through the sent-back
+          instances one at a time. */}
+      <CorrectionBar />
 
       {/* Review feedback and the reviewer's send-back control. Renders nothing
           when there is no open feedback and the user cannot reject. */}

--- a/src/components/correction/CorrectionBar.jsx
+++ b/src/components/correction/CorrectionBar.jsx
@@ -1,0 +1,318 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import {
+  Check,
+  Loader2,
+  PenLine,
+  Pencil,
+  ScanEye,
+  SkipForward,
+  Wrench,
+  X,
+  XCircle,
+} from 'lucide-react';
+import { resolveRejection } from '../../api/reviews';
+import { useCorrection } from '../../contexts/CorrectionContext';
+import { useToast } from '../../contexts/ToastContext';
+import { useContourEditing } from '../../hooks/useContourEditing';
+import { useZoomToObject } from '../../hooks/useZoomToObject';
+import { getContourId } from '../../utils/objectUtils';
+import { calculateRenderedImageDimensions, getCanvasContainer } from '../../utils/canvasUtils';
+import {
+  useObjectsList,
+  useSelectObject,
+  useClearSelection,
+  useCurrentMaskId,
+  useWebSocketIsReady,
+  useImageObject,
+  useEnterEditMode,
+  useExitEditMode,
+  useSetCurrentTool,
+  useStartLineEdit,
+  useStopLineEdit,
+} from '../../stores/selectors/annotationSelectors';
+
+const readableError = (err, fallback) =>
+  (err?.message || '').replace(/^API Error:\s*/i, '') || fallback;
+
+/** Reasons whose fix is a re-outline, so the canvas drops straight into point editing. */
+const OUTLINE_REASONS = new Set(['bad_outline']);
+
+/**
+ * Drives a correction session from inside the annotation editor.
+ *
+ * A correction session is a queue of open rejections (built on the launch page,
+ * held in `CorrectionContext`). This bar walks it one item at a time: it keeps the
+ * editor pointed at the current item's image, auto-selects the sent-back instance
+ * and — for an outline complaint — drops into the manual contour editor (drag the
+ * control points) so the annotator can reshape it immediately. "Mark as done" /
+ * "Won't fix" resolve the rejection with the matching kind and advance; "Skip"
+ * advances without resolving. Any pending point edit is saved on every advance.
+ *
+ * Renders nothing when no session is active, so mounting it unconditionally in
+ * `MainLayout` is free for ordinary annotation work.
+ */
+const CorrectionBar = () => {
+  const { datasetId, imageId: urlImageId } = useParams();
+  const navigate = useNavigate();
+  const { addToast } = useToast();
+  const {
+    active,
+    currentItem,
+    index,
+    total,
+    datasetId: sessionDatasetId,
+    advance,
+    endSession,
+  } = useCorrection();
+
+  const objectsList = useObjectsList();
+  const selectObject = useSelectObject();
+  const clearSelection = useClearSelection();
+  const currentMaskId = useCurrentMaskId();
+  const sessionReady = useWebSocketIsReady();
+  const imageObject = useImageObject();
+  const enterEditMode = useEnterEditMode();
+  const exitEditMode = useExitEditMode();
+  const setCurrentTool = useSetCurrentTool();
+  const startLineEdit = useStartLineEdit();
+  const stopLineEdit = useStopLineEdit();
+  const { saveEditing, cancelAutoSave } = useContourEditing();
+  const { zoomToObject } = useZoomToObject({ marginPct: 0.25, maxZoom: 4, minZoom: 1 });
+
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState(null);
+  // The rejection id we have already auto-focused, so the effect fires once per item.
+  const focusedRejectionRef = useRef(null);
+
+  const findTarget = useCallback(
+    (contourId) =>
+      contourId == null
+        ? null
+        : objectsList.find((obj) => Number(getContourId(obj)) === Number(contourId)) || null,
+    [objectsList]
+  );
+
+  const zoomToInstance = useCallback(
+    (target) => {
+      if (!imageObject || !target?.x?.length) return;
+      const container =
+        getCanvasContainer(null) || document.querySelector('.relative.overflow-hidden');
+      if (!container) return;
+      const cw = container.offsetWidth;
+      const ch = container.offsetHeight;
+      if (!cw || !ch) return;
+      const rendered = calculateRenderedImageDimensions(imageObject, cw, ch);
+      zoomToObject(
+        target,
+        { width: imageObject.width, height: imageObject.height },
+        { width: cw, height: ch },
+        rendered,
+        { animateMs: 300 }
+      );
+    },
+    [imageObject, zoomToObject]
+  );
+
+  // Bring one instance into focus: select it, frame it, and open the requested
+  // fixing tool — 'line' (draw a line merged into the boundary), 'points' (drag
+  // control points), or 'none' (just look).
+  const focusInstance = useCallback(
+    (target, { tool }) => {
+      clearSelection();
+      selectObject(target.id);
+      setCurrentTool('selection');
+      zoomToInstance(target);
+      if (tool === 'line') startLineEdit(target.id, target.contour_id, target.x, target.y);
+      else if (tool === 'points') enterEditMode(target.id, target.contour_id, target.x, target.y);
+    },
+    [clearSelection, selectObject, setCurrentTool, zoomToInstance, startLineEdit, enterEditMode]
+  );
+
+  // -- Keep the editor on the current item's image ---------------------------
+  useEffect(() => {
+    if (!active || !currentItem) return;
+    if (String(currentItem.image_id) !== String(urlImageId)) {
+      navigate(`/dataset/${sessionDatasetId}/annotate/${currentItem.image_id}`);
+    }
+  }, [active, currentItem, urlImageId, sessionDatasetId, navigate]);
+
+  // -- Auto-select / edit the sent-back instance once its image is loaded ----
+  useEffect(() => {
+    if (!active || !currentItem) return;
+    if (focusedRejectionRef.current === currentItem.rejection_id) return;
+    // Wait until the editor session for this exact mask is ready and its objects
+    // have arrived over the socket.
+    if (!sessionReady || currentMaskId !== currentItem.mask_id) return;
+
+    // Mask-level feedback (e.g. "objects are missing") has no single instance to
+    // open — leave the whole image in view and just show the note.
+    if (currentItem.contour_id == null) {
+      focusedRejectionRef.current = currentItem.rejection_id;
+      clearSelection();
+      return;
+    }
+
+    const target = findTarget(currentItem.contour_id);
+    if (!target) return; // Objects still loading; try again on the next render.
+
+    focusedRejectionRef.current = currentItem.rejection_id;
+    // An outline complaint drops straight into the line tool (the user's primary
+    // fix); other reasons just frame the instance.
+    focusInstance(target, { tool: OUTLINE_REASONS.has(currentItem.reason) ? 'line' : 'none' });
+  }, [active, currentItem, sessionReady, currentMaskId, findTarget, focusInstance, clearSelection]);
+
+  // Persist any pending point edit, drop any in-progress line edit, then step to
+  // the next item (or finish).
+  const goNext = useCallback(() => {
+    saveEditing().catch(() => {}); // no-op when not editing or nothing changed
+    cancelAutoSave();
+    stopLineEdit();
+    if (index >= total - 1) {
+      endSession();
+      addToast({ type: 'success', message: 'Correction session complete.' });
+      navigate(`/dataset/${sessionDatasetId}/datamanagement`);
+    } else {
+      advance();
+    }
+  }, [saveEditing, cancelAutoSave, stopLineEdit, index, total, advance, endSession, addToast, navigate, sessionDatasetId]);
+
+  const resolveAndAdvance = useCallback(
+    async (resolution) => {
+      if (!currentItem || busy) return;
+      setBusy(true);
+      setError(null);
+      try {
+        await resolveRejection(currentItem.rejection_id, resolution);
+        goNext();
+      } catch (err) {
+        setError(readableError(err, 'Could not resolve this item.'));
+      } finally {
+        setBusy(false);
+      }
+    },
+    [currentItem, busy, goNext]
+  );
+
+  const handleExit = useCallback(() => {
+    saveEditing().catch(() => {});
+    cancelAutoSave();
+    exitEditMode();
+    stopLineEdit();
+    endSession();
+    navigate(`/dataset/${sessionDatasetId}/datamanagement`);
+  }, [saveEditing, cancelAutoSave, exitEditMode, stopLineEdit, endSession, navigate, sessionDatasetId]);
+
+  if (!active || !currentItem) return null;
+
+  // Guard against a session that belongs to another dataset (stale navigation).
+  if (String(sessionDatasetId) !== String(datasetId)) return null;
+
+  const isOutline = OUTLINE_REASONS.has(currentItem.reason);
+
+  const focusWith = (tool) => {
+    const target = findTarget(currentItem.contour_id);
+    if (target) focusInstance(target, { tool });
+  };
+
+  return (
+    <div className="bg-teal-50 border-b border-teal-200 px-4 py-2.5">
+      <div className="flex items-center gap-4 flex-wrap">
+        <div className="flex items-center gap-2 text-teal-800 flex-shrink-0">
+          <Wrench className="w-5 h-5" />
+          <span className="font-semibold text-sm">Correcting</span>
+          <span className="text-sm text-teal-600">
+            {index + 1} / {total}
+          </span>
+        </div>
+
+        <div className="flex-1 min-w-0 text-sm">
+          <span className="font-medium text-gray-900">{currentItem.reason_label}</span>
+          {currentItem.contour_id != null && (
+            <span className="text-gray-500"> · object #{currentItem.contour_id}</span>
+          )}
+          {currentItem.note && (
+            <span className="text-gray-700"> — “{currentItem.note}”</span>
+          )}
+          {currentItem.created_by && (
+            <span className="text-gray-400"> ({currentItem.created_by})</span>
+          )}
+          {error && <span className="block text-red-700">{error}</span>}
+        </div>
+
+        <div className="flex items-center gap-2 flex-shrink-0">
+          {currentItem.contour_id != null && isOutline && (
+            <>
+              <button
+                onClick={() => focusWith('line')}
+                disabled={busy}
+                className="inline-flex items-center gap-1.5 px-2.5 py-1.5 text-xs font-semibold text-teal-700 bg-white border border-teal-300 rounded-lg hover:bg-teal-100 disabled:opacity-50 transition-colors"
+                title="Draw a line across the boundary to cut off or add a region"
+              >
+                <PenLine className="w-3.5 h-3.5" />
+                Draw line
+              </button>
+              <button
+                onClick={() => focusWith('points')}
+                disabled={busy}
+                className="inline-flex items-center gap-1.5 px-2.5 py-1.5 text-xs font-medium text-gray-600 bg-white border border-gray-200 rounded-lg hover:bg-gray-50 disabled:opacity-50 transition-colors"
+                title="Drag the existing outline's control points instead"
+              >
+                <Pencil className="w-3.5 h-3.5" />
+                Adjust points
+              </button>
+            </>
+          )}
+          {currentItem.contour_id != null && !isOutline && (
+            <button
+              onClick={() => focusWith('none')}
+              disabled={busy}
+              className="inline-flex items-center gap-1.5 px-2.5 py-1.5 text-xs font-medium text-teal-700 bg-white border border-teal-200 rounded-lg hover:bg-teal-100 disabled:opacity-50 transition-colors"
+              title="Zoom to this instance"
+            >
+              <ScanEye className="w-3.5 h-3.5" />
+              Locate
+            </button>
+          )}
+          <button
+            onClick={() => resolveAndAdvance('fixed')}
+            disabled={busy}
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-semibold text-white bg-teal-600 rounded-lg hover:bg-teal-700 disabled:bg-gray-300 transition-colors"
+          >
+            {busy ? <Loader2 className="w-4 h-4 animate-spin" /> : <Check className="w-4 h-4" />}
+            Mark as done
+          </button>
+          <button
+            onClick={() => resolveAndAdvance('wont_fix')}
+            disabled={busy}
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 disabled:opacity-50 transition-colors"
+            title="Leave the annotation as it is — I checked, it is correct"
+          >
+            <XCircle className="w-4 h-4" />
+            Won&apos;t fix
+          </button>
+          <button
+            onClick={goNext}
+            disabled={busy}
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-gray-600 hover:text-gray-800 disabled:opacity-50 transition-colors"
+            title="Skip this item — leaves it open for later"
+          >
+            <SkipForward className="w-4 h-4" />
+            Skip
+          </button>
+          <button
+            onClick={handleExit}
+            disabled={busy}
+            className="inline-flex items-center gap-1 px-2 py-1.5 text-sm font-medium text-gray-500 hover:text-gray-700 disabled:opacity-50 transition-colors"
+            title="End the correction session"
+          >
+            <X className="w-4 h-4" />
+            End
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CorrectionBar;

--- a/src/components/datasets/DatasetGallery.jsx
+++ b/src/components/datasets/DatasetGallery.jsx
@@ -5,6 +5,7 @@ import DataManagementView from "./gallery/DataManagementView";
 import LabelManagementView from "./gallery/LabelManagementView";
 import ManagementCardsView from "./gallery/ManagementCardsView";
 import CocoExportModal from "./gallery/CocoExportModal";
+import AnnotationQueueModal from "./gallery/AnnotationQueueModal";
 import DatasetManagementLayout from "./gallery/DatasetManagementLayout";
 import * as api from "../../api";
 import { normalizeImage } from "../../hooks/useDatasetGalleryData";
@@ -26,7 +27,8 @@ const DatasetGallery = () => {
   const galleryActions = useGalleryActions();
 
   const [showCocoModal, setShowCocoModal] = useState(false);
-  
+  const [showQueueModal, setShowQueueModal] = useState(false);
+
   // Derive current view from URL path so refresh preserves the view
   const pathname = location.pathname;
   const currentView = pathname.endsWith("/images")
@@ -43,23 +45,29 @@ const DatasetGallery = () => {
     galleryActions.setLabels(updatedLabels);
   }, [galleryActions]);
 
-  const handleStartAnnotation = async () => {
-    try {
-      // Get the first unannotated image
-      const response = await api.fetchImagesWithAnnotationStatus(dataset.id, "not_started");
-      
-      if (response.success && response.image_ids && response.image_ids.length > 0) {
-        const firstUnannotatedImageId = response.image_ids[0];
-        navigate(`/dataset/${dataset.id}/annotate/${firstUnannotatedImageId}`);
-      } else {
-        // No unannotated images, go to general annotation page
-        navigate(`/dataset/${dataset.id}/annotate`);
-      }
-    } catch (error) {
-      console.error("Error fetching unannotated images:", error);
-      // Fallback to general annotation page
+  // The Annotation card opens the queue builder rather than jumping straight into
+  // the editor: the queue defines the order images are worked in.
+  const handleAnnotationClick = () => setShowQueueModal(true);
+
+  // Called by the queue modal once a queue is built or resumed. Land on the first
+  // not-yet-finished image in queue order (fall back to the first image, then to
+  // the general page), and hand the order over via router state so the editor's
+  // loader can apply it without a reorder flash — it also re-reads the saved queue.
+  const handleQueueStart = (imageIds) => {
+    setShowQueueModal(false);
+    if (!imageIds || imageIds.length === 0) {
       navigate(`/dataset/${dataset.id}/annotate`);
+      return;
     }
+    const statusById = new Map(images.map((img) => [img.id, img]));
+    const firstUnfinished = imageIds.find((id) => {
+      const img = statusById.get(id);
+      return !img || (img.status !== "finished" && !img.finished);
+    });
+    const targetId = firstUnfinished ?? imageIds[0];
+    navigate(`/dataset/${dataset.id}/annotate/${targetId}`, {
+      state: { queueImageIds: imageIds },
+    });
   };
 
   const handleImageClick = (image) => {
@@ -112,6 +120,14 @@ const DatasetGallery = () => {
     navigate(`/dataset/${datasetId}/access`);
   };
 
+  const handleReviewClick = () => {
+    navigate(`/dataset/${datasetId}/review`);
+  };
+
+  const handleCorrectClick = () => {
+    navigate(`/dataset/${datasetId}/correct`);
+  };
+
   return (
     <DatasetManagementLayout>
       <div className="h-full overflow-hidden">
@@ -121,12 +137,14 @@ const DatasetGallery = () => {
             onDataManagementClick={handleDataManagementClick}
             onModelZooClick={handleModelZooClick}
             onQuantificationsClick={handleQuantificationsClick}
-            onStartAnnotation={handleStartAnnotation}
+            onAnnotationClick={handleAnnotationClick}
             onLabelManagementClick={handleLabelManagementClick}
             onExportCocoClick={() => setShowCocoModal(true)}
             onModelTrainingClick={handleModelTrainingClick}
             onBrowseAnnotations={handleBrowseAnnotations}
             onManageAccessClick={handleManageAccessClick}
+            onReviewClick={handleReviewClick}
+            onCorrectClick={handleCorrectClick}
           />
         ) : currentView === "dataManagement" ? (
           <DataManagementView
@@ -150,6 +168,13 @@ const DatasetGallery = () => {
         isOpen={showCocoModal}
         onClose={() => setShowCocoModal(false)}
         dataset={dataset}
+      />
+
+      <AnnotationQueueModal
+        isOpen={showQueueModal}
+        onClose={() => setShowQueueModal(false)}
+        dataset={dataset}
+        onStart={handleQueueStart}
       />
     </DatasetManagementLayout>
   );

--- a/src/components/datasets/gallery/AnnotationQueueModal.jsx
+++ b/src/components/datasets/gallery/AnnotationQueueModal.jsx
@@ -1,0 +1,279 @@
+import React, { useEffect, useState } from "react";
+import {
+  ArrowDownUp,
+  Loader2,
+  Play,
+  RotateCcw,
+  Shuffle,
+  Sparkles,
+  SquarePen,
+  X,
+} from "lucide-react";
+import {
+  buildAnnotationQueue,
+  fetchAnnotationQueue,
+  fetchAnnotationQueueSummary,
+} from "../../../api";
+
+/** Icon per ordering strategy; falls back to the generic reorder icon. */
+const STRATEGY_ICONS = {
+  as_uploaded: ArrowDownUp,
+  random: Shuffle,
+  diversity: Sparkles,
+};
+
+/**
+ * The step between the Annotation card and the editor: choose the order images
+ * are annotated in (as uploaded, randomized, or a future active-learning
+ * ordering) and build the queue, or resume the one saved from last time.
+ *
+ * The built order is persisted per (dataset, user) on the backend; `onStart` is
+ * called with the ordered image ids so the caller can jump into the editor. The
+ * editor's loader re-reads the saved queue, so the order survives a refresh even
+ * though we hand it over here to avoid a reorder flash.
+ */
+const AnnotationQueueModal = ({ isOpen, onClose, dataset, onStart }) => {
+  const [summary, setSummary] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [strategy, setStrategy] = useState(null);
+  // Even when a queue is saved, let the user drop into the chooser to rebuild it.
+  const [recomputing, setRecomputing] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState(null);
+
+  // Load the workload + saved-queue state each time the modal opens.
+  useEffect(() => {
+    if (!isOpen || !dataset?.id) return undefined;
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    setRecomputing(false);
+    fetchAnnotationQueueSummary(dataset.id)
+      .then((response) => {
+        if (cancelled) return;
+        if (response?.success) {
+          setSummary(response.summary);
+          const available = (response.summary.strategies || []).filter((s) => s.available);
+          setStrategy(response.summary.saved_strategy || available[0]?.key || null);
+        } else {
+          setError("Could not load annotation options.");
+        }
+      })
+      .catch(() => !cancelled && setError("Could not load annotation options."))
+      .finally(() => !cancelled && setLoading(false));
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen, dataset?.id]);
+
+  if (!isOpen) return null;
+
+  const strategies = summary?.strategies || [];
+  const hasSavedQueue = summary?.has_saved_queue;
+  const noImages = summary != null && summary.total === 0;
+  // The chooser shows either when nothing is saved, or the user asked to rebuild.
+  const showChooser = !hasSavedQueue || recomputing;
+
+  const finish = (imageIds) => {
+    if (!imageIds || imageIds.length === 0) {
+      setError("This dataset has no images to annotate.");
+      return;
+    }
+    onStart(imageIds);
+  };
+
+  const handleResume = async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      const response = await fetchAnnotationQueue(dataset.id);
+      if (response?.success && response.queue) {
+        finish(response.queue.image_ids);
+      } else {
+        // The saved queue vanished (e.g. cleared elsewhere) — fall back to building.
+        setRecomputing(true);
+      }
+    } catch (err) {
+      setError(err.message || "Could not load the saved queue.");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleBuild = async () => {
+    if (!strategy) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const response = await buildAnnotationQueue(dataset.id, { strategy });
+      if (response?.success && response.queue) {
+        finish(response.queue.image_ids);
+      } else {
+        setError("Could not build the queue.");
+      }
+    } catch (err) {
+      setError(err.message || "Could not build the queue.");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const savedStrategyLabel =
+    strategies.find((s) => s.key === summary?.saved_strategy)?.label || summary?.saved_strategy;
+
+  return (
+    <div className="fixed inset-0 z-50 overflow-y-auto">
+      <div className="flex items-center justify-center min-h-screen px-4 py-6">
+        <div className="fixed inset-0 bg-gray-500/75 transition-opacity" onClick={onClose} />
+
+        <div className="relative inline-block w-full max-w-lg text-left align-middle bg-white rounded-2xl shadow-xl overflow-hidden">
+          {/* Header */}
+          <div className="relative bg-gradient-to-r from-teal-500 to-teal-600 px-6 py-5 text-white">
+            <button
+              onClick={onClose}
+              className="absolute top-4 right-4 p-1 rounded-lg text-white/80 hover:text-white hover:bg-white/20 transition-colors"
+              title="Close"
+            >
+              <X size={20} />
+            </button>
+            <div className="flex items-center gap-3 pr-8">
+              <div className="flex items-center justify-center w-11 h-11 rounded-xl bg-white/20 shrink-0">
+                <SquarePen className="w-6 h-6" />
+              </div>
+              <div>
+                <h3 className="text-xl font-bold">Annotate images</h3>
+                <p className="text-sm text-white/90 mt-0.5">
+                  Choose the order to work through{" "}
+                  {dataset?.name ? `“${dataset.name}”` : "this dataset"}.
+                </p>
+              </div>
+            </div>
+          </div>
+
+          {/* Body */}
+          <div className="px-6 py-5 space-y-4 min-h-[8rem]">
+            {loading ? (
+              <div className="flex items-center justify-center py-8 text-gray-500">
+                <Loader2 className="w-5 h-5 animate-spin mr-2" />
+                Loading…
+              </div>
+            ) : noImages ? (
+              <div className="p-4 bg-amber-50 border border-amber-200 rounded-lg text-sm text-amber-800">
+                This dataset has no images yet. Upload some from Data Management first.
+              </div>
+            ) : (
+              <>
+                {/* Resume state: offer to pick up the saved order, with a way to rebuild. */}
+                {hasSavedQueue && !recomputing && (
+                  <div className="rounded-xl border border-teal-200 bg-teal-50 p-4">
+                    <div className="text-sm font-semibold text-gray-800">
+                      Resume your saved queue
+                    </div>
+                    <div className="text-sm text-gray-600 mt-0.5">
+                      Ordered <span className="font-medium">{savedStrategyLabel}</span>. You’ll
+                      start at the first unfinished image.
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => setRecomputing(true)}
+                      className="mt-3 inline-flex items-center gap-1.5 text-sm font-medium text-teal-700 hover:text-teal-800"
+                    >
+                      <RotateCcw className="w-4 h-4" />
+                      Change or recompute order
+                    </button>
+                  </div>
+                )}
+
+                {/* Ordering chooser. */}
+                {showChooser && (
+                  <div className="space-y-2">
+                    {hasSavedQueue && (
+                      <div className="text-sm font-semibold text-gray-700">Pick a new order</div>
+                    )}
+                    {strategies.map((option) => {
+                      const Icon = STRATEGY_ICONS[option.key] || ArrowDownUp;
+                      const active = strategy === option.key;
+                      const disabled = !option.available;
+                      return (
+                        <button
+                          key={option.key}
+                          type="button"
+                          disabled={disabled}
+                          onClick={() => setStrategy(option.key)}
+                          className={`w-full text-left rounded-xl border-2 p-3 transition-all flex items-start gap-3 ${
+                            disabled
+                              ? "border-gray-200 bg-gray-50 cursor-not-allowed opacity-70"
+                              : active
+                                ? "border-teal-500 bg-teal-50 shadow-sm"
+                                : "border-gray-200 bg-white hover:border-teal-300"
+                          }`}
+                        >
+                          <Icon
+                            className={`w-5 h-5 mt-0.5 shrink-0 ${
+                              active && !disabled ? "text-teal-600" : "text-gray-400"
+                            }`}
+                          />
+                          <span className="flex-1">
+                            <span className="flex items-center gap-2">
+                              <span className="font-semibold text-gray-900">{option.label}</span>
+                              {disabled && (
+                                <span className="inline-block px-1.5 py-0.5 rounded bg-gray-200 text-gray-600 text-[11px] font-medium">
+                                  Coming soon
+                                </span>
+                              )}
+                            </span>
+                            <span className="block text-sm text-gray-600 leading-snug">
+                              {option.description}
+                            </span>
+                          </span>
+                        </button>
+                      );
+                    })}
+                  </div>
+                )}
+
+                {error && (
+                  <div className="p-3 bg-red-50 border border-red-200 rounded-lg text-sm text-red-700">
+                    {error}
+                  </div>
+                )}
+              </>
+            )}
+          </div>
+
+          {/* Footer */}
+          <div className="flex justify-end gap-3 px-6 py-4 bg-gray-50 border-t border-gray-200">
+            <button
+              onClick={onClose}
+              disabled={busy}
+              className="px-4 py-2 text-sm font-medium text-gray-600 bg-white border border-gray-300 rounded-lg hover:bg-gray-100 transition-colors disabled:opacity-50"
+            >
+              Cancel
+            </button>
+            {!loading && !noImages && hasSavedQueue && !recomputing ? (
+              <button
+                onClick={handleResume}
+                disabled={busy}
+                className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-white bg-teal-600 rounded-lg hover:bg-teal-700 transition-colors disabled:opacity-60"
+              >
+                {busy ? <Loader2 className="w-4 h-4 animate-spin" /> : <Play className="w-4 h-4" />}
+                Resume
+              </button>
+            ) : (
+              <button
+                onClick={handleBuild}
+                disabled={busy || loading || noImages || !strategy}
+                className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-white bg-teal-600 rounded-lg hover:bg-teal-700 transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
+              >
+                {busy ? <Loader2 className="w-4 h-4 animate-spin" /> : <Play className="w-4 h-4" />}
+                {busy ? "Building…" : "Build queue & start"}
+              </button>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default AnnotationQueueModal;

--- a/src/components/datasets/gallery/ManagementCard.jsx
+++ b/src/components/datasets/gallery/ManagementCard.jsx
@@ -1,52 +1,72 @@
 import React from 'react';
 
-const ManagementCard = ({ 
-  icon: Icon, 
-  title, 
-  description, 
-  onClick, 
-  iconBgColor = "bg-blue-100",
-  iconHoverBgColor = "group-hover:bg-blue-200",
-  iconColor = "text-blue-600",
-  isGradient = false,
-  gradientClasses = ""
+/**
+ * Per-colour class sets for a card. Every card is white; its identity comes from
+ * the icon colour, which the border, hover border, title-hover and stat all pick
+ * up so the tile reads as one hue without a heavy filled background.
+ *
+ * The class strings are spelled out in full (never built by interpolation) so
+ * Tailwind's scanner keeps them in the build.
+ */
+const PALETTE = {
+  blue:   { iconBg: 'bg-blue-100',   iconHover: 'group-hover:bg-blue-200',   icon: 'text-blue-600',   border: 'border-blue-200',   hoverBorder: 'hover:border-blue-400',   title: 'group-hover:text-blue-700',   stat: 'text-blue-700' },
+  purple: { iconBg: 'bg-purple-100', iconHover: 'group-hover:bg-purple-200', icon: 'text-purple-600', border: 'border-purple-200', hoverBorder: 'hover:border-purple-400', title: 'group-hover:text-purple-700', stat: 'text-purple-700' },
+  indigo: { iconBg: 'bg-indigo-100', iconHover: 'group-hover:bg-indigo-200', icon: 'text-indigo-600', border: 'border-indigo-200', hoverBorder: 'hover:border-indigo-400', title: 'group-hover:text-indigo-700', stat: 'text-indigo-700' },
+  green:  { iconBg: 'bg-green-100',  iconHover: 'group-hover:bg-green-200',  icon: 'text-green-600',  border: 'border-green-200',  hoverBorder: 'hover:border-green-400',  title: 'group-hover:text-green-700',  stat: 'text-green-700' },
+  teal:   { iconBg: 'bg-teal-100',   iconHover: 'group-hover:bg-teal-200',   icon: 'text-teal-600',   border: 'border-teal-200',   hoverBorder: 'hover:border-teal-400',   title: 'group-hover:text-teal-700',   stat: 'text-teal-700' },
+  orange: { iconBg: 'bg-orange-100', iconHover: 'group-hover:bg-orange-200', icon: 'text-orange-600', border: 'border-orange-200', hoverBorder: 'hover:border-orange-400', title: 'group-hover:text-orange-700', stat: 'text-orange-700' },
+  rose:   { iconBg: 'bg-rose-100',   iconHover: 'group-hover:bg-rose-200',   icon: 'text-rose-600',   border: 'border-rose-200',   hoverBorder: 'hover:border-rose-400',   title: 'group-hover:text-rose-700',   stat: 'text-rose-700' },
+  pink:   { iconBg: 'bg-pink-100',   iconHover: 'group-hover:bg-pink-200',   icon: 'text-pink-600',   border: 'border-pink-200',   hoverBorder: 'hover:border-pink-400',   title: 'group-hover:text-pink-700',   stat: 'text-pink-700' },
+  amber:  { iconBg: 'bg-amber-100',  iconHover: 'group-hover:bg-amber-200',  icon: 'text-amber-600',  border: 'border-amber-200',  hoverBorder: 'hover:border-amber-400',  title: 'group-hover:text-amber-700',  stat: 'text-amber-700' },
+  slate:  { iconBg: 'bg-slate-100',  iconHover: 'group-hover:bg-slate-200',  icon: 'text-slate-600',  border: 'border-slate-200',  hoverBorder: 'hover:border-slate-400',  title: 'group-hover:text-slate-700',  stat: 'text-slate-700' },
+};
+
+const ManagementCard = ({
+  icon: Icon,
+  title,
+  description,
+  stat = null,
+  onClick,
+  color = 'blue',
+  // A placeholder card: it renders but does nothing yet. It drops the hover lift
+  // and click affordance, dims itself, and shows a "Coming soon" tag so it reads
+  // as not-yet-available rather than broken.
+  disabled = false,
 }) => {
-  const baseClasses = isGradient
-    ? `group bg-gradient-to-br ${gradientClasses} rounded-xl shadow-sm hover:shadow-xl transition-all duration-300 p-6 sm:p-8 cursor-pointer border border-teal-400 transform hover:-translate-y-1 flex flex-col min-h-[200px] sm:min-h-[240px] lg:min-h-[280px]`
-    : `group bg-white rounded-xl shadow-sm hover:shadow-xl transition-all duration-300 p-6 sm:p-8 cursor-pointer border border-gray-200 hover:border-teal-300 transform hover:-translate-y-1 flex flex-col min-h-[200px] sm:min-h-[240px] lg:min-h-[280px]`;
+  const c = PALETTE[color] || PALETTE.blue;
 
-  const titleClasses = isGradient
-    ? "text-xl sm:text-2xl font-semibold text-white mb-3 sm:mb-4"
-    : "text-xl sm:text-2xl font-semibold text-gray-900 mb-3 sm:mb-4 group-hover:text-teal-600 transition-colors";
-
-  const descriptionClasses = isGradient
-    ? "text-teal-50 text-sm sm:text-base leading-relaxed flex-grow"
-    : "text-gray-600 text-sm sm:text-base leading-relaxed flex-grow";
-
-  const iconContainerClasses = isGradient
-    ? "w-14 h-14 sm:w-16 sm:h-16 bg-white/20 rounded-xl flex items-center justify-center group-hover:bg-white/30 transition-colors"
-    : `w-14 h-14 sm:w-16 sm:h-16 ${iconBgColor} rounded-xl flex items-center justify-center ${iconHoverBgColor} transition-colors`;
-
-  const iconClasses = isGradient
-    ? "w-7 h-7 sm:w-8 sm:h-8 text-white"
-    : `w-7 h-7 sm:w-8 sm:h-8 ${iconColor}`;
+  const containerClasses = disabled
+    ? `bg-white rounded-xl shadow-sm p-6 sm:p-8 cursor-not-allowed border ${c.border} opacity-70 flex flex-col min-h-[200px] sm:min-h-[240px] lg:min-h-[280px]`
+    : `group bg-white rounded-xl shadow-sm hover:shadow-xl transition-all duration-300 p-6 sm:p-8 cursor-pointer border ${c.border} ${c.hoverBorder} transform hover:-translate-y-1 flex flex-col min-h-[200px] sm:min-h-[240px] lg:min-h-[280px]`;
 
   return (
-    <div onClick={onClick} className={baseClasses}>
+    <div onClick={disabled ? undefined : onClick} className={containerClasses}>
       <div className="flex items-center justify-between mb-5 sm:mb-6">
-        <div className={iconContainerClasses}>
-          <Icon className={iconClasses} />
+        <div
+          className={`w-14 h-14 sm:w-16 sm:h-16 ${c.iconBg} rounded-xl flex items-center justify-center ${disabled ? '' : c.iconHover} transition-colors`}
+        >
+          <Icon className={`w-7 h-7 sm:w-8 sm:h-8 ${c.icon}`} />
         </div>
       </div>
-      <h3 className={titleClasses}>
+      <h3 className={`text-xl sm:text-2xl font-semibold text-gray-900 mb-3 sm:mb-4 transition-colors ${disabled ? '' : c.title}`}>
         {title}
       </h3>
-      <p className={descriptionClasses}>
+      <p className="text-gray-600 text-sm sm:text-base leading-relaxed flex-grow">
         {description}
       </p>
+      {disabled ? (
+        <span className="mt-3 inline-flex items-center w-fit text-xs font-medium text-gray-500 bg-gray-100 rounded-full px-2.5 py-0.5">
+          Coming soon
+        </span>
+      ) : (
+        stat && (
+          <p className={`mt-3 text-sm sm:text-base font-semibold ${c.stat}`}>
+            {stat}
+          </p>
+        )
+      )}
     </div>
   );
 };
 
 export default ManagementCard;
-

--- a/src/components/datasets/gallery/ManagementCardsView.jsx
+++ b/src/components/datasets/gallery/ManagementCardsView.jsx
@@ -1,9 +1,23 @@
-import React from 'react';
-import { Database, Brain, BarChart3, Tag, Play, Download, Eye, GraduationCap, Users2 } from 'lucide-react';
+import React, { useEffect, useState } from 'react';
+import { Database, Brain, BarChart3, Tag, SquarePen, Download, Eye, GraduationCap, Users2, ClipboardCheck, Wrench, Settings, HelpCircle } from 'lucide-react';
 import ManagementCard from './ManagementCard';
 import RoleBadge from '../RoleBadge';
 import { usePermissions } from '../../../hooks/usePermissions';
 import { Permission } from '../../../utils/permissions';
+import { fetchReviewSummary, fetchCorrectionSummary } from '../../../api/reviews';
+import { fetchAnnotationQueueSummary } from '../../../api/annotation_queue';
+
+/**
+ * The sections the cards are grouped under, in display order. Each card names its
+ * `group` by id; a group with no permitted cards for the current role is not
+ * rendered at all (see `groupsInOrder` below).
+ */
+const GROUPS = [
+  { id: 'annotation', title: 'Annotation workflow' },
+  { id: 'data', title: 'Data & Analysis' },
+  { id: 'models', title: 'Artificial Intelligence' },
+  { id: 'configurations', title: 'Configurations' },
+];
 
 /**
  * The dataset's action grid.
@@ -17,19 +31,154 @@ const ManagementCardsView = ({
   onDataManagementClick,
   onModelZooClick,
   onQuantificationsClick,
-  onStartAnnotation,
+  onAnnotationClick,
   onLabelManagementClick,
   onExportCocoClick,
   onModelTrainingClick,
   onBrowseAnnotations,
   onManageAccessClick,
+  onReviewClick,
+  onCorrectClick,
   dataset,
 }) => {
   const { can, canAny, role } = usePermissions(dataset);
+  const canReview = can(Permission.REVIEW_APPROVE);
+  const canCorrect = can(Permission.ANNOTATION_EDIT_OWN);
+
+  // The pending-instance count on the Review card. Loaded here rather than in
+  // the card so a failed fetch degrades to a card without a number, not an
+  // empty tile.
+  const [reviewSummary, setReviewSummary] = useState(null);
+  useEffect(() => {
+    if (!dataset?.id || !canReview) return undefined;
+    let cancelled = false;
+    fetchReviewSummary(dataset.id)
+      .then((response) => {
+        if (!cancelled && response?.success) setReviewSummary(response.summary);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [dataset?.id, canReview]);
+
+  // The sent-back count on the Correct card. Loaded alongside the review summary,
+  // and for the same reason kept here so a failed fetch degrades to a numberless
+  // card rather than an empty tile.
+  const [correctionSummary, setCorrectionSummary] = useState(null);
+  useEffect(() => {
+    if (!dataset?.id || !canCorrect) return undefined;
+    let cancelled = false;
+    fetchCorrectionSummary(dataset.id)
+      .then((response) => {
+        if (!cancelled && response?.success) setCorrectionSummary(response.summary);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [dataset?.id, canCorrect]);
+
+  // Progress counts for the Annotation card's subcaption. Loaded here for the same
+  // reason as the review/correction summaries: a failed fetch degrades to a card
+  // without a subcaption rather than an empty tile.
+  const canAnnotate = can(Permission.ANNOTATION_CREATE);
+  const [annotationSummary, setAnnotationSummary] = useState(null);
+  useEffect(() => {
+    if (!dataset?.id || !canAnnotate) return undefined;
+    let cancelled = false;
+    fetchAnnotationQueueSummary(dataset.id)
+      .then((response) => {
+        if (!cancelled && response?.success) setAnnotationSummary(response.summary);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [dataset?.id, canAnnotate]);
+
+  const annotationStat =
+    annotationSummary == null
+      ? null
+      : `${annotationSummary.in_progress} image${
+          annotationSummary.in_progress === 1 ? '' : 's'
+        } in progress, ${annotationSummary.not_started} not started`;
+
+  const openRejections = correctionSummary?.open_rejections;
+  const correctStat =
+    openRejections == null
+      ? null
+      : openRejections === 1
+      ? '1 instance sent back for correction'
+      : openRejections > 1
+      ? `${openRejections} instances sent back for correction`
+      : 'Nothing sent back for correction';
+
+  const pendingInstances = reviewSummary?.pending_instances;
+  const reviewedInstances = reviewSummary?.reviewed_instances ?? 0;
+  const reviewStat =
+    pendingInstances == null
+      ? null
+      : pendingInstances === 1
+      ? 'There is 1 instance to review'
+      : pendingInstances > 1
+      ? `There are ${pendingInstances} instances to review`
+      : reviewedInstances > 0
+      ? `${reviewedInstances} reviewed instance${
+          reviewedInstances === 1 ? '' : 's'
+        } available for re-review`
+      : 'Nothing waiting for review right now';
 
   const cards = [
     {
+      id: 'annotation',
+      group: 'annotation',
+      icon: SquarePen,
+      title: 'Annotation',
+      description: 'Annotate instances on images from this dataset',
+      stat: annotationStat,
+      onClick: onAnnotationClick,
+      permitted: canAnnotate,
+      color: 'teal',
+    },
+    {
+      id: 'review',
+      group: 'annotation',
+      icon: ClipboardCheck,
+      title: 'Review',
+      description: 'Go through annotated instances and approve them or send them back',
+      stat: reviewStat,
+      onClick: onReviewClick,
+      permitted: canReview,
+      color: 'orange',
+    },
+    {
+      id: 'correct',
+      group: 'annotation',
+      icon: Wrench,
+      title: 'Correct',
+      description: 'Correct sent back instances',
+      stat: correctStat,
+      onClick: onCorrectClick,
+      permitted: canCorrect,
+      color: 'rose',
+    },
+    {
+      // The read-only counterpart for anyone who can see annotations but not make
+      // them. Annotators and above reach the same view from inside the editor, so
+      // this card only earns its space when the editor is unavailable.
+      id: 'browse-annotations',
+      group: 'annotation',
+      icon: Eye,
+      title: 'Browse Annotations',
+      description: 'Look through the images and their annotations without editing anything',
+      onClick: onBrowseAnnotations,
+      permitted: can(Permission.ANNOTATION_READ) && !can(Permission.ANNOTATION_CREATE),
+      color: 'teal',
+    },
+    {
       id: 'data-management',
+      group: 'data',
       icon: Database,
       title: 'Data Management',
       description: 'Upload, organize, and manage your dataset images and files',
@@ -37,79 +186,61 @@ const ManagementCardsView = ({
       // Viewing the gallery only needs read; the upload/delete controls inside it
       // are gated separately.
       permitted: can(Permission.IMAGE_READ),
-      iconBgColor: 'bg-blue-100',
-      iconHoverBgColor: 'group-hover:bg-blue-200',
-      iconColor: 'text-blue-600',
-    },
-    {
-      id: 'model-zoo',
-      icon: Brain,
-      title: 'Model Zoo',
-      description: 'Browse, select, and manage AI models for training and inference',
-      onClick: onModelZooClick,
-      permitted: canAny([Permission.AI_INTERACTIVE, Permission.AI_BATCH_INFER]),
-      iconBgColor: 'bg-purple-100',
-      iconHoverBgColor: 'group-hover:bg-purple-200',
-      iconColor: 'text-purple-600',
-    },
-    {
-      id: 'model-training',
-      icon: GraduationCap,
-      title: 'Model Training',
-      description: 'Train an instance segmentation model on this dataset and watch progress live',
-      onClick: onModelTrainingClick,
-      permitted: can(Permission.AI_TRAIN),
-      iconBgColor: 'bg-indigo-100',
-      iconHoverBgColor: 'group-hover:bg-indigo-200',
-      iconColor: 'text-indigo-600',
-    },
-    {
-      id: 'quantifications',
-      icon: BarChart3,
-      title: 'Quantifications',
-      description: 'Analyze and quantify your annotated data with statistical insights',
-      onClick: onQuantificationsClick,
-      permitted: can(Permission.EXPORT_QUANTIFICATION),
-      iconBgColor: 'bg-green-100',
-      iconHoverBgColor: 'group-hover:bg-green-200',
-      iconColor: 'text-green-600',
-    },
-    {
-      id: 'start-annotation',
-      icon: Play,
-      title: 'Start Annotation',
-      description: 'Begin annotating your images with labels and segmentation masks',
-      onClick: onStartAnnotation,
-      permitted: can(Permission.ANNOTATION_CREATE),
-      isGradient: true,
-      gradientClasses: 'from-teal-500 to-teal-600',
-    },
-    {
-      // The read-only counterpart for anyone who can see annotations but not make
-      // them. Annotators and above reach the same view from inside the editor, so
-      // this card only earns its space when the editor is unavailable.
-      id: 'browse-annotations',
-      icon: Eye,
-      title: 'Browse Annotations',
-      description: 'Look through the images and their annotations without editing anything',
-      onClick: onBrowseAnnotations,
-      permitted: can(Permission.ANNOTATION_READ) && !can(Permission.ANNOTATION_CREATE),
-      isGradient: true,
-      gradientClasses: 'from-teal-500 to-teal-600',
+      color: 'blue',
     },
     {
       id: 'label-management',
+      group: 'data',
       icon: Tag,
       title: 'Label Management',
       description: 'Create, edit, and organize labels and their hierarchical structure',
       onClick: onLabelManagementClick,
       permitted: can(Permission.LABEL_MANAGE),
-      iconBgColor: 'bg-pink-100',
-      iconHoverBgColor: 'group-hover:bg-pink-200',
-      iconColor: 'text-pink-600',
+      color: 'pink',
+    },
+    {
+      id: 'export-coco',
+      group: 'models',
+      icon: Download,
+      title: 'Export to COCO',
+      description: 'Download the dataset in COCO format (with images or annotations only) for ML tasks',
+      onClick: onExportCocoClick,
+      permitted: can(Permission.EXPORT_ANNOTATIONS),
+      color: 'amber',
+    },
+    {
+      id: 'model-zoo',
+      group: 'models',
+      icon: Brain,
+      title: 'Model Zoo',
+      description: 'Browse, select, and manage AI models for training and inference',
+      onClick: onModelZooClick,
+      permitted: canAny([Permission.AI_INTERACTIVE, Permission.AI_BATCH_INFER]),
+      color: 'purple',
+    },
+    {
+      id: 'model-training',
+      group: 'models',
+      icon: GraduationCap,
+      title: 'Model Training',
+      description: 'Train an instance segmentation model on this dataset and watch progress live',
+      onClick: onModelTrainingClick,
+      permitted: can(Permission.AI_TRAIN),
+      color: 'indigo',
+    },
+    {
+      id: 'quantifications',
+      group: 'data',
+      icon: BarChart3,
+      title: 'Quantifications',
+      description: 'Analyze and quantify your annotated data with statistical insights',
+      onClick: onQuantificationsClick,
+      permitted: can(Permission.EXPORT_QUANTIFICATION),
+      color: 'green',
     },
     {
       id: 'manage-access',
+      group: 'configurations',
       icon: Users2,
       title: 'Manage Access',
       description: 'Control who can see, annotate and review this dataset, and how work is reviewed',
@@ -117,27 +248,44 @@ const ManagementCardsView = ({
       // Curators can see and invite; only owners can change roles. Either is
       // enough to make the page worth opening.
       permitted: canAny([Permission.MEMBER_LIST, Permission.MEMBER_GRANT, Permission.INVITE_CREATE]),
-      iconBgColor: 'bg-teal-100',
-      iconHoverBgColor: 'group-hover:bg-teal-200',
-      iconColor: 'text-teal-600',
+      color: 'teal',
     },
     {
-      id: 'export-coco',
-      icon: Download,
-      title: 'Export to COCO',
-      description: 'Download the dataset in COCO format (with images or annotations only) for ML tasks',
-      onClick: onExportCocoClick,
-      permitted: can(Permission.EXPORT_ANNOTATIONS),
-      iconBgColor: 'bg-amber-100',
-      iconHoverBgColor: 'group-hover:bg-amber-200',
-      iconColor: 'text-amber-600',
+      // Placeholder: will open a settings page. Dysfunctional for now.
+      id: 'settings',
+      group: 'configurations',
+      icon: Settings,
+      title: 'Settings',
+      description: 'View and change all settings for this dataset',
+      permitted: true,
+      color: 'slate',
+      disabled: true,
+    },
+    {
+      // Placeholder: will open the documentation. Dysfunctional for now.
+      id: 'help',
+      group: 'configurations',
+      icon: HelpCircle,
+      title: 'Help',
+      description: 'Read the documentation and learn how everything works',
+      permitted: true,
+      color: 'blue',
+      disabled: true,
     },
   ].filter((card) => card.permitted);
+
+  // Cards are grouped into labelled sections so the grid reads as a few small
+  // workflows instead of one long wall of tiles. A section with no permitted
+  // cards for the current role is dropped entirely (header and divider included).
+  const groupsInOrder = GROUPS.map((group) => ({
+    ...group,
+    cards: cards.filter((card) => card.group === group.id),
+  })).filter((group) => group.cards.length > 0);
 
   return (
     <div className="overflow-y-auto bg-gradient-to-br from-gray-50 to-gray-100 p-4 sm:p-5 lg:p-6 h-full">
       <div className="w-full mx-auto">
-        <div className="mb-4 sm:mb-5">
+        <div className="mb-6 sm:mb-8">
           <div className="flex items-center gap-3 mb-1 sm:mb-2">
             <h2 className="text-2xl sm:text-3xl font-bold text-gray-900">Dataset Management</h2>
             {role && <RoleBadge role={role} showDescription />}
@@ -145,20 +293,30 @@ const ManagementCardsView = ({
           <p className="text-sm sm:text-base text-gray-600">Manage your dataset, models, and annotations</p>
         </div>
 
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 sm:gap-5 lg:gap-6">
-          {cards.map((card) => (
-            <ManagementCard
-              key={card.id}
-              icon={card.icon}
-              title={card.title}
-              description={card.description}
-              onClick={card.onClick}
-              iconBgColor={card.iconBgColor}
-              iconHoverBgColor={card.iconHoverBgColor}
-              iconColor={card.iconColor}
-              isGradient={card.isGradient}
-              gradientClasses={card.gradientClasses}
-            />
+        <div className="space-y-8 sm:space-y-10">
+          {groupsInOrder.map((group) => (
+            <section key={group.id}>
+              <div className="flex items-center gap-4 mb-4 sm:mb-5">
+                <h3 className="text-base sm:text-lg font-semibold text-gray-700 whitespace-nowrap">
+                  {group.title}
+                </h3>
+                <div className="flex-1 h-px bg-gray-200" />
+              </div>
+              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 sm:gap-5 lg:gap-6">
+                {group.cards.map((card) => (
+                  <ManagementCard
+                    key={card.id}
+                    icon={card.icon}
+                    title={card.title}
+                    description={card.description}
+                    stat={card.stat}
+                    onClick={card.onClick}
+                    color={card.color}
+                    disabled={card.disabled}
+                  />
+                ))}
+              </div>
+            </section>
           ))}
         </div>
       </div>

--- a/src/components/review/ReviewSession.jsx
+++ b/src/components/review/ReviewSession.jsx
@@ -1,0 +1,428 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  Check,
+  CheckCircle2,
+  Loader2,
+  MessageSquarePlus,
+  ScanEye,
+  SkipForward,
+  Undo2,
+} from 'lucide-react';
+import * as api from '../../api';
+import { getContoursOfMask } from '../../api/masks';
+import { markContourAsReviewed } from '../../api/contours';
+import { approveMask, rejectMask } from '../../api/reviews';
+import { useToast } from '../../contexts/ToastContext';
+import { getLabelColor } from '../../utils/labelColors';
+import AnnotationViewerCanvas from '../viewer/AnnotationViewerCanvas';
+
+const readableError = (err, fallback) =>
+  (err?.message || '').replace(/^API Error:\s*/i, '') || fallback;
+
+/**
+ * The reject buttons of the queue. The wording is the reviewer's, the values are
+ * the backend's `RejectionReason` vocabulary — kept as a fixed map here (rather
+ * than the `/reviews/reasons` catalog) because the queue offers a deliberate
+ * subset with queue-specific phrasing.
+ */
+const REJECT_ACTIONS = [
+  { reason: 'bad_outline', label: 'Bad outlines', instanceLabel: 'Bad outline' },
+  { reason: 'missing_objects', label: 'Missed instances', instanceLabel: 'Missed instances' },
+  { reason: 'wrong_label', label: 'Wrong labels', instanceLabel: 'Wrong label' },
+  { reason: 'wrong_hierarchy', label: 'Hierarchy wrong', instanceLabel: 'Hierarchy wrong' },
+];
+
+/**
+ * Plays a review queue one item at a time.
+ *
+ * Image items show the whole mask; instance items show one contour plus its
+ * immediate children, framed. Accepting approves (the mask's pending contours,
+ * or the one instance); rejecting records a rejection with the chosen reason and
+ * sends the mask back to its annotator — which also invalidates every other
+ * queued item on that mask, so those are dropped from the queue on the spot.
+ */
+const ReviewSession = ({ queue, labelsById, onExit }) => {
+  const { addToast } = useToast();
+  const isImageMode = queue.granularity === 'images';
+
+  // The queue is state, not a constant: a rejection removes the sibling items of
+  // the same mask (they went back to the annotator along with it).
+  const [items, setItems] = useState(() =>
+    isImageMode ? queue.images : queue.instances
+  );
+  const [index, setIndex] = useState(0);
+  const [tally, setTally] = useState({ accepted: 0, rejected: 0, skipped: 0 });
+
+  const [imageSrc, setImageSrc] = useState(null);
+  const [contours, setContours] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState(null);
+  const [note, setNote] = useState('');
+  const [showNote, setShowNote] = useState(false);
+  const [zoomTarget, setZoomTarget] = useState(null);
+  const [selectedContourId, setSelectedContourId] = useState(null);
+
+  // Consecutive queue items often share an image/mask (hierarchy order groups
+  // them); the caches make advancing through those instant.
+  const imageCache = useRef(new Map());
+  const contourCache = useRef(new Map());
+
+  const current = items[index] || null;
+  const done = index >= items.length;
+
+  // -- Data loading ---------------------------------------------------------
+
+  useEffect(() => {
+    if (!current) return undefined;
+    let cancelled = false;
+
+    const load = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        let src = imageCache.current.get(current.image_id);
+        if (!src) {
+          const imageData = await api.getImageById(current.image_id, false);
+          const base64 =
+            imageData[current.image_id] ??
+            imageData[String(current.image_id)] ??
+            Object.entries(imageData).find(
+              ([key]) => key !== 'success' && key !== 'message'
+            )?.[1];
+          src = base64 ? `data:image/png;base64,${base64}` : null;
+          imageCache.current.set(current.image_id, src);
+        }
+
+        let maskContours = contourCache.current.get(current.mask_id);
+        if (!maskContours) {
+          const contourResponse = await getContoursOfMask(current.mask_id, true);
+          maskContours = contourResponse.contours || [];
+          contourCache.current.set(current.mask_id, maskContours);
+        }
+
+        if (cancelled) return;
+        setImageSrc(src);
+        setContours(maskContours);
+        if (!isImageMode) {
+          const instance = maskContours.find((c) => c.id === current.contour_id);
+          setSelectedContourId(current.contour_id);
+          // New object identity so revisiting the same instance re-frames it.
+          setZoomTarget(instance ? { ...instance } : null);
+        } else {
+          setSelectedContourId(null);
+          setZoomTarget(null);
+        }
+      } catch (err) {
+        if (!cancelled) setError(readableError(err, 'Could not load this item.'));
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [current, isImageMode]);
+
+  // -- Derived display state --------------------------------------------------
+
+  /** Image mode shows everything; instance mode the instance and its children. */
+  const visibleContours = useMemo(() => {
+    if (isImageMode || !current) return contours;
+    return contours.filter(
+      (contour) =>
+        contour.id === current.contour_id || contour.parent_id === current.contour_id
+    );
+  }, [contours, current, isImageMode]);
+
+  const instanceContour = useMemo(
+    () =>
+      !isImageMode && current
+        ? contours.find((contour) => contour.id === current.contour_id) || null
+        : null,
+    [contours, current, isImageMode]
+  );
+
+  const childCount = useMemo(
+    () =>
+      !isImageMode && current
+        ? contours.filter((contour) => contour.parent_id === current.contour_id).length
+        : 0,
+    [contours, current, isImageMode]
+  );
+
+  const labelNameFor = useCallback(
+    (labelId) => labelsById[labelId]?.name || 'Unlabelled',
+    [labelsById]
+  );
+
+  const colorFor = useCallback(
+    (contour) => (contour.label_id ? getLabelColor(contour.label_id) : '#94a3b8'),
+    []
+  );
+
+  // -- Advancing ---------------------------------------------------------------
+
+  const advance = useCallback(
+    (outcome, { dropMaskId = null } = {}) => {
+      setTally((current_) => ({ ...current_, [outcome]: current_[outcome] + 1 }));
+      setNote('');
+      setShowNote(false);
+      setItems((currentItems) => {
+        if (dropMaskId == null) return currentItems;
+        // A rejected mask went back to the annotator: its other queued items are
+        // stale now, so drop everything after the current position that points
+        // at it. The contour cache entry is stale too.
+        contourCache.current.delete(dropMaskId);
+        return currentItems.filter(
+          (item, itemIndex) => itemIndex <= index || item.mask_id !== dropMaskId
+        );
+      });
+      setIndex((currentIndex) => currentIndex + 1);
+    },
+    [index]
+  );
+
+  const handleAccept = async () => {
+    if (!current || busy) return;
+    setBusy(true);
+    try {
+      if (isImageMode) {
+        // The Accept must cover exactly what this queue considers open, so the
+        // second-opinion flag travels with the queue it was built for.
+        const response = await approveMask(current.mask_id, {
+          includeReviewed: Boolean(queue.include_reviewed),
+        });
+        contourCache.current.delete(current.mask_id);
+        if (response?.skipped?.length) {
+          addToast({
+            type: 'error',
+            message: `${response.skipped.length} of your own annotations were not self-approved; another reviewer has to look at those.`,
+          });
+        }
+      } else {
+        await markContourAsReviewed(current.contour_id);
+        contourCache.current.delete(current.mask_id);
+      }
+      advance('accepted');
+    } catch (err) {
+      setError(readableError(err, 'Could not approve this item.'));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleReject = async (reason) => {
+    if (!current || busy) return;
+    setBusy(true);
+    try {
+      await rejectMask(current.mask_id, {
+        reason,
+        note: note.trim() || null,
+        contourId: isImageMode ? null : current.contour_id,
+      });
+      advance('rejected', { dropMaskId: current.mask_id });
+    } catch (err) {
+      setError(readableError(err, 'Could not send this item back.'));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleSkip = () => {
+    if (!current || busy) return;
+    advance('skipped');
+  };
+
+  // Keyboard: A accepts, S skips — but never while typing the note.
+  useEffect(() => {
+    const onKey = (event) => {
+      if (done || busy) return;
+      const tag = event.target?.tagName?.toLowerCase();
+      if (tag === 'input' || tag === 'textarea' || tag === 'select') return;
+      if (event.key === 'a' || event.key === 'A') handleAccept();
+      if (event.key === 's' || event.key === 'S') handleSkip();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  });
+
+  // -- Rendering -----------------------------------------------------------------
+
+  if (done) {
+    return (
+      <div className="h-full flex flex-col items-center justify-center text-center px-4">
+        <CheckCircle2 className="w-12 h-12 text-teal-500 mb-4" />
+        <h2 className="text-2xl font-bold text-gray-900 mb-2">Session finished</h2>
+        <p className="text-gray-600 mb-6">
+          {tally.accepted} accepted · {tally.rejected} sent back · {tally.skipped} skipped
+        </p>
+        <button
+          onClick={onExit}
+          className="flex items-center gap-2 px-5 py-2.5 rounded-lg font-semibold bg-teal-600 text-white hover:bg-teal-700 transition-colors"
+        >
+          <Undo2 className="w-4 h-4" />
+          Back to review setup
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-full flex min-h-0">
+      {/* Canvas */}
+      <main className="flex-1 relative min-w-0">
+        {loading && (
+          <div className="absolute inset-0 z-10 flex items-center justify-center bg-gray-900/60 text-white">
+            <Loader2 className="w-6 h-6 animate-spin mr-2" />
+            Loading…
+          </div>
+        )}
+        {imageSrc && (
+          <AnnotationViewerCanvas
+            imageSrc={imageSrc}
+            contours={visibleContours}
+            selectedId={selectedContourId}
+            onSelect={setSelectedContourId}
+            zoomTarget={zoomTarget}
+            colorFor={colorFor}
+          />
+        )}
+      </main>
+
+      {/* Action panel */}
+      <aside className="w-80 border-l border-gray-200 bg-white flex flex-col flex-shrink-0">
+        <div className="px-4 py-3 border-b border-gray-200">
+          <div className="flex items-center justify-between mb-1">
+            <span className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+              {isImageMode ? 'Image review' : 'Instance review'}
+            </span>
+            <span className="text-sm font-medium text-gray-700">
+              {index + 1} / {items.length}
+            </span>
+          </div>
+          <div className="w-full bg-gray-100 rounded-full h-1.5">
+            <div
+              className="bg-teal-500 h-1.5 rounded-full transition-all"
+              style={{ width: `${(index / Math.max(items.length, 1)) * 100}%` }}
+            />
+          </div>
+        </div>
+
+        {/* What is on the table */}
+        <div className="px-4 py-3 border-b border-gray-200 text-sm text-gray-700 space-y-1">
+          {isImageMode ? (
+            <>
+              <div>
+                Image <span className="font-medium">#{current.image_id}</span>
+              </div>
+              <div className="text-gray-500">
+                {current.pending_instances} of {current.total_instances} instances awaiting{' '}
+                {queue.include_reviewed ? 'your review' : 'review'}
+              </div>
+            </>
+          ) : (
+            <>
+              <div className="flex items-center gap-2">
+                <span
+                  className="w-3 h-3 rounded-full border border-black/10 flex-shrink-0"
+                  style={{
+                    backgroundColor: current.label_id
+                      ? getLabelColor(current.label_id)
+                      : '#94a3b8',
+                  }}
+                />
+                <span className="font-medium">{labelNameFor(current.label_id)}</span>
+                <span className="text-gray-400">#{current.contour_id}</span>
+              </div>
+              <div className="text-gray-500">
+                Depth {current.depth}
+                {childCount > 0 &&
+                  ` · ${childCount} direct child${childCount === 1 ? '' : 'ren'} shown`}
+                {instanceContour?.added_by && ` · by ${instanceContour.added_by}`}
+              </div>
+              {(instanceContour?.reviewed_by?.length ?? 0) > 0 && (
+                <div className="text-emerald-600">
+                  Already approved by {instanceContour.reviewed_by.join(', ')} — accept to
+                  confirm, send back to overrule (withdraws your own approval).
+                </div>
+              )}
+              <button
+                onClick={() => instanceContour && setZoomTarget({ ...instanceContour })}
+                className="flex items-center gap-1.5 text-teal-600 hover:text-teal-700 text-xs font-medium"
+              >
+                <ScanEye className="w-3.5 h-3.5" />
+                Re-frame instance
+              </button>
+            </>
+          )}
+        </div>
+
+        {error && (
+          <div className="px-4 py-2 bg-red-50 border-b border-red-200">
+            <p className="text-sm text-red-700">{error}</p>
+          </div>
+        )}
+
+        {/* Actions */}
+        <div className="flex-1 overflow-y-auto px-4 py-4 space-y-2">
+          <button
+            onClick={handleAccept}
+            disabled={busy || loading}
+            className="w-full flex items-center justify-center gap-2 px-4 py-3 rounded-lg font-semibold bg-teal-600 text-white hover:bg-teal-700 disabled:bg-gray-200 disabled:text-gray-400 transition-colors"
+          >
+            {busy ? <Loader2 className="w-5 h-5 animate-spin" /> : <Check className="w-5 h-5" />}
+            Accept
+          </button>
+
+          <div className="pt-2 text-xs font-semibold uppercase tracking-wide text-gray-500">
+            Send back
+          </div>
+          {REJECT_ACTIONS.map(({ reason, label, instanceLabel }) => (
+            <button
+              key={reason}
+              onClick={() => handleReject(reason)}
+              disabled={busy || loading}
+              className="w-full text-left px-4 py-2.5 rounded-lg border border-red-200 text-red-700 hover:bg-red-50 disabled:border-gray-200 disabled:text-gray-400 transition-colors text-sm font-medium"
+            >
+              {isImageMode ? label : instanceLabel}
+            </button>
+          ))}
+
+          {showNote ? (
+            <textarea
+              value={note}
+              onChange={(e) => setNote(e.target.value)}
+              placeholder="Optional note for the annotator…"
+              rows={3}
+              className="w-full mt-2 border border-gray-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-teal-500 focus:border-teal-500"
+            />
+          ) : (
+            <button
+              onClick={() => setShowNote(true)}
+              className="flex items-center gap-1.5 text-gray-500 hover:text-gray-700 text-xs font-medium mt-2"
+            >
+              <MessageSquarePlus className="w-3.5 h-3.5" />
+              Add a note to the next send-back
+            </button>
+          )}
+        </div>
+
+        <div className="px-4 py-3 border-t border-gray-200">
+          <button
+            onClick={handleSkip}
+            disabled={busy}
+            className="w-full flex items-center justify-center gap-2 px-4 py-2 rounded-lg border border-gray-300 text-gray-700 hover:bg-gray-50 disabled:text-gray-400 transition-colors text-sm font-medium"
+          >
+            <SkipForward className="w-4 h-4" />
+            Skip (S) — Accept with (A)
+          </button>
+        </div>
+      </aside>
+    </div>
+  );
+};
+
+export default ReviewSession;

--- a/src/components/review/ReviewSetup.jsx
+++ b/src/components/review/ReviewSetup.jsx
@@ -1,0 +1,269 @@
+import React, { useMemo, useState } from 'react';
+import {
+  ArrowDownWideNarrow,
+  ArrowUpNarrowWide,
+  Images,
+  ListTree,
+  Loader2,
+  Play,
+  SlidersHorizontal,
+} from 'lucide-react';
+import { buildLabelHierarchy } from '../../utils/labelHierarchy';
+import { getLabelColor } from '../../utils/labelColors';
+
+/** The three ways to slice the review work. */
+const MODES = [
+  {
+    key: 'images',
+    icon: Images,
+    title: 'Entire images',
+    description:
+      'One image at a time, with every annotation on it. Accept the whole image or send it back with a reason.',
+  },
+  {
+    key: 'hierarchy',
+    icon: ListTree,
+    title: 'Instances by hierarchy',
+    description:
+      'One instance at a time with its immediate children. Root instances are verified first, then their children.',
+  },
+  {
+    key: 'custom',
+    icon: SlidersHorizontal,
+    title: 'Custom selection',
+    description:
+      'Only instances carrying the labels you pick, one at a time. Useful for sweeping a single class.',
+  },
+];
+
+/** Depth-first flattening of the label tree, so the checklist can indent. */
+const flattenWithDepth = (labels) => {
+  const result = [];
+  const walk = (nodes, depth) => {
+    nodes.forEach((node) => {
+      result.push({ ...node, depth });
+      if (node.children?.length) walk(node.children, depth + 1);
+    });
+  };
+  walk(buildLabelHierarchy(labels), 0);
+  return result;
+};
+
+/**
+ * The review session's launch pad: granularity, ordering, and (for the custom
+ * mode) which labels to sweep. Calls `onStart` with the options the API expects.
+ */
+const ReviewSetup = ({ summary, labels, building, onStart }) => {
+  const [mode, setMode] = useState('hierarchy');
+  const [direction, setDirection] = useState('asc');
+  const [strategy, setStrategy] = useState('hierarchy');
+  const [selectedLabelIds, setSelectedLabelIds] = useState([]);
+  const [includeReviewed, setIncludeReviewed] = useState(false);
+
+  const strategies = summary?.strategies || [];
+  const indentedLabels = useMemo(() => flattenWithDepth(labels), [labels]);
+  const isInstanceMode = mode === 'hierarchy' || mode === 'custom';
+  const pending = summary?.pending_instances ?? null;
+  const reviewedCount = summary?.reviewed_instances ?? 0;
+  // What the queue will actually contain under the current toggle state.
+  const available = pending == null ? null : includeReviewed ? pending + reviewedCount : pending;
+
+  const toggleLabel = (labelId) => {
+    setSelectedLabelIds((current) =>
+      current.includes(labelId)
+        ? current.filter((id) => id !== labelId)
+        : [...current, labelId]
+    );
+  };
+
+  const canStart =
+    !building &&
+    (mode !== 'custom' || selectedLabelIds.length > 0) &&
+    (available == null || available > 0);
+
+  const handleStart = () => {
+    onStart({
+      granularity: mode,
+      sortStrategy: strategy,
+      direction,
+      labelIds: mode === 'custom' ? selectedLabelIds : null,
+      includeReviewed,
+    });
+  };
+
+  return (
+    <div className="h-full overflow-y-auto">
+      <div className="max-w-4xl mx-auto p-6 sm:p-8">
+        <h2 className="text-2xl font-bold text-gray-900 mb-1">Start a review session</h2>
+        <p className="text-gray-600 mb-2">
+          Choose how to work through the annotations awaiting review.
+        </p>
+        {pending != null && (
+          <p className="text-sm font-medium text-teal-700 mb-6">
+            {pending === 0
+              ? reviewedCount > 0
+                ? `No unreviewed instances — but ${reviewedCount} already-reviewed instance${
+                    reviewedCount === 1 ? '' : 's'
+                  } can be re-reviewed.`
+                : 'Nothing is waiting for review right now.'
+              : `${pending} instance${pending === 1 ? '' : 's'} across ${
+                  summary.pending_images
+                } image${summary.pending_images === 1 ? '' : 's'} waiting for review.`}
+            {summary?.open_rejections > 0 &&
+              ` ${summary.open_rejections} sent-back item${
+                summary.open_rejections === 1 ? ' is' : 's are'
+              } still with the annotators.`}
+          </p>
+        )}
+
+        {/* Granularity */}
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-6">
+          {MODES.map(({ key, icon: Icon, title, description }) => {
+            const active = mode === key;
+            return (
+              <button
+                key={key}
+                onClick={() => setMode(key)}
+                className={`text-left rounded-xl border-2 p-4 transition-all ${
+                  active
+                    ? 'border-teal-500 bg-teal-50 shadow-sm'
+                    : 'border-gray-200 bg-white hover:border-teal-300'
+                }`}
+              >
+                <Icon className={`w-6 h-6 mb-2 ${active ? 'text-teal-600' : 'text-gray-400'}`} />
+                <div className="font-semibold text-gray-900 mb-1">{title}</div>
+                <div className="text-sm text-gray-600 leading-snug">{description}</div>
+              </button>
+            );
+          })}
+        </div>
+
+        {/* Second opinions: re-open work that other reviewers already approved. */}
+        <div className="bg-white rounded-xl border border-gray-200 p-4 mb-6">
+          <label className="flex items-start gap-3 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={includeReviewed}
+              onChange={(e) => setIncludeReviewed(e.target.checked)}
+              className="mt-0.5 rounded border-gray-300 text-teal-600 focus:ring-teal-500"
+            />
+            <span>
+              <span className="block text-sm font-semibold text-gray-700">
+                Include already-reviewed instances
+                {reviewedCount > 0 && (
+                  <span className="ml-2 inline-block px-1.5 py-0.5 rounded bg-teal-100 text-teal-700 text-xs font-medium">
+                    +{reviewedCount}
+                  </span>
+                )}
+              </span>
+              <span className="block text-sm text-gray-600">
+                Re-review approved work, your own approvals included. Accepting
+                again confirms an approval; sending an instance back withdraws
+                your earlier approval of it.
+              </span>
+            </span>
+          </label>
+        </div>
+
+        {/* Ordering — only meaningful when the queue is instance-by-instance. */}
+        {isInstanceMode && (
+          <div className="bg-white rounded-xl border border-gray-200 p-4 mb-6">
+            <div className="text-sm font-semibold text-gray-700 mb-3">Queue order</div>
+            <div className="flex flex-wrap items-center gap-3">
+              {strategies.length > 1 && (
+                <select
+                  value={strategy}
+                  onChange={(e) => setStrategy(e.target.value)}
+                  className="border border-gray-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-teal-500 focus:border-teal-500"
+                >
+                  {strategies.map((option) => (
+                    <option key={option.key} value={option.key}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+              )}
+              <div className="flex rounded-lg border border-gray-300 overflow-hidden">
+                <button
+                  onClick={() => setDirection('asc')}
+                  className={`flex items-center gap-1.5 px-3 py-2 text-sm transition-colors ${
+                    direction === 'asc'
+                      ? 'bg-teal-600 text-white'
+                      : 'bg-white text-gray-700 hover:bg-gray-50'
+                  }`}
+                >
+                  <ArrowUpNarrowWide className="w-4 h-4" />
+                  Ascending
+                </button>
+                <button
+                  onClick={() => setDirection('desc')}
+                  className={`flex items-center gap-1.5 px-3 py-2 text-sm transition-colors ${
+                    direction === 'desc'
+                      ? 'bg-teal-600 text-white'
+                      : 'bg-white text-gray-700 hover:bg-gray-50'
+                  }`}
+                >
+                  <ArrowDownWideNarrow className="w-4 h-4" />
+                  Descending
+                </button>
+              </div>
+              <span className="text-xs text-gray-500">
+                {strategies.find((option) => option.key === strategy)?.description ||
+                  'Root instances first, then their children.'}
+              </span>
+            </div>
+          </div>
+        )}
+
+        {/* Label filter for the custom mode. */}
+        {mode === 'custom' && (
+          <div className="bg-white rounded-xl border border-gray-200 p-4 mb-6">
+            <div className="text-sm font-semibold text-gray-700 mb-3">
+              Labels to review ({selectedLabelIds.length} selected)
+            </div>
+            {indentedLabels.length === 0 ? (
+              <p className="text-sm text-gray-500">This dataset has no labels yet.</p>
+            ) : (
+              <div className="max-h-64 overflow-y-auto space-y-1">
+                {indentedLabels.map((label) => (
+                  <label
+                    key={label.id}
+                    className="flex items-center gap-2 py-1 px-2 rounded hover:bg-gray-50 cursor-pointer"
+                    style={{ paddingLeft: `${8 + label.depth * 20}px` }}
+                  >
+                    <input
+                      type="checkbox"
+                      checked={selectedLabelIds.includes(label.id)}
+                      onChange={() => toggleLabel(label.id)}
+                      className="rounded border-gray-300 text-teal-600 focus:ring-teal-500"
+                    />
+                    <span
+                      className="w-3 h-3 rounded-full border border-black/10 flex-shrink-0"
+                      style={{ backgroundColor: getLabelColor(label.id) }}
+                    />
+                    <span className="text-sm text-gray-800">{label.name}</span>
+                  </label>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+
+        <button
+          onClick={handleStart}
+          disabled={!canStart}
+          className={`flex items-center gap-2 px-5 py-2.5 rounded-lg font-semibold transition-colors ${
+            canStart
+              ? 'bg-teal-600 text-white hover:bg-teal-700'
+              : 'bg-gray-200 text-gray-400 cursor-not-allowed'
+          }`}
+        >
+          {building ? <Loader2 className="w-4 h-4 animate-spin" /> : <Play className="w-4 h-4" />}
+          {building ? 'Building queue…' : 'Start reviewing'}
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default ReviewSetup;

--- a/src/components/viewer/AnnotationViewerCanvas.jsx
+++ b/src/components/viewer/AnnotationViewerCanvas.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Maximize2, Minus, Plus } from 'lucide-react';
 
 const MIN_ZOOM = 0.2;
@@ -16,6 +16,29 @@ const contourBounds = (contour) => {
     minY: Math.min(...ys),
     maxY: Math.max(...ys),
   };
+};
+
+/**
+ * SVG path for a contour, built from its normalized (0–1) coordinates scaled to
+ * the dimensions of the bitmap actually on screen.
+ *
+ * The normalized coordinates are the source of truth here, NOT the backend's
+ * precomputed `path`: that path bakes in the `Images.width/height` stored in the
+ * database, and rows ingested before the thumbnail-mutation fix carry thumbnail
+ * dimensions there — which squashed every contour into the top-left corner at
+ * 1/20 scale. Scaling by the loaded image's own size cannot disagree with the
+ * viewBox, which is derived from the same measurement. The backend path is only
+ * a fallback for contours that arrive without coordinate arrays.
+ */
+const pathFor = (contour, width, height) => {
+  const xs = contour?.x || [];
+  const ys = contour?.y || [];
+  if (xs.length < 3 || ys.length < 3) return contour?.path || null;
+  let d = `M ${Math.round(xs[0] * width)} ${Math.round(ys[0] * height)}`;
+  for (let i = 1; i < xs.length; i += 1) {
+    d += ` L ${Math.round(xs[i] * width)} ${Math.round(ys[i] * height)}`;
+  }
+  return `${d} Z`;
 };
 
 /**
@@ -46,6 +69,35 @@ const AnnotationViewerCanvas = ({
   const [zoom, setZoom] = useState(1);
   const [offset, setOffset] = useState({ x: 0, y: 0 });
   const dragRef = useRef(null);
+
+  // Centre of the selected contour in natural-pixel coordinates, or null when
+  // nothing is selected. This is the anchor zooming pivots around while an
+  // instance is in focus, so the object stays put instead of drifting toward or
+  // away from the image centre.
+  const selectedCenter = useMemo(() => {
+    if (selectedId == null || !natural.width) return null;
+    const contour = contours.find((c) => c.id === selectedId);
+    const bounds = contour && contourBounds(contour);
+    if (!bounds) return null;
+    return {
+      x: ((bounds.minX + bounds.maxX) / 2) * natural.width,
+      y: ((bounds.minY + bounds.maxY) / 2) * natural.height,
+    };
+  }, [selectedId, contours, natural]);
+
+  // Precomputed per contour: SAM-drawn contours run to thousands of points, and
+  // the SVG re-renders on every zoom tick — rebuilding the path strings each
+  // time would jank the wheel.
+  const drawableContours = useMemo(
+    () =>
+      contours
+        .map((contour) => ({
+          contour,
+          d: pathFor(contour, natural.width, natural.height),
+        }))
+        .filter((entry) => entry.d),
+    [contours, natural]
+  );
 
   /** Scale that fits the whole image in the viewport. */
   const fitScale = useCallback(() => {
@@ -90,10 +142,54 @@ const AnnotationViewerCanvas = ({
     });
   }, [zoomTarget, natural]);
 
+  /**
+   * Zoom to `nextZoom` while keeping `focal` (a point in natural-pixel
+   * coordinates) pinned to its current spot on screen.
+   *
+   * The wrapper is transformed with `transformOrigin: center center`, so a local
+   * point P lands on screen at `containerCentre + offset + zoom * (P - imageCentre)`.
+   * Holding that screen position fixed across a zoom change gives
+   * `offset' = offset + (zoom - nextZoom) * (P - imageCentre)`.
+   *
+   * `focal` defaults to the selected instance's centre (so the buttons pivot on
+   * it too) and falls back to the image centre when nothing is selected.
+   */
+  const zoomTo = useCallback(
+    (nextZoom, focal) => {
+      const clamped = Math.min(Math.max(nextZoom, MIN_ZOOM), MAX_ZOOM);
+      if (clamped === zoom || !natural.width) return;
+      const imageCenter = { x: natural.width / 2, y: natural.height / 2 };
+      const pivot = focal || selectedCenter || imageCenter;
+      setOffset({
+        x: offset.x + (zoom - clamped) * (pivot.x - imageCenter.x),
+        y: offset.y + (zoom - clamped) * (pivot.y - imageCenter.y),
+      });
+      setZoom(clamped);
+    },
+    [zoom, offset, natural, selectedCenter]
+  );
+
   const handleWheel = (e) => {
     e.preventDefault();
-    const direction = e.deltaY < 0 ? ZOOM_STEP : 1 / ZOOM_STEP;
-    setZoom((current) => Math.min(Math.max(current * direction, MIN_ZOOM), MAX_ZOOM));
+    if (!natural.width || !containerRef.current) return;
+    const nextZoom = zoom * (e.deltaY < 0 ? ZOOM_STEP : 1 / ZOOM_STEP);
+
+    // With an instance selected, pivot on it. Otherwise pivot on whatever the
+    // cursor is hovering over: invert the transform to recover the natural-pixel
+    // point currently under the pointer.
+    let focal = selectedCenter;
+    if (!focal) {
+      const rect = containerRef.current.getBoundingClientRect();
+      const cursorFromCenter = {
+        x: e.clientX - rect.left - rect.width / 2,
+        y: e.clientY - rect.top - rect.height / 2,
+      };
+      focal = {
+        x: natural.width / 2 + (cursorFromCenter.x - offset.x) / zoom,
+        y: natural.height / 2 + (cursorFromCenter.y - offset.y) / zoom,
+      };
+    }
+    zoomTo(nextZoom, focal);
   };
 
   const handleMouseDown = (e) => {
@@ -152,14 +248,13 @@ const AnnotationViewerCanvas = ({
                 // Clicking empty space clears the selection.
                 onClick={() => onSelect?.(null)}
               >
-                {contours.map((contour) => {
-                  if (!contour.path) return null;
+                {drawableContours.map(({ contour, d }) => {
                   const isSelected = contour.id === selectedId;
                   const color = colorFor ? colorFor(contour) : '#38bdf8';
                   return (
                     <path
                       key={contour.id}
-                      d={contour.path}
+                      d={d}
                       fill={color}
                       fillOpacity={isSelected ? 0.4 : 0.18}
                       stroke={color}
@@ -183,14 +278,14 @@ const AnnotationViewerCanvas = ({
       {/* Zoom controls */}
       <div className="absolute bottom-4 right-4 flex flex-col gap-1 bg-white/90 rounded-lg shadow p-1">
         <button
-          onClick={() => setZoom((z) => Math.min(z * ZOOM_STEP, MAX_ZOOM))}
+          onClick={() => zoomTo(zoom * ZOOM_STEP)}
           className="p-1.5 hover:bg-gray-100 rounded transition-colors"
           title="Zoom in"
         >
           <Plus className="w-4 h-4 text-gray-700" />
         </button>
         <button
-          onClick={() => setZoom((z) => Math.max(z / ZOOM_STEP, MIN_ZOOM))}
+          onClick={() => zoomTo(zoom / ZOOM_STEP)}
           className="p-1.5 hover:bg-gray-100 rounded transition-colors"
           title="Zoom out"
         >

--- a/src/contexts/CorrectionContext.jsx
+++ b/src/contexts/CorrectionContext.jsx
@@ -1,0 +1,65 @@
+import React, { createContext, useCallback, useContext, useMemo, useState } from 'react';
+
+const CorrectionContext = createContext(null);
+
+/**
+ * Holds the state of an in-flight correction session — the queue of sent-back
+ * items and where in it the annotator is.
+ *
+ * The session is played *inside the annotation editor* (`CorrectionBar` drives the
+ * canvas), and advancing from an item on one image to an item on another navigates
+ * the editor's route. So this state has to outlive those navigations: it lives here,
+ * above the router, rather than in any page's own state. It is memory-only and
+ * dataset-agnostic — a refresh ends the session, which is honest since the backend
+ * queue is a snapshot, not a reservation.
+ *
+ * Resolving an item (the network call) stays in the bar, which owns the toasts and
+ * error surface; this context only tracks position in the queue.
+ */
+export const CorrectionProvider = ({ children }) => {
+  const [session, setSession] = useState(null); // { datasetId, items, index } | null
+
+  const start = useCallback((datasetId, items) => {
+    if (!items?.length) return;
+    setSession({ datasetId: String(datasetId), items, index: 0 });
+  }, []);
+
+  // Step to the next item. When the index passes the last item the session is
+  // exhausted (`active` derives to false); the caller detects "was that the last
+  // one?" from the index/total it already holds, not from this call.
+  const advance = useCallback(() => {
+    setSession((current) => {
+      if (!current) return current;
+      return { ...current, index: current.index + 1 };
+    });
+  }, []);
+
+  const endSession = useCallback(() => setSession(null), []);
+
+  const value = useMemo(() => {
+    const active = Boolean(session) && session.index < session.items.length;
+    return {
+      active,
+      datasetId: session?.datasetId ?? null,
+      items: session?.items ?? [],
+      index: session?.index ?? 0,
+      total: session?.items.length ?? 0,
+      currentItem: active ? session.items[session.index] : null,
+      start,
+      advance,
+      endSession,
+    };
+  }, [session, start, advance, endSession]);
+
+  return (
+    <CorrectionContext.Provider value={value}>
+      {children}
+    </CorrectionContext.Provider>
+  );
+};
+
+export const useCorrection = () => {
+  const ctx = useContext(CorrectionContext);
+  if (!ctx) throw new Error('useCorrection must be used within a CorrectionProvider');
+  return ctx;
+};

--- a/src/hooks/useContourEditing.js
+++ b/src/hooks/useContourEditing.js
@@ -6,7 +6,6 @@ import {
   useEditModeIsDirty,
   useEditModeObjectId,
   useEnterEditMode,
-  useUpdateDraftPoint,
   useResetDraft,
   useExitEditMode,
   useUpdateObject,
@@ -29,7 +28,6 @@ export const useContourEditing = () => {
 
   // Actions
   const enterEditMode = useEnterEditMode();
-  const updateDraftPoint = useUpdateDraftPoint();
   const resetDraft = useResetDraft();
   const exitEditMode = useExitEditMode();
   const updateObject = useUpdateObject();
@@ -65,21 +63,6 @@ export const useContourEditing = () => {
     
     enterEditMode(objectId, contourId, x, y);
   }, [enterEditMode]);
-
-  /**
-   * Update a single point in the draft contour with interpolation
-   * @param {number} pointIndex - Index of the point to update
-   * @param {number} normalizedX - New x coordinate (normalized 0-1)
-   * @param {number} normalizedY - New y coordinate (normalized 0-1)
-   * @param {number} decimationFactor - Factor for point decimation 
-   */
-  const updatePoint = useCallback((pointIndex, normalizedX, normalizedY, decimationFactor = 1) => {
-    if (!isEditModeActive) {
-      return;
-    }
-    
-    updateDraftPoint(pointIndex, normalizedX, normalizedY, decimationFactor);
-  }, [isEditModeActive, updateDraftPoint]);
 
   /**
    * Cancel editing and revert to original coordinates
@@ -224,7 +207,6 @@ export const useContourEditing = () => {
     
     // Actions
     startEditing,
-    updatePoint,
     cancelEditing,
     resetChanges,
     saveEditing,

--- a/src/hooks/usePromptDrawing.js
+++ b/src/hooks/usePromptDrawing.js
@@ -17,8 +17,11 @@ const MIN_SKETCH_DIST_PX = 4; // minimum spacing between captured freehand point
  * @param {Function} params.stageToImageCoords - Maps stage px -> {imageX, imageY}
  * @param {Function} params.getScale - Returns the current stage scale (px per image px)
  * @param {Function} params.onFinalize - Called with (points, { freehand }) on completion
+ * @param {number} [params.minPoints=3] - Fewest points a completed shape needs (2 for an open line)
+ * @param {boolean} [params.closeOnFirst=true] - Polygon closes when clicking near the first vertex
+ *   (turn off for open lines, which finish on double-click / Enter instead)
  */
-const usePromptDrawing = ({ mode, stageToImageCoords, getScale, onFinalize }) => {
+const usePromptDrawing = ({ mode, stageToImageCoords, getScale, onFinalize, minPoints = 3, closeOnFirst = true }) => {
   const [polygonPoints, setPolygonPoints] = useState([]);
   const [cursorImagePt, setCursorImagePt] = useState(null); // live vertex for the rubber band
   const [isSketching, setIsSketching] = useState(false); // freehand drag in progress
@@ -44,9 +47,9 @@ const usePromptDrawing = ({ mode, stageToImageCoords, getScale, onFinalize }) =>
   const finalize = useCallback((ptsArg, freehand = false) => {
     const pts = ptsArg || pointsRef.current;
     resetDrawing();
-    if (!pts || pts.length < 3) return;
+    if (!pts || pts.length < minPoints) return;
     onFinalize(pts.map((p) => ({ x: p.x, y: p.y })), { freehand });
-  }, [onFinalize, resetDrawing]);
+  }, [onFinalize, resetDrawing, minPoints]);
 
   const handleMouseDown = useCallback((e) => {
     const stage = e.target.getStage();
@@ -72,7 +75,7 @@ const usePromptDrawing = ({ mode, stageToImageCoords, getScale, onFinalize }) =>
     if (e.evt.button !== 0) return;
 
     const existing = pointsRef.current;
-    if (existing.length >= 3) {
+    if (closeOnFirst && existing.length >= 3) {
       // Close the shape when clicking near the first vertex
       const first = existing[0];
       const scale = getScale();
@@ -84,7 +87,7 @@ const usePromptDrawing = ({ mode, stageToImageCoords, getScale, onFinalize }) =>
       }
     }
     setPolygonPoints((pts) => [...pts, pt]);
-  }, [mode, stageToImageCoords, getScale, finalize]);
+  }, [mode, stageToImageCoords, getScale, finalize, closeOnFirst]);
 
   const handleMouseMove = useCallback((e) => {
     const stage = e.target.getStage();

--- a/src/pages/CorrectionPage.jsx
+++ b/src/pages/CorrectionPage.jsx
@@ -1,0 +1,265 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import {
+  ArrowLeft,
+  ArrowDownWideNarrow,
+  ArrowUpNarrowWide,
+  CheckCircle2,
+  Loader2,
+  Play,
+  Wrench,
+} from 'lucide-react';
+import {
+  fetchCorrectionSummary,
+  buildCorrectionQueue,
+  fetchRejectionReasons,
+} from '../api/reviews';
+import { useAuth } from '../contexts/AuthContext';
+import { useDataset } from '../contexts/DatasetContext';
+import { useCorrection } from '../contexts/CorrectionContext';
+import { usePermissions } from '../hooks/usePermissions';
+import { Permission } from '../utils/permissions';
+import RoleBadge from '../components/datasets/RoleBadge';
+
+const readableError = (err, fallback) =>
+  (err?.message || '').replace(/^API Error:\s*/i, '') || fallback;
+
+/**
+ * The correction session's launch pad.
+ *
+ * Picks an order (and optionally a subset of reasons), builds the queue of open
+ * rejections, and hands it to the CorrectionContext — then jumps into the
+ * annotation editor on the first item's image, where `CorrectionBar` drives the
+ * rest. The queue is memory-only (a snapshot), so this page is where a session
+ * always begins; a refresh mid-session lands back here.
+ */
+const CorrectionPage = () => {
+  const { datasetId } = useParams();
+  const navigate = useNavigate();
+  const { isAuthenticated } = useAuth();
+  const { datasets } = useDataset();
+  const correction = useCorrection();
+
+  const dataset = useMemo(
+    () => datasets?.find((d) => String(d.id) === String(datasetId)) || null,
+    [datasets, datasetId]
+  );
+  const { can, role } = usePermissions(dataset);
+  const mayCorrect = can(Permission.ANNOTATION_EDIT_OWN);
+
+  const [summary, setSummary] = useState(null);
+  const [reasons, setReasons] = useState([]);
+  const [order, setOrder] = useState('oldest');
+  const [selectedReasons, setSelectedReasons] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [building, setBuilding] = useState(false);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    if (!datasetId || !isAuthenticated) return undefined;
+    let cancelled = false;
+
+    const load = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const [summaryResponse, reasonResponse] = await Promise.all([
+          fetchCorrectionSummary(datasetId),
+          fetchRejectionReasons(),
+        ]);
+        if (cancelled) return;
+        if (summaryResponse?.success) setSummary(summaryResponse.summary);
+        setReasons(reasonResponse?.reasons || []);
+      } catch (err) {
+        if (!cancelled) setError(readableError(err, 'Could not load the correction overview.'));
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [datasetId, isAuthenticated]);
+
+  const openCount = summary?.open_rejections ?? null;
+
+  const toggleReason = (value) => {
+    setSelectedReasons((current) =>
+      current.includes(value)
+        ? current.filter((v) => v !== value)
+        : [...current, value]
+    );
+  };
+
+  const handleStart = useCallback(async () => {
+    setBuilding(true);
+    setError(null);
+    try {
+      const response = await buildCorrectionQueue(datasetId, {
+        order,
+        reasons: selectedReasons.length > 0 ? selectedReasons : null,
+      });
+      const items = response?.queue?.items || [];
+      if (items.length === 0) {
+        setError('Nothing matches — there is no correction work with those filters.');
+        return;
+      }
+      correction.start(datasetId, items);
+      navigate(`/dataset/${datasetId}/annotate/${items[0].image_id}`);
+    } catch (err) {
+      setError(readableError(err, 'Could not build the correction queue.'));
+    } finally {
+      setBuilding(false);
+    }
+  }, [datasetId, order, selectedReasons, correction, navigate]);
+
+  const canStart = !building && (openCount == null || openCount > 0);
+
+  return (
+    <div className="h-screen flex flex-col bg-gray-50">
+      <div className="bg-teal-600 text-white flex-shrink-0">
+        <div className="px-4 py-3 flex items-center justify-between gap-4">
+          <div className="flex items-center gap-3 min-w-0">
+            <button
+              onClick={() => navigate(`/dataset/${datasetId}/datamanagement`)}
+              className="flex items-center gap-2 hover:text-teal-200 transition-colors flex-shrink-0"
+            >
+              <ArrowLeft className="w-5 h-5" />
+              <span className="hidden sm:inline">Back</span>
+            </button>
+            <div className="h-6 w-px bg-teal-400 flex-shrink-0" />
+            <Wrench className="w-5 h-5 flex-shrink-0" />
+            <h1 className="text-lg font-bold truncate">
+              Correct {dataset?.name ? `· ${dataset.name}` : ''}
+            </h1>
+            {role && <RoleBadge role={role} showDescription />}
+          </div>
+        </div>
+      </div>
+
+      {error && (
+        <div className="px-4 py-2 bg-red-50 border-b border-red-200 flex-shrink-0">
+          <p className="text-sm text-red-700">{error}</p>
+        </div>
+      )}
+
+      <div className="flex-1 min-h-0 overflow-y-auto">
+        {!mayCorrect && !loading ? (
+          <div className="h-full flex items-center justify-center text-gray-500 text-sm">
+            You do not have permission to correct annotations on this dataset.
+          </div>
+        ) : loading ? (
+          <div className="h-full flex items-center justify-center text-gray-500">
+            <Loader2 className="w-5 h-5 animate-spin mr-2" />
+            Loading…
+          </div>
+        ) : openCount === 0 ? (
+          <div className="h-full flex flex-col items-center justify-center text-center px-4">
+            <CheckCircle2 className="w-12 h-12 text-teal-500 mb-4" />
+            <h2 className="text-2xl font-bold text-gray-900 mb-2">Nothing to correct</h2>
+            <p className="text-gray-600 mb-6">
+              No annotations have been sent back for correction right now.
+            </p>
+            <button
+              onClick={() => navigate(`/dataset/${datasetId}/datamanagement`)}
+              className="px-5 py-2.5 rounded-lg font-semibold bg-teal-600 text-white hover:bg-teal-700 transition-colors"
+            >
+              Back to dataset
+            </button>
+          </div>
+        ) : (
+          <div className="max-w-4xl mx-auto p-6 sm:p-8">
+            <h2 className="text-2xl font-bold text-gray-900 mb-1">Start a correction session</h2>
+            <p className="text-gray-600 mb-2">
+              Work through every instance a reviewer sent back, one at a time, in the
+              annotation editor.
+            </p>
+            {openCount != null && (
+              <p className="text-sm font-medium text-teal-700 mb-6">
+                {openCount === 1
+                  ? '1 instance sent back for correction'
+                  : `${openCount} instances sent back for correction`}
+                {summary?.affected_images > 0 &&
+                  ` across ${summary.affected_images} image${
+                    summary.affected_images === 1 ? '' : 's'
+                  }.`}
+              </p>
+            )}
+
+            {/* Order */}
+            <div className="bg-white rounded-xl border border-gray-200 p-4 mb-6">
+              <div className="text-sm font-semibold text-gray-700 mb-3">Order</div>
+              <div className="flex rounded-lg border border-gray-300 overflow-hidden w-fit">
+                <button
+                  onClick={() => setOrder('oldest')}
+                  className={`flex items-center gap-1.5 px-3 py-2 text-sm transition-colors ${
+                    order === 'oldest'
+                      ? 'bg-teal-600 text-white'
+                      : 'bg-white text-gray-700 hover:bg-gray-50'
+                  }`}
+                >
+                  <ArrowUpNarrowWide className="w-4 h-4" />
+                  Oldest feedback first
+                </button>
+                <button
+                  onClick={() => setOrder('newest')}
+                  className={`flex items-center gap-1.5 px-3 py-2 text-sm transition-colors ${
+                    order === 'newest'
+                      ? 'bg-teal-600 text-white'
+                      : 'bg-white text-gray-700 hover:bg-gray-50'
+                  }`}
+                >
+                  <ArrowDownWideNarrow className="w-4 h-4" />
+                  Newest first
+                </button>
+              </div>
+            </div>
+
+            {/* Reason filter */}
+            <div className="bg-white rounded-xl border border-gray-200 p-4 mb-6">
+              <div className="text-sm font-semibold text-gray-700 mb-1">
+                Limit to reasons ({selectedReasons.length || 'all'})
+              </div>
+              <p className="text-xs text-gray-500 mb-3">
+                Leave all unchecked to correct every kind of feedback.
+              </p>
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-1">
+                {reasons.map((reason) => (
+                  <label
+                    key={reason.value}
+                    className="flex items-center gap-2 py-1 px-2 rounded hover:bg-gray-50 cursor-pointer"
+                  >
+                    <input
+                      type="checkbox"
+                      checked={selectedReasons.includes(reason.value)}
+                      onChange={() => toggleReason(reason.value)}
+                      className="rounded border-gray-300 text-teal-600 focus:ring-teal-500"
+                    />
+                    <span className="text-sm text-gray-800">{reason.label}</span>
+                  </label>
+                ))}
+              </div>
+            </div>
+
+            <button
+              onClick={handleStart}
+              disabled={!canStart}
+              className={`flex items-center gap-2 px-5 py-2.5 rounded-lg font-semibold transition-colors ${
+                canStart
+                  ? 'bg-teal-600 text-white hover:bg-teal-700'
+                  : 'bg-gray-200 text-gray-400 cursor-not-allowed'
+              }`}
+            >
+              {building ? <Loader2 className="w-4 h-4 animate-spin" /> : <Play className="w-4 h-4" />}
+              {building ? 'Building queue…' : 'Start correcting'}
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default CorrectionPage;

--- a/src/pages/ReviewPage.jsx
+++ b/src/pages/ReviewPage.jsx
@@ -1,0 +1,164 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { ArrowLeft, ClipboardCheck, Loader2 } from 'lucide-react';
+import * as api from '../api';
+import { fetchReviewSummary, buildReviewQueue } from '../api/reviews';
+import { useAuth } from '../contexts/AuthContext';
+import { useDataset } from '../contexts/DatasetContext';
+import { usePermissions } from '../hooks/usePermissions';
+import { Permission } from '../utils/permissions';
+import { extractLabelsFromResponse } from '../utils/labelHierarchy';
+import RoleBadge from '../components/datasets/RoleBadge';
+import ReviewSetup from '../components/review/ReviewSetup';
+import ReviewSession from '../components/review/ReviewSession';
+
+const readableError = (err, fallback) =>
+  (err?.message || '').replace(/^API Error:\s*/i, '') || fallback;
+
+/**
+ * The review workflow: pick a granularity, get a queue, work through it.
+ *
+ * Two phases on one page. "Setup" chooses what to review (whole images,
+ * instances ordered by hierarchy, or a custom label selection) and how to order
+ * it; "session" plays the resulting queue one item at a time. The queue lives in
+ * memory only — a refresh returns to setup, which is the honest thing to do
+ * since the backend queue is a snapshot, not a reservation.
+ */
+const ReviewPage = () => {
+  const { datasetId } = useParams();
+  const navigate = useNavigate();
+  const { isAuthenticated } = useAuth();
+  const { datasets } = useDataset();
+
+  const dataset = useMemo(
+    () => datasets?.find((d) => String(d.id) === String(datasetId)) || null,
+    [datasets, datasetId]
+  );
+  const { can, role } = usePermissions(dataset);
+  const mayReview = can(Permission.REVIEW_APPROVE);
+
+  const [summary, setSummary] = useState(null);
+  const [labels, setLabels] = useState([]);
+  const [queue, setQueue] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [building, setBuilding] = useState(false);
+  const [error, setError] = useState(null);
+
+  const loadSummary = useCallback(async () => {
+    const response = await fetchReviewSummary(datasetId);
+    if (response?.success) setSummary(response.summary);
+  }, [datasetId]);
+
+  useEffect(() => {
+    if (!datasetId || !isAuthenticated) return undefined;
+    let cancelled = false;
+
+    const load = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const [summaryResponse, labelResponse] = await Promise.all([
+          fetchReviewSummary(datasetId),
+          api.fetchLabels(datasetId),
+        ]);
+        if (cancelled) return;
+        if (summaryResponse?.success) setSummary(summaryResponse.summary);
+        setLabels(extractLabelsFromResponse(labelResponse));
+      } catch (err) {
+        if (!cancelled) setError(readableError(err, 'Could not load the review overview.'));
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [datasetId, isAuthenticated]);
+
+  const labelsById = useMemo(
+    () => Object.fromEntries(labels.map((label) => [label.id, label])),
+    [labels]
+  );
+
+  const handleStart = async (options) => {
+    setBuilding(true);
+    setError(null);
+    try {
+      const response = await buildReviewQueue(datasetId, options);
+      if (response?.success) setQueue(response.queue);
+    } catch (err) {
+      setError(readableError(err, 'Could not build the review queue.'));
+    } finally {
+      setBuilding(false);
+    }
+  };
+
+  // Leaving a session refreshes the counts: they just changed by however many
+  // items were approved or sent back.
+  const handleExitSession = useCallback(() => {
+    setQueue(null);
+    loadSummary().catch(() => {});
+  }, [loadSummary]);
+
+  return (
+    <div className="h-screen flex flex-col bg-gray-50">
+      <div className="bg-teal-600 text-white flex-shrink-0">
+        <div className="px-4 py-3 flex items-center justify-between gap-4">
+          <div className="flex items-center gap-3 min-w-0">
+            <button
+              onClick={() =>
+                queue ? handleExitSession() : navigate(`/dataset/${datasetId}/datamanagement`)
+              }
+              className="flex items-center gap-2 hover:text-teal-200 transition-colors flex-shrink-0"
+            >
+              <ArrowLeft className="w-5 h-5" />
+              <span className="hidden sm:inline">{queue ? 'End session' : 'Back'}</span>
+            </button>
+            <div className="h-6 w-px bg-teal-400 flex-shrink-0" />
+            <ClipboardCheck className="w-5 h-5 flex-shrink-0" />
+            <h1 className="text-lg font-bold truncate">
+              Review {dataset?.name ? `· ${dataset.name}` : ''}
+            </h1>
+            {role && <RoleBadge role={role} showDescription />}
+          </div>
+        </div>
+      </div>
+
+      {error && (
+        <div className="px-4 py-2 bg-red-50 border-b border-red-200 flex-shrink-0">
+          <p className="text-sm text-red-700">{error}</p>
+        </div>
+      )}
+
+      <div className="flex-1 min-h-0">
+        {!mayReview && !loading ? (
+          <div className="h-full flex items-center justify-center text-gray-500 text-sm">
+            You do not have review permissions on this dataset.
+          </div>
+        ) : loading ? (
+          <div className="h-full flex items-center justify-center text-gray-500">
+            <Loader2 className="w-5 h-5 animate-spin mr-2" />
+            Loading…
+          </div>
+        ) : queue ? (
+          <ReviewSession
+            queue={queue}
+            labelsById={labelsById}
+            onExit={handleExitSession}
+          />
+        ) : (
+          <ReviewSetup
+            summary={summary}
+            labels={labels}
+            building={building}
+            onStart={handleStart}
+          />
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default ReviewPage;

--- a/src/stores/initialState.js
+++ b/src/stores/initialState.js
@@ -65,9 +65,21 @@ export const initialState = {
     active: false,
     objectId: null,
     contourId: null,
-    originalCoordinates: null, // { x: [], y: [] }
-    draftCoordinates: null, // { x: [], y: [] }
+    originalCoordinates: null, // { x: [], y: [] } — the dense outline as it was on entry
+    draftCoordinates: null, // { x: [], y: [] } — dense outline resampled from `vertices` (displayed + saved)
+    vertices: null, // { x: [], y: [] } — the few control handles the user drags
+    initialVertices: null, // { x: [], y: [] } — vertices at entry, for Reset
     isDirty: false, // Track if changes have been made
+  },
+
+  // Line-edit Mode State (draw an open line near the boundary; it is merged into
+  // the contour, replacing the nearest boundary arc — cutting a region off or
+  // adding one). An alternative to dragging the outline's control points.
+  lineEdit: {
+    active: false,
+    objectId: null, // store object id being reshaped
+    contourId: null, // backend contour id for the modify call
+    original: null, // { x: [], y: [] } normalized — the contour being reshaped
   },
   
   // Image State

--- a/src/stores/selectors/annotationSelectors.js
+++ b/src/stores/selectors/annotationSelectors.js
@@ -205,11 +205,24 @@ export const useEditModeObjectId = () => useAnnotationStore(state => state.editM
 export const useEditModeContourId = () => useAnnotationStore(state => state.editMode.contourId);
 export const useEditModeOriginalCoordinates = () => useAnnotationStore(state => state.editMode.originalCoordinates);
 export const useEditModeDraftCoordinates = () => useAnnotationStore(state => state.editMode.draftCoordinates);
+export const useEditModeVertices = () => useAnnotationStore(state => state.editMode.vertices);
 export const useEditModeIsDirty = () => useAnnotationStore(state => state.editMode.isDirty);
 
 // Edit Mode actions
 export const useEnterEditMode = () => useAnnotationStore(state => state.enterEditMode);
-export const useUpdateDraftPoint = () => useAnnotationStore(state => state.updateDraftPoint);
+export const useMoveVertex = () => useAnnotationStore(state => state.moveVertex);
+export const useInsertVertex = () => useAnnotationStore(state => state.insertVertex);
+export const useDeleteVertex = () => useAnnotationStore(state => state.deleteVertex);
 export const useResetDraft = () => useAnnotationStore(state => state.resetDraft);
 export const useSyncEditModeDraftFromRefinement = () => useAnnotationStore(state => state.syncEditModeDraftFromRefinement);
 export const useExitEditMode = () => useAnnotationStore(state => state.exitEditMode);
+
+// Line-edit Mode selectors
+export const useLineEditActive = () => useAnnotationStore(state => state.lineEdit.active);
+export const useLineEditObjectId = () => useAnnotationStore(state => state.lineEdit.objectId);
+export const useLineEditContourId = () => useAnnotationStore(state => state.lineEdit.contourId);
+export const useLineEditOriginal = () => useAnnotationStore(state => state.lineEdit.original);
+
+// Line-edit Mode actions
+export const useStartLineEdit = () => useAnnotationStore(state => state.startLineEdit);
+export const useStopLineEdit = () => useAnnotationStore(state => state.stopLineEdit);

--- a/src/stores/slices/editModeSlice.js
+++ b/src/stores/slices/editModeSlice.js
@@ -1,93 +1,90 @@
 /**
- * Edit Mode slice - manages contour editing mode
+ * Edit Mode slice - manages manual contour editing.
+ *
+ * The editable shape is a small set of **control vertices**, not the dense point
+ * list the model emits. On entry the dense outline is simplified to a few vertices
+ * (`simplifyClosedContour`); the user drags/adds/removes those, and after every
+ * change the dense `draftCoordinates` — what the canvas draws and what gets saved —
+ * is resampled as a smooth closed curve through the vertices
+ * (`densifyClosedVertices`). Keeping `draftCoordinates` dense means the save path
+ * (`useContourEditing`, `RefinementOverlay`) is unchanged; only the handles moved
+ * from "every Nth dense point" to "the control vertices".
  */
+import { simplifyClosedContour, densifyClosedVertices } from '../../utils/contourEditing';
+
+/** Recompute the dense draft outline from the current control vertices. */
+const syncDraftFromVertices = (state) => {
+  const { vertices } = state.editMode;
+  if (!vertices || vertices.x.length < 3) return;
+  state.editMode.draftCoordinates = densifyClosedVertices(vertices.x, vertices.y);
+};
+
 export const createEditModeSlice = (set) => ({
   enterEditMode: (objectId, contourId, originalX, originalY) => set((state) => {
+    const vertices = simplifyClosedContour(originalX, originalY);
     state.editMode.active = true;
     state.editMode.objectId = objectId;
     state.editMode.contourId = contourId;
     state.editMode.originalCoordinates = { x: [...originalX], y: [...originalY] };
-    state.editMode.draftCoordinates = { x: [...originalX], y: [...originalY] };
+    state.editMode.vertices = { x: [...vertices.x], y: [...vertices.y] };
+    state.editMode.initialVertices = { x: [...vertices.x], y: [...vertices.y] };
+    state.editMode.draftCoordinates = densifyClosedVertices(vertices.x, vertices.y);
     state.editMode.isDirty = false;
   }),
-  
-  updateDraftPoint: (index, newX, newY, decimationFactor = 1) => set((state) => {
-    if (state.editMode.active && state.editMode.draftCoordinates) {
-      const xCoords = state.editMode.draftCoordinates.x;
-      const yCoords = state.editMode.draftCoordinates.y;
-      const totalPoints = xCoords.length;
-      
-      // Update the main control point
-      xCoords[index] = newX;
-      yCoords[index] = newY;
-      
-      // If decimation is used, interpolate intermediate points
-      if (decimationFactor > 1) {
-        // Find previous and next control points
-        const prevIndex = index - decimationFactor;
-        const nextIndex = index + decimationFactor;
-        
-        // Interpolate points between previous control point and this one
-        if (prevIndex >= 0) {
-          for (let i = prevIndex + 1; i < index; i++) {
-            const t = (i - prevIndex) / (index - prevIndex);
-            xCoords[i] = xCoords[prevIndex] + t * (xCoords[index] - xCoords[prevIndex]);
-            yCoords[i] = yCoords[prevIndex] + t * (yCoords[index] - yCoords[prevIndex]);
-          }
-        }
-        
-        // Interpolate points between this control point and next one
-        if (nextIndex < totalPoints) {
-          for (let i = index + 1; i < nextIndex; i++) {
-            const t = (i - index) / (nextIndex - index);
-            xCoords[i] = xCoords[index] + t * (xCoords[nextIndex] - xCoords[index]);
-            yCoords[i] = yCoords[index] + t * (yCoords[nextIndex] - yCoords[index]);
-          }
-        }
-        
-        // Handle wrap-around for closed contours
-        if (nextIndex >= totalPoints) {
-          const wrapNextIndex = nextIndex % totalPoints;
-          for (let i = index + 1; i < totalPoints; i++) {
-            const t = (i - index) / (totalPoints - index + wrapNextIndex);
-            xCoords[i] = xCoords[index] + t * (xCoords[wrapNextIndex] - xCoords[index]);
-            yCoords[i] = yCoords[index] + t * (yCoords[wrapNextIndex] - yCoords[index]);
-          }
-        }
-        
-        // Handle wrap-around from start to first control point
-        if (prevIndex < 0) {
-          const wrapPrevIndex = totalPoints + prevIndex;
-          for (let i = 0; i < index; i++) {
-            const t = (i + totalPoints - wrapPrevIndex) / (index + totalPoints - wrapPrevIndex);
-            xCoords[i] = xCoords[wrapPrevIndex] + t * (xCoords[index] - xCoords[wrapPrevIndex]);
-            yCoords[i] = yCoords[wrapPrevIndex] + t * (yCoords[index] - yCoords[wrapPrevIndex]);
-          }
-        }
-      }
-      
-      state.editMode.isDirty = true;
-    }
+
+  /** Move one control vertex to a new normalized position. */
+  moveVertex: (index, newX, newY) => set((state) => {
+    const { vertices } = state.editMode;
+    if (!state.editMode.active || !vertices || index < 0 || index >= vertices.x.length) return;
+    vertices.x[index] = newX;
+    vertices.y[index] = newY;
+    syncDraftFromVertices(state);
+    state.editMode.isDirty = true;
   }),
-  
+
+  /** Insert a new control vertex after `afterIndex` (adds local precision). */
+  insertVertex: (afterIndex, newX, newY) => set((state) => {
+    const { vertices } = state.editMode;
+    if (!state.editMode.active || !vertices) return;
+    const at = afterIndex + 1;
+    vertices.x.splice(at, 0, newX);
+    vertices.y.splice(at, 0, newY);
+    syncDraftFromVertices(state);
+    state.editMode.isDirty = true;
+  }),
+
+  /** Remove one control vertex. A closed shape needs at least three. */
+  deleteVertex: (index) => set((state) => {
+    const { vertices } = state.editMode;
+    if (!state.editMode.active || !vertices || vertices.x.length <= 3) return;
+    if (index < 0 || index >= vertices.x.length) return;
+    vertices.x.splice(index, 1);
+    vertices.y.splice(index, 1);
+    syncDraftFromVertices(state);
+    state.editMode.isDirty = true;
+  }),
+
   resetDraft: () => set((state) => {
-    if (state.editMode.active && state.editMode.originalCoordinates) {
-      state.editMode.draftCoordinates = {
-        x: [...state.editMode.originalCoordinates.x],
-        y: [...state.editMode.originalCoordinates.y]
-      };
-      state.editMode.isDirty = false;
-    }
+    const { initialVertices } = state.editMode;
+    if (!state.editMode.active || !initialVertices) return;
+    state.editMode.vertices = { x: [...initialVertices.x], y: [...initialVertices.y] };
+    syncDraftFromVertices(state);
+    state.editMode.isDirty = false;
   }),
 
   /**
-   * Sync edit mode draft and original coordinates to new contour (e.g. after "Refine object").
-   * Updates the blue control-point overlay to the new shape while staying in edit mode.
+   * Sync edit mode to a new contour (e.g. after "Refine object" re-segments it):
+   * re-simplify the new dense outline into fresh control vertices while staying in
+   * edit mode.
    */
   syncEditModeDraftFromRefinement: (newX, newY) => set((state) => {
-    if (!state.editMode.active || !Array.isArray(newX) || !Array.isArray(newY) || newX.length === 0 || newY.length === 0) return;
+    if (!state.editMode.active || !Array.isArray(newX) || !Array.isArray(newY) ||
+        newX.length === 0 || newY.length === 0) return;
+    const vertices = simplifyClosedContour(newX, newY);
     state.editMode.originalCoordinates = { x: [...newX], y: [...newY] };
-    state.editMode.draftCoordinates = { x: [...newX], y: [...newY] };
+    state.editMode.vertices = { x: [...vertices.x], y: [...vertices.y] };
+    state.editMode.initialVertices = { x: [...vertices.x], y: [...vertices.y] };
+    state.editMode.draftCoordinates = densifyClosedVertices(vertices.x, vertices.y);
     state.editMode.isDirty = false;
   }),
 
@@ -97,6 +94,37 @@ export const createEditModeSlice = (set) => ({
     state.editMode.contourId = null;
     state.editMode.originalCoordinates = null;
     state.editMode.draftCoordinates = null;
+    state.editMode.vertices = null;
+    state.editMode.initialVertices = null;
     state.editMode.isDirty = false;
+  }),
+
+  /**
+   * Enter line-edit mode: the user draws an open line near the boundary that gets
+   * merged into this contour (cut/add). Any point-editing session is closed first —
+   * the two ways of reshaping a contour are mutually exclusive.
+   */
+  startLineEdit: (objectId, contourId, x, y) => set((state) => {
+    state.editMode.active = false;
+    state.editMode.objectId = null;
+    state.editMode.contourId = null;
+    state.editMode.vertices = null;
+    state.editMode.initialVertices = null;
+    state.editMode.draftCoordinates = null;
+    state.editMode.originalCoordinates = null;
+    state.editMode.isDirty = false;
+    state.lineEdit.active = true;
+    state.lineEdit.objectId = objectId;
+    state.lineEdit.contourId = contourId;
+    state.lineEdit.original = (Array.isArray(x) && Array.isArray(y))
+      ? { x: [...x], y: [...y] }
+      : null;
+  }),
+
+  stopLineEdit: () => set((state) => {
+    state.lineEdit.active = false;
+    state.lineEdit.objectId = null;
+    state.lineEdit.contourId = null;
+    state.lineEdit.original = null;
   }),
 });

--- a/src/stores/slices/imagesSlice.js
+++ b/src/stores/slices/imagesSlice.js
@@ -30,7 +30,13 @@ export const createImagesSlice = (set) => ({
       state.editMode.contourId = null;
       state.editMode.originalCoordinates = null;
       state.editMode.draftCoordinates = null;
+      state.editMode.vertices = null;
+      state.editMode.initialVertices = null;
       state.editMode.isDirty = false;
+      state.lineEdit.active = false;
+      state.lineEdit.objectId = null;
+      state.lineEdit.contourId = null;
+      state.lineEdit.original = null;
     }
   }),
   

--- a/src/utils/contourEditing.js
+++ b/src/utils/contourEditing.js
@@ -1,0 +1,271 @@
+/**
+ * Geometry helpers for the manual contour editor.
+ *
+ * The editor's model is a small set of **control vertices** rather than the dense
+ * point list a segmentation model emits (which can be hundreds of points — far too
+ * many handles to drag, and every point sat on top of its neighbours). On entering
+ * edit mode we simplify the dense outline to a handful of vertices with
+ * Ramer–Douglas–Peucker (`simplifyClosedContour`); the handles the user drags are
+ * those vertices. The outline actually shown and saved is a smooth closed
+ * Catmull-Rom curve resampled through the vertices (`densifyClosedVertices`), so a
+ * dozen handles still describe a clean curve, and the user adds a vertex only where
+ * they need finer control. Everything works in normalized [0,1] image coordinates.
+ */
+
+/** Perpendicular distance from point `p` to the segment `a`–`b`. */
+function segmentDistance(p, a, b) {
+  const dx = b.x - a.x;
+  const dy = b.y - a.y;
+  const len2 = dx * dx + dy * dy;
+  if (len2 === 0) return Math.hypot(p.x - a.x, p.y - a.y);
+  let t = ((p.x - a.x) * dx + (p.y - a.y) * dy) / len2;
+  t = Math.max(0, Math.min(1, t));
+  return Math.hypot(p.x - (a.x + t * dx), p.y - (a.y + t * dy));
+}
+
+/** Classic Ramer–Douglas–Peucker on an open polyline of {x,y} points. */
+function rdp(points, epsilon) {
+  if (points.length < 3) return points.slice();
+  let maxDist = 0;
+  let index = 0;
+  const first = points[0];
+  const last = points[points.length - 1];
+  for (let i = 1; i < points.length - 1; i++) {
+    const dist = segmentDistance(points[i], first, last);
+    if (dist > maxDist) {
+      maxDist = dist;
+      index = i;
+    }
+  }
+  if (maxDist > epsilon) {
+    const left = rdp(points.slice(0, index + 1), epsilon);
+    const right = rdp(points.slice(index), epsilon);
+    return left.slice(0, -1).concat(right);
+  }
+  return [first, last];
+}
+
+/** Turn parallel x/y arrays into {x,y} points, dropping a repeated closing point. */
+function toPoints(xs, ys) {
+  const n = Math.min(xs.length, ys.length);
+  const points = [];
+  for (let i = 0; i < n; i++) points.push({ x: xs[i], y: ys[i] });
+  if (
+    points.length > 1 &&
+    points[0].x === points[points.length - 1].x &&
+    points[0].y === points[points.length - 1].y
+  ) {
+    points.pop();
+  }
+  return points;
+}
+
+/** Index of the point farthest from the centroid — a stable, shape-independent seam. */
+function farthestFromCentroid(points) {
+  const cx = points.reduce((s, p) => s + p.x, 0) / points.length;
+  const cy = points.reduce((s, p) => s + p.y, 0) / points.length;
+  let best = 0;
+  let bestDist = -1;
+  points.forEach((p, i) => {
+    const d = (p.x - cx) ** 2 + (p.y - cy) ** 2;
+    if (d > bestDist) {
+      bestDist = d;
+      best = i;
+    }
+  });
+  return best;
+}
+
+/**
+ * Simplify a dense closed contour to a small set of control vertices.
+ *
+ * Bisects the RDP tolerance to land the vertex count inside
+ * [minVertices, maxVertices] — "as few points as possible" while still tracking the
+ * shape. The polyline is rotated to start at an extreme point so the fixed RDP
+ * endpoints do not fall in the middle of a curve and leave a flat seam.
+ *
+ * @returns {{x: number[], y: number[]}} sparse vertices in draw order (open loop).
+ */
+export function simplifyClosedContour(xs, ys, { maxVertices = 16, minVertices = 5 } = {}) {
+  const points = toPoints(xs, ys);
+  if (points.length <= minVertices) {
+    return { x: points.map((p) => p.x), y: points.map((p) => p.y) };
+  }
+
+  // Rotate to start at an extreme point, then close the polyline back onto it so
+  // RDP simplifies the whole loop rather than an arbitrary cut of it.
+  const start = farthestFromCentroid(points);
+  const rotated = points.slice(start).concat(points.slice(0, start));
+  const closedLine = rotated.concat([rotated[0]]);
+
+  const diag = Math.hypot(1, 1); // normalized coords: bbox diagonal upper bound.
+  let lo = 0;
+  let hi = diag;
+  let best = closedLine;
+
+  for (let iter = 0; iter < 24; iter++) {
+    const mid = (lo + hi) / 2;
+    const simplified = rdp(closedLine, mid);
+    const count = simplified.length - 1; // last point repeats the first.
+    if (count > maxVertices) {
+      lo = mid; // too many → simplify harder.
+    } else {
+      best = simplified;
+      if (count <= minVertices) {
+        hi = mid; // too few → back off.
+      } else {
+        hi = mid;
+      }
+    }
+  }
+
+  const vertices = best.slice(0, -1); // drop the repeated closing point.
+  return { x: vertices.map((p) => p.x), y: vertices.map((p) => p.y) };
+}
+
+/** Uniform Catmull-Rom interpolation of one scalar channel. */
+function catmullRom(p0, p1, p2, p3, t) {
+  const t2 = t * t;
+  const t3 = t2 * t;
+  return (
+    0.5 *
+    (2 * p1 +
+      (-p0 + p2) * t +
+      (2 * p0 - 5 * p1 + 4 * p2 - p3) * t2 +
+      (-p0 + 3 * p1 - 3 * p2 + p3) * t3)
+  );
+}
+
+/**
+ * Resample a smooth closed curve through the control vertices.
+ *
+ * Produces the dense outline that is displayed and saved, so a few vertices still
+ * yield a clean curve downstream (metrics, mask, export all read the dense x/y).
+ *
+ * @returns {{x: number[], y: number[]}} dense outline (open loop; no repeated point).
+ */
+export function densifyClosedVertices(vx, vy, { samplesPerSegment = 16 } = {}) {
+  const n = Math.min(vx.length, vy.length);
+  if (n < 3) return { x: [...vx], y: [...vy] };
+
+  const x = [];
+  const y = [];
+  for (let i = 0; i < n; i++) {
+    const p0x = vx[(i - 1 + n) % n];
+    const p0y = vy[(i - 1 + n) % n];
+    const p1x = vx[i];
+    const p1y = vy[i];
+    const p2x = vx[(i + 1) % n];
+    const p2y = vy[(i + 1) % n];
+    const p3x = vx[(i + 2) % n];
+    const p3y = vy[(i + 2) % n];
+    for (let s = 0; s < samplesPerSegment; s++) {
+      const t = s / samplesPerSegment;
+      x.push(catmullRom(p0x, p1x, p2x, p3x, t));
+      y.push(catmullRom(p0y, p1y, p2y, p3y, t));
+    }
+  }
+  return { x, y };
+}
+
+/**
+ * Which edge of the vertex loop a click lands nearest, for inserting a vertex.
+ *
+ * @returns {{index: number, distance: number}} `index` is the vertex the new point
+ *   should be inserted *after* (i.e. the start of the nearest edge).
+ */
+export function nearestEdge(vx, vy, point) {
+  const n = Math.min(vx.length, vy.length);
+  let bestIndex = 0;
+  let bestDist = Infinity;
+  for (let i = 0; i < n; i++) {
+    const a = { x: vx[i], y: vy[i] };
+    const b = { x: vx[(i + 1) % n], y: vy[(i + 1) % n] };
+    const dist = segmentDistance(point, a, b);
+    if (dist < bestDist) {
+      bestDist = dist;
+      bestIndex = i;
+    }
+  }
+  return { index: bestIndex, distance: bestDist };
+}
+
+// -- Line-merge editing -----------------------------------------------------
+//
+// Reshape a contour by drawing an open line near its boundary: the line's two ends
+// snap to the closest points on the contour, and the boundary arc that runs closest
+// to the line is replaced by the line. Drawing the line just outside the boundary
+// bulges it out (adds a region); drawing it just inside bites in (cuts a region).
+
+function nearestIndex(points, pt) {
+  let best = 0;
+  let bestDist = Infinity;
+  for (let i = 0; i < points.length; i++) {
+    const d = (points[i].x - pt.x) ** 2 + (points[i].y - pt.y) ** 2;
+    if (d < bestDist) {
+      bestDist = d;
+      best = i;
+    }
+  }
+  return best;
+}
+
+/** Minimum distance from a point to an open polyline. */
+function pointToPolyline(pt, line) {
+  let best = Infinity;
+  for (let i = 0; i < line.length - 1; i++) {
+    best = Math.min(best, segmentDistance(pt, line[i], line[i + 1]));
+  }
+  return best;
+}
+
+/** Contour vertices from index `from` to `to`, walking forward (wrapping), inclusive. */
+function collectArc(contour, from, to) {
+  const n = contour.length;
+  const out = [];
+  let i = from;
+  while (true) {
+    out.push(contour[i]);
+    if (i === to) break;
+    i = (i + 1) % n;
+  }
+  return out;
+}
+
+/** Mean distance from the vertices of an arc (from→to forward) to the line. */
+function arcMeanDistanceToLine(contour, from, to, line) {
+  const arc = collectArc(contour, from, to);
+  let sum = 0;
+  for (const p of arc) sum += pointToPolyline(p, line);
+  return sum / arc.length;
+}
+
+/**
+ * Merge an open line into a closed contour, replacing the boundary arc nearest the
+ * line. All points are {x, y} in the same (e.g. pixel) space.
+ *
+ * @param {Array<{x:number,y:number}>} contour - closed contour vertices (no repeated point)
+ * @param {Array<{x:number,y:number}>} line - the drawn open polyline (>= 2 points)
+ * @returns {Array<{x:number,y:number}>} the reshaped closed contour, or the original
+ *   contour unchanged when the edit is degenerate (both ends snap to the same vertex).
+ */
+export function mergeLineIntoContour(contour, line) {
+  const n = contour.length;
+  if (n < 3 || !line || line.length < 2) return contour;
+
+  const a = nearestIndex(contour, line[0]);
+  const b = nearestIndex(contour, line[line.length - 1]);
+  if (a === b) return contour; // ends land on the same vertex — nothing to split.
+
+  // Of the two arcs between the snap points, replace the one the line runs closest
+  // to (the boundary the user drew over); keep the other.
+  const distForward = arcMeanDistanceToLine(contour, a, b, line); // a→…→b
+  const distBackward = arcMeanDistanceToLine(contour, b, a, line); // b→…→a
+
+  if (distForward <= distBackward) {
+    // Replace a→b; keep b→a. Line runs a-side → b-side, then follow the kept arc.
+    return [...line, ...collectArc(contour, b, a)];
+  }
+  // Replace b→a; keep a→b. Walk the kept arc a→b, then back along the reversed line.
+  return [...collectArc(contour, a, b), ...[...line].reverse()];
+}


### PR DESCRIPTION
Added review and correct cards.

Review:
- Create a review queue to look at images or instances
- Opens up a new viewer showing either one imager or one instance with options to accept or send back with a reason for rejection

Correct:
- Collects the rejections
- Create a correct queue with filters and recency
- Opens up the annotation page, with the wrong instance being pre-selected in refinement mode
- Users can then refine and select "done" or say "wont fix"

Additional changes:
- tidied up cards in dataset management
- added new context menu point in annotation canvas. User can now refine the mask via slicing.