### PR TITLE
Calibration expanded

### DIFF
--- a/src/api/calibration.js
+++ b/src/api/calibration.js
@@ -1,0 +1,183 @@
+/**
+ * API client functions for image calibration.
+ *
+ * The generalisation of api/scale.js: scale is one calibration kind among
+ * several, and every kind goes through the same four endpoints. The kind is a
+ * path segment rather than a per-kind function, so a kind added on the server
+ * needs no change here.
+ *
+ * api/scale.js is still used for the draw-a-line flow, which has its own
+ * endpoint (the server derives the scale from two points and a distance).
+ *
+ * All fetch() calls live here — never in components or stores.
+ */
+import { getAuthHeaders, handleApiError } from './util';
+import { API_BASE_URL } from './config';
+
+/**
+ * Describe every calibration kind the server supports.
+ *
+ * Drives the ordering and the copy of the Calibrate tab's cards, and lets the
+ * client at least name a kind it has no purpose-built card for.
+ *
+ * @returns {Promise<{kinds: Array<Object>}>}
+ */
+export const fetchCalibrationKinds = async () => {
+  const response = await fetch(`${API_BASE_URL}/calibration/kinds`, {
+    headers: getAuthHeaders(),
+  });
+  return handleApiError(response);
+};
+
+/**
+ * Every kind's state for one image — one entry per kind, calibrated or not.
+ *
+ * @param {number} imageId
+ * @returns {Promise<{image_id: number, dataset_id: number, calibrations: Array<Object>,
+ *                    calibrated_count: number, total_count: number}>}
+ */
+export const fetchImageCalibrations = async (imageId) => {
+  const response = await fetch(`${API_BASE_URL}/calibration/image/${imageId}`, {
+    headers: getAuthHeaders(),
+  });
+  return handleApiError(response);
+};
+
+/**
+ * Set (or replace) one calibration on one image.
+ *
+ * Parameters are validated server-side by the kind, so this passes them through
+ * untouched rather than duplicating the shapes here.
+ *
+ * @param {number} imageId
+ * @param {string} kind    Registry key, e.g. 'scale' | 'intensity' | 'color'.
+ * @param {Object} params  Kind-specific parameters.
+ * @param {string} source  'manual' | 'measured' | 'dataset' | 'file_metadata'.
+ * @returns {Promise<{message: string, params: Object, description: string,
+ *                    metrics_invalidated: number}>}
+ */
+export const setImageCalibration = async (imageId, kind, params, source = 'manual') => {
+  const response = await fetch(`${API_BASE_URL}/calibration/image/${imageId}/${kind}`, {
+    method: 'PUT',
+    headers: getAuthHeaders({ 'Content-Type': 'application/json' }),
+    body: JSON.stringify({ params, source }),
+  });
+  return handleApiError(response);
+};
+
+/**
+ * Remove one calibration, returning the image to its uncalibrated reading.
+ *
+ * @param {number} imageId
+ * @param {string} kind
+ * @returns {Promise<{message: string, cleared: boolean, metrics_invalidated: number}>}
+ */
+export const clearImageCalibration = async (imageId, kind) => {
+  const response = await fetch(`${API_BASE_URL}/calibration/image/${imageId}/${kind}`, {
+    method: 'DELETE',
+    headers: getAuthHeaders(),
+  });
+  return handleApiError(response);
+};
+
+/**
+ * Apply one calibration to every image in a dataset.
+ *
+ * @param {number} datasetId
+ * @param {string} kind
+ * @param {Object} params
+ * @returns {Promise<{message: string, images_updated: number, metrics_invalidated: number}>}
+ */
+export const applyCalibrationToDataset = async (datasetId, kind, params) => {
+  const response = await fetch(`${API_BASE_URL}/calibration/dataset/${kind}`, {
+    method: 'POST',
+    headers: getAuthHeaders({ 'Content-Type': 'application/json' }),
+    body: JSON.stringify({ dataset_id: datasetId, params }),
+  });
+  return handleApiError(response);
+};
+
+/**
+ * Average a disc of pixels around a point, for use as a calibration reference.
+ *
+ * Sampled server-side from the original file rather than in the browser from the
+ * rendered <img>: the canvas shows a scaled, possibly re-encoded copy, and
+ * reading a reference patch off that would calibrate the display, not the data.
+ *
+ * @param {number} imageId
+ * @param {number} x        Sample centre x, in image pixels.
+ * @param {number} y        Sample centre y, in image pixels.
+ * @param {number} radius   Radius of the averaged disc, in image pixels.
+ * @param {string} forKind  Kind being calibrated. Stages ordered before it are
+ *                          applied first, so the sample is read in the space
+ *                          that kind's parameters will act on.
+ * @returns {Promise<{mean_rgb: number[], std_rgb: number[], mean_intensity: number,
+ *                    n_pixels: number, stages_applied: string[]}>}
+ */
+export const sampleCalibrationPatch = async (imageId, x, y, radius, forKind) => {
+  const response = await fetch(`${API_BASE_URL}/calibration/image/${imageId}/sample`, {
+    method: 'POST',
+    headers: getAuthHeaders({ 'Content-Type': 'application/json' }),
+    body: JSON.stringify({ x, y, radius, for_kind: forKind ?? null }),
+  });
+  return handleApiError(response);
+};
+
+/**
+ * Read every patch of a reference card at once.
+ *
+ * One request rather than one per patch: the server decodes the image and applies
+ * the preceding calibration stages a single time, which for a twenty-patch card is
+ * the difference between one decode and twenty.
+ *
+ * @param {number} imageId
+ * @param {Array<[number, number]>} points  Patch centres in image pixels, card order.
+ * @param {number} radius
+ * @param {string} forKind
+ * @returns {Promise<{samples: Array<Object>, stages_applied: string[]}>}
+ */
+export const sampleCalibrationPatches = async (imageId, points, radius, forKind) => {
+  const response = await fetch(`${API_BASE_URL}/calibration/image/${imageId}/sample_batch`, {
+    method: 'POST',
+    headers: getAuthHeaders({ 'Content-Type': 'application/json' }),
+    body: JSON.stringify({ points, radius, for_kind: forKind ?? null }),
+  });
+  return handleApiError(response);
+};
+
+/**
+ * How a dataset calibrates each kind — the strategy new calibrations start from.
+ *
+ * @param {number} datasetId
+ * @returns {Promise<{dataset_id: number, defaults: Object}>}
+ */
+export const fetchDatasetCalibrationDefaults = async (datasetId) => {
+  const response = await fetch(
+    `${API_BASE_URL}/calibration/dataset/${datasetId}/defaults`,
+    { headers: getAuthHeaders() },
+  );
+  return handleApiError(response);
+};
+
+/**
+ * Choose the strategy (and reference card) a dataset calibrates one kind with.
+ *
+ * Deliberately does not touch existing calibrations: changing the default is a
+ * choice about future work, not a correction to past work.
+ *
+ * @param {number} datasetId
+ * @param {string} kind
+ * @param {Object} defaults  e.g. { strategy: 'gray_wedge', card: 'kodak_q13' }
+ * @returns {Promise<{message: string, defaults: Object}>}
+ */
+export const setDatasetCalibrationDefaults = async (datasetId, kind, defaults) => {
+  const response = await fetch(
+    `${API_BASE_URL}/calibration/dataset/${datasetId}/defaults/${kind}`,
+    {
+      method: 'PUT',
+      headers: getAuthHeaders({ 'Content-Type': 'application/json' }),
+      body: JSON.stringify({ defaults }),
+    },
+  );
+  return handleApiError(response);
+};

--- a/src/components/annotationPage/canvas/CanvasContainer.jsx
+++ b/src/components/annotationPage/canvas/CanvasContainer.jsx
@@ -11,6 +11,7 @@ import RefinementOverlay from './RefinementOverlay';
 import EditableContourOverlay from './EditableContourOverlay';
 import LineEditCanvas from './LineEditCanvas';
 import ScaleCalibrationOverlay from './ScaleCalibrationOverlay';
+import PatchPickOverlay from './PatchPickOverlay';
 import ScaleBarIndicator from './ScaleBarIndicator';
 import useAIAnnotationShortcuts from '../../../hooks/useAIAnnotationShortcuts';
 import useFocusModeEscape from '../../../hooks/useFocusModeEscape';
@@ -22,6 +23,7 @@ import {
   useRefinementModeActive,
   useFocusModeActive,
   useLineEditActive,
+  useWorkspaceMode,
 } from '../../../stores/selectors/annotationSelectors';
 
 /**
@@ -40,6 +42,13 @@ const CanvasContainer = ({ imageObject, currentImage, zoomLevel, panOffset }) =>
   const focusModeActive = useFocusModeActive();
   const lineEditActive = useLineEditActive();
   const setCursorPosition = useSetCursorPosition();
+  const workspaceMode = useWorkspaceMode();
+
+  // Calibrate mode borrows the canvas for measuring, not for annotating. The
+  // drawing surfaces are gated on the mode rather than only on the tool because
+  // stepping to another image resets the tool to 'ai_annotation', which would
+  // otherwise put the prompt canvas back over the calibration overlays.
+  const annotating = workspaceMode !== 'calibrate';
 
   useAIAnnotationShortcuts();
   useFocusModeEscape();
@@ -95,7 +104,7 @@ const CanvasContainer = ({ imageObject, currentImage, zoomLevel, panOffset }) =>
           draggable={false}
         />
 
-        {currentTool !== 'ai_annotation' && <PromptOverlay canvasRef={canvasRef} />}
+        {annotating && currentTool !== 'ai_annotation' && <PromptOverlay canvasRef={canvasRef} />}
       </div>
 
       {/* Overlays sit outside the transform so their own coordinate maths holds. */}
@@ -109,11 +118,12 @@ const CanvasContainer = ({ imageObject, currentImage, zoomLevel, panOffset }) =>
       {lineEditActive && <LineEditCanvas />}
 
       <ScaleCalibrationOverlay canvasRef={canvasRef} zoomLevel={zoomLevel} panOffset={panOffset} />
+      <PatchPickOverlay canvasRef={canvasRef} />
       <ScaleBarIndicator canvasRef={canvasRef} zoomLevel={zoomLevel} />
       <InferenceScanOverlay containerRef={containerRef} />
       <ObjectContextMenu />
 
-      {currentTool === 'ai_annotation' && (
+      {annotating && currentTool === 'ai_annotation' && (
         <div
           className="absolute inset-0 pointer-events-none"
           /* Focus mode lifts the prompt canvas above the dim (z40) but below the
@@ -132,7 +142,7 @@ const CanvasContainer = ({ imageObject, currentImage, zoomLevel, panOffset }) =>
         </div>
       )}
 
-      {currentTool === 'manual_drawing' && (
+      {annotating && currentTool === 'manual_drawing' && (
         <div className="absolute inset-0 pointer-events-auto">
           <ManualDrawCanvas />
         </div>

--- a/src/components/annotationPage/canvas/PatchPickOverlay.jsx
+++ b/src/components/annotationPage/canvas/PatchPickOverlay.jsx
@@ -1,0 +1,241 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { sampleCalibrationPatch } from '../../../api/calibration';
+import { useToast } from '../../../contexts/ToastContext';
+import {
+  useActiveCalibrationKind,
+  useActivePatchPick,
+  useAddWedgeEnd,
+  useCalibrationEntries,
+  useCancelPatchPick,
+  useCurrentImageId,
+  useImageObject,
+  useSampleRadius,
+  useSetPendingSample,
+  useSetWedgePoint,
+  useWedgeState,
+  useWorkspaceMode,
+} from '../../../stores/selectors/annotationSelectors';
+
+/**
+ * Canvas half of the calibration measurements.
+ *
+ * The drawer arms a pick; this captures the clicks and converts them to image
+ * pixels. It handles three shapes of measurement:
+ *
+ *   role        one named reference (the two-patch strategy's black/white/neutral)
+ *   wedge_ends  the two ends of a reference card, from which every patch centre
+ *               between them is derived
+ *   wedge_patch one card patch, to correct a disc that landed badly
+ *
+ * Whatever the mode, the *averaging* happens server-side on the original file, not
+ * here on the rendered `<img>`: the canvas shows a scaled and possibly re-encoded
+ * copy, and a reference read off that would calibrate the display rather than the
+ * data. The only thing this component contributes is *where*.
+ *
+ * It also draws a placed card's discs whenever Calibrate mode is open, armed or
+ * not, because seeing where the twenty samples actually land is the only way to
+ * catch a card that is rotated, foreshortened, or one patch out.
+ *
+ * Sits at z-85, above the scale calibration overlay (z-80), so the two can never
+ * both be capturing clicks — arming one is what cancels the other.
+ */
+const PatchPickOverlay = ({ canvasRef }) => {
+  const mode = useWorkspaceMode();
+  const activePick = useActivePatchPick();
+  const activeKind = useActiveCalibrationKind();
+  const cancelPatchPick = useCancelPatchPick();
+  const setPendingSample = useSetPendingSample();
+  const addWedgeEnd = useAddWedgeEnd();
+  const setWedgePoint = useSetWedgePoint();
+  const sampleRadius = useSampleRadius();
+  const currentImageId = useCurrentImageId();
+  const imageObject = useImageObject();
+  const wedge = useWedgeState();
+  const entries = useCalibrationEntries();
+  const { addToast } = useToast();
+
+  const containerRef = useRef(null);
+  const [cursor, setCursor] = useState(null);
+  const [sampling, setSampling] = useState(false);
+
+  const calibrating = mode === 'calibrate';
+
+  /** How many patches the selected reference card has, for the two-click placement. */
+  const patchCount = (() => {
+    const entry = entries.find((item) => item.kind === (activePick?.kind || activeKind));
+    if (!entry?.cards?.length) return 0;
+    const key = entry.params?.card || entry.dataset_defaults?.card || entry.default_card;
+    const card = entry.cards.find((item) => item.card === key) || entry.cards[0];
+    return card?.neutral_patch_count || 0;
+  })();
+
+  /** Container-relative point -> image pixels, via the rendered image rect. */
+  const containerToImagePx = useCallback((containerX, containerY) => {
+    if (!canvasRef?.current || !containerRef.current) return null;
+    const imageRect = canvasRef.current.getBoundingClientRect();
+    const containerRect = containerRef.current.getBoundingClientRect();
+    if (!imageRect.width || !imageRect.height) return null;
+
+    const relX = containerX + containerRect.left - imageRect.left;
+    const relY = containerY + containerRect.top - imageRect.top;
+    const imgW = imageObject?.width || imageObject?.naturalWidth || 1;
+    const imgH = imageObject?.height || imageObject?.naturalHeight || 1;
+    return {
+      x: (relX * imgW) / imageRect.width,
+      y: (relY * imgH) / imageRect.height,
+    };
+  }, [canvasRef, imageObject]);
+
+  /** Image pixels -> container-relative, for drawing a placed card back. */
+  const imagePxToContainer = useCallback((point) => {
+    if (!canvasRef?.current || !containerRef.current) return null;
+    const imageRect = canvasRef.current.getBoundingClientRect();
+    const containerRect = containerRef.current.getBoundingClientRect();
+    const imgW = imageObject?.width || imageObject?.naturalWidth || 1;
+    const imgH = imageObject?.height || imageObject?.naturalHeight || 1;
+    return {
+      x: (point.x * imageRect.width) / imgW + imageRect.left - containerRect.left,
+      y: (point.y * imageRect.height) / imgH + imageRect.top - containerRect.top,
+    };
+  }, [canvasRef, imageObject]);
+
+  /** How many screen pixels the sample radius currently covers. */
+  const screenRadius = useCallback(() => {
+    if (!canvasRef?.current) return sampleRadius;
+    const rect = canvasRef.current.getBoundingClientRect();
+    const imgW = imageObject?.width || imageObject?.naturalWidth || 1;
+    if (!rect.width || !imgW) return sampleRadius;
+    return Math.max(2, (sampleRadius * rect.width) / imgW);
+  }, [canvasRef, imageObject, sampleRadius]);
+
+  const handleMouseMove = useCallback((event) => {
+    const rect = containerRef.current?.getBoundingClientRect();
+    if (!rect) return;
+    setCursor({ x: event.clientX - rect.left, y: event.clientY - rect.top });
+  }, []);
+
+  const handleClick = useCallback(async (event) => {
+    if (!activePick || sampling || !currentImageId) return;
+    const rect = containerRef.current?.getBoundingClientRect();
+    if (!rect) return;
+    const point = containerToImagePx(event.clientX - rect.left, event.clientY - rect.top);
+    if (!point) return;
+
+    if (activePick.mode === 'wedge_ends') {
+      addWedgeEnd(point, patchCount);
+      return;
+    }
+    if (activePick.mode === 'wedge_patch') {
+      // The drawer's sampler notices the missing reading and re-reads this one.
+      setWedgePoint(activePick.index, point);
+      return;
+    }
+
+    setSampling(true);
+    try {
+      const sample = await sampleCalibrationPatch(
+        currentImageId, point.x, point.y, sampleRadius, activePick.kind,
+      );
+      setPendingSample(activePick.kind, activePick.role, sample);
+    } catch (error) {
+      addToast({ message: error.message || 'Could not sample that point.', type: 'error' });
+    } finally {
+      setSampling(false);
+    }
+  }, [activePick, sampling, currentImageId, containerToImagePx, sampleRadius, patchCount,
+      addWedgeEnd, setWedgePoint, setPendingSample, addToast]);
+
+  // Escape disarms, matching the scale calibration overlay.
+  useEffect(() => {
+    if (!activePick) return undefined;
+    const onKeyDown = (event) => {
+      if (event.key === 'Escape') cancelPatchPick();
+    };
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, [activePick, cancelPatchPick]);
+
+  // Nothing to capture and nothing placed to show.
+  if (!activePick && !(calibrating && wedge.points.length)) return null;
+
+  const radius = screenRadius();
+  const placed = wedge.points.map(imagePxToContainer);
+
+  return (
+    <div
+      ref={containerRef}
+      className={`absolute inset-0 ${activePick ? 'cursor-crosshair' : 'pointer-events-none'}`}
+      style={{ zIndex: 85 }}
+      onClick={activePick ? handleClick : undefined}
+      onMouseMove={activePick ? handleMouseMove : undefined}
+      onMouseLeave={() => setCursor(null)}
+    >
+      <svg className="absolute inset-0 w-full h-full pointer-events-none">
+        {/* A placed reference card: every disc that will be averaged, at true size. */}
+        {placed.map((point, index) => point && (
+          <circle
+            key={index}
+            cx={point.x}
+            cy={point.y}
+            r={radius}
+            fill="none"
+            stroke={activePick?.mode === 'wedge_patch' && activePick.index === index
+              ? '#f59e0b' : '#38bdf8'}
+            strokeWidth={activePick?.mode === 'wedge_patch' && activePick.index === index
+              ? 2.5 : 1.25}
+            opacity={0.9}
+          />
+        ))}
+
+        {/* The first end of a card, while waiting for the second. */}
+        {wedge.ends.length === 1 && activePick?.mode === 'wedge_ends' && (() => {
+          const first = imagePxToContainer(wedge.ends[0]);
+          if (!first) return null;
+          return (
+            <>
+              <circle cx={first.x} cy={first.y} r={radius} fill="rgba(56,189,248,0.16)"
+                      stroke="#38bdf8" strokeWidth="1.5" />
+              {cursor && (
+                <line x1={first.x} y1={first.y} x2={cursor.x} y2={cursor.y}
+                      stroke="#38bdf8" strokeWidth="1.5" strokeDasharray="6,4" />
+              )}
+            </>
+          );
+        })()}
+
+        {cursor && activePick && (
+          <>
+            <circle cx={cursor.x} cy={cursor.y} r={radius}
+                    fill="rgba(56,189,248,0.16)" stroke="#38bdf8" strokeWidth="1.5" />
+            <circle cx={cursor.x} cy={cursor.y} r="1.5" fill="#38bdf8" />
+          </>
+        )}
+      </svg>
+
+      {activePick && (
+        <div className="absolute top-4 left-1/2 -translate-x-1/2 pointer-events-none">
+          <div className="flex items-center gap-2 px-4 py-2 rounded-full bg-accent text-onAccent text-sm font-medium shadow-lg">
+            <span>{instructionFor(activePick, wedge, patchCount, sampling, sampleRadius)}</span>
+            <span className="text-onAccent opacity-70 text-xs ml-2">ESC to cancel</span>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+/** What to ask for next, in terms of the card rather than of the interaction. */
+const instructionFor = (pick, wedge, patchCount, sampling, radius) => {
+  if (sampling) return 'Reading the patch…';
+  if (pick.mode === 'wedge_ends') {
+    return wedge.ends.length === 0
+      ? 'Click the centre of the lightest patch'
+      : `Click the centre of the darkest patch (${patchCount} of ${patchCount})`;
+  }
+  if (pick.mode === 'wedge_patch') {
+    return `Click where patch ${pick.index + 1} actually is`;
+  }
+  return `Click the ${pick.role} patch — averaged over ${radius} px`;
+};
+
+export default PatchPickOverlay;

--- a/src/components/annotationPage/workspace/CalibrationDrawer.jsx
+++ b/src/components/annotationPage/workspace/CalibrationDrawer.jsx
@@ -1,0 +1,251 @@
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { AlertTriangle, ChevronLeft, Layers, Loader2, Trash2 } from 'lucide-react';
+import ConfirmDialog from './ConfirmDialog';
+import useCalibrationState from './useCalibrationState';
+import { BODIES, FallbackBody } from './calibrationKindBodies';
+import {
+  useActiveCalibrationKind,
+  useActivePatchPick,
+  useSampleRadius,
+  useSetActiveCalibrationKind,
+  useSetSampleRadius,
+  useToggleLeftDrawer,
+  useWedgeState,
+} from '../../../stores/selectors/annotationSelectors';
+
+/**
+ * The Calibrate drawer — the controls for whichever calibration the rail selected.
+ *
+ * Takes the place of the annotation tool-options drawer while in Calibrate mode,
+ * which is what makes calibration read as a tool rather than as a product: pick it
+ * on the rail, configure it here, measure it on the canvas. The right panel is
+ * left alone for the objects and label taxonomy, which are still worth seeing.
+ *
+ * Everything except the strategy controls is driven by the registry entry the
+ * server returned — label, summary, affected metrics, whether it can be
+ * propagated — so a kind added on the server appears here with its own copy, and
+ * a kind this build has no controls for falls back to a read-only view rather
+ * than vanishing.
+ */
+
+/** How a calibration was obtained, in words the drawer can show. */
+const SOURCE_LABELS = {
+  measured: 'measured on this image',
+  manual: 'entered by hand',
+  dataset: 'applied dataset-wide',
+  file_metadata: 'read from file metadata',
+};
+
+const CalibrationDrawer = () => {
+  const {
+    entries, loading, error,
+    save, clear, applyToDataset, saveDatasetDefaults, sampleWedge, resampleWedgePatch,
+  } = useCalibrationState();
+
+  const activeKind = useActiveCalibrationKind();
+  const setActiveKind = useSetActiveCalibrationKind();
+  const toggleDrawer = useToggleLeftDrawer();
+  const sampleRadius = useSampleRadius();
+  const setSampleRadius = useSetSampleRadius();
+  const activePick = useActivePatchPick();
+  const wedge = useWedgeState();
+
+  const [confirmClear, setConfirmClear] = useState(false);
+  const [applying, setApplying] = useState(false);
+
+  const { datasetId: datasetIdParam } = useParams();
+  const datasetId = datasetIdParam ? Number(datasetIdParam) : null;
+
+  // Land on the first uncalibrated kind rather than on nothing, so opening
+  // Calibrate mode already shows the thing most likely to need attention.
+  useEffect(() => {
+    if (activeKind || !entries.length) return;
+    const next = entries.find((entry) => !entry.calibrated) || entries[0];
+    setActiveKind(next.kind);
+  }, [activeKind, entries, setActiveKind]);
+
+  const entry = entries.find((item) => item.kind === activeKind) || null;
+  const Body = entry ? (BODIES[entry.kind] || FallbackBody) : null;
+
+  return (
+    <div className="w-[252px] flex-none flex flex-col bg-p1 border-r border-ln min-h-0">
+      <div className="h-8 flex-none flex items-center gap-[7px] px-[10px] border-b border-ln">
+        <span className="flex-1 text-sect font-bold tracking-[.09em] uppercase text-t3 truncate">
+          {entry ? entry.label : 'Calibration'}
+        </span>
+        {entry && (
+          <span
+            className={`h-[16px] px-[5px] inline-flex items-center rounded-4 text-meta font-semibold ${
+              entry.calibrated ? 'bg-okBg text-ok' : 'bg-well text-t3'
+            }`}
+          >
+            {entry.calibrated ? 'set' : 'not set'}
+          </span>
+        )}
+        <button
+          type="button"
+          onClick={toggleDrawer}
+          aria-label="Collapse calibration options"
+          className="w-[22px] h-[22px] flex items-center justify-center rounded-5 text-t3 hover:bg-hv hover:text-ac transition-colors duration-150"
+        >
+          <ChevronLeft size={14} strokeWidth={1.9} />
+        </button>
+      </div>
+
+      <div className="flex-1 min-h-0 overflow-y-auto p-[10px] flex flex-col gap-[10px]">
+        {error && (
+          <div className="flex items-start gap-[6px] px-[9px] py-[7px] rounded-7 bg-errBg border border-errLn">
+            <AlertTriangle size={13} className="text-err flex-none mt-[2px]" />
+            <span className="text-meta text-t1">{error}</span>
+          </div>
+        )}
+
+        {loading && !entries.length && (
+          <div className="flex items-center gap-[6px] text-meta text-t3">
+            <Loader2 size={13} className="animate-spin" />
+            Loading calibrations…
+          </div>
+        )}
+
+        {!loading && !entries.length && !error && (
+          <p className="text-meta text-t3">No calibrations are available for this image.</p>
+        )}
+
+        {entry && (
+          <>
+            <p className="text-meta text-t3 leading-[1.45]">{entry.summary}</p>
+
+            {entry.calibrated && (
+              <div className="px-[8px] py-[6px] rounded-6 bg-well border border-ln2 flex flex-col gap-[2px]">
+                <span className="font-mono text-ctl text-t1 break-words">
+                  {entry.description}
+                </span>
+                <span className="text-meta text-t3">
+                  {SOURCE_LABELS[entry.source] || 'source unknown'}
+                  {entry.created_by ? ` · ${entry.created_by}` : ''}
+                  {entry.updated_at ? ` · ${entry.updated_at.slice(0, 10)}` : ''}
+                </span>
+              </div>
+            )}
+
+            <Body
+              entry={entry}
+              onSave={(params, source) => save(entry.kind, params, source)}
+              onSaveDatasetDefault={(defaults) =>
+                saveDatasetDefaults(datasetId, entry.kind, defaults)}
+            />
+
+            <label className="flex items-center gap-[6px] text-meta text-t3">
+              Patch radius
+              <input
+                type="number"
+                min="1"
+                max="256"
+                value={sampleRadius}
+                onChange={(event) => setSampleRadius(event.target.value)}
+                title="Radius of the averaged reference patch, in image pixels"
+                className="w-[48px] h-[20px] px-[5px] rounded-5 bg-well border border-ln2 font-mono text-meta text-t1 outline-none focus:border-ac"
+              />
+              px
+            </label>
+
+            {entry.affects_metrics?.length > 0 && (
+              <p className="text-meta text-t3 leading-[1.45]">
+                Affects {entry.affects_metrics.join(', ')}. Changing it flags those
+                measurements for recomputation; nothing is rewritten until then, and
+                the image file is never modified.
+              </p>
+            )}
+
+            <div className="flex items-center gap-[6px] pt-[8px] border-t border-ln">
+              {entry.dataset_propagatable && (
+                <button
+                  type="button"
+                  disabled={!entry.calibrated || !datasetId || applying}
+                  title={entry.calibrated
+                    ? 'Copy this calibration to every image in the dataset'
+                    : 'Set the calibration first'}
+                  onClick={async () => {
+                    setApplying(true);
+                    await applyToDataset(datasetId, entry.kind, entry.params);
+                    setApplying(false);
+                  }}
+                  className="h-7 px-[9px] flex items-center gap-[5px] rounded-7 border border-ln2 text-btn font-semibold text-t2 hover:bg-hv hover:text-t1 transition-colors disabled:opacity-35 disabled:cursor-not-allowed disabled:hover:bg-transparent"
+                >
+                  <Layers size={13} strokeWidth={1.9} />
+                  {applying ? 'Applying…' : 'Apply to dataset'}
+                </button>
+              )}
+
+              <span className="flex-1" />
+
+              <button
+                type="button"
+                disabled={!entry.calibrated}
+                onClick={() => setConfirmClear(true)}
+                aria-label={`Clear ${entry.label} calibration`}
+                className="w-7 h-7 flex items-center justify-center rounded-7 text-t3 hover:bg-hv hover:text-err transition-colors disabled:opacity-35 disabled:cursor-not-allowed disabled:hover:bg-transparent disabled:hover:text-t3"
+              >
+                <Trash2 size={13} strokeWidth={1.9} />
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+
+      <ConfirmDialog
+        open={confirmClear}
+        title={entry ? `Clear the ${entry.label.toLowerCase()} calibration?` : ''}
+        body={
+          'This image goes back to its uncalibrated reading, and the measurements '
+          + 'that depend on it are flagged for recomputation. The image file itself '
+          + 'is unaffected.'
+        }
+        confirmLabel="Clear"
+        onCancel={() => setConfirmClear(false)}
+        onConfirm={async () => {
+          await clear(entry.kind);
+          setConfirmClear(false);
+        }}
+      />
+
+      <WedgeSampler
+        entry={entry}
+        wedge={wedge}
+        activePick={activePick}
+        sampleWedge={sampleWedge}
+        resamplePatch={resampleWedgePatch}
+      />
+    </div>
+  );
+};
+
+/**
+ * Reads whichever reference-card patches do not have a reading yet.
+ *
+ * Renders nothing — it exists so that placing the card (a canvas interaction) and
+ * reading it (a request) stay one action from the user's point of view, without
+ * the overlay having to know about the card profile or the batch endpoint.
+ *
+ * One re-placed patch is re-read on its own; anything more goes through the batch
+ * endpoint, which decodes the image once instead of once per patch.
+ */
+const WedgeSampler = ({ entry, wedge, activePick, sampleWedge, resamplePatch }) => {
+  const { points, samples, sampling } = wedge;
+
+  useEffect(() => {
+    if (!entry || activePick || sampling || !points.length) return;
+    const missing = points
+      .map((_, index) => index)
+      .filter((index) => !samples[index]);
+    if (!missing.length) return;
+
+    if (missing.length === 1) resamplePatch(missing[0], points[missing[0]], entry.kind);
+    else sampleWedge(points, entry.kind);
+  }, [entry, points, samples, sampling, activePick, sampleWedge, resamplePatch]);
+
+  return null;
+};
+
+export default CalibrationDrawer;

--- a/src/components/annotationPage/workspace/Filmstrip.jsx
+++ b/src/components/annotationPage/workspace/Filmstrip.jsx
@@ -2,17 +2,8 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { ChevronDown } from 'lucide-react';
 import useWorkspaceImageNav from './useWorkspaceImageNav';
 import { getImageById } from '../../../api/images';
-import { getImageStatus } from '../../../utils/imageStatus';
+import { getCoarseStatus, getImageStatus } from '../../../utils/imageStatus';
 import { useToggleFilmstrip } from '../../../stores/selectors/annotationSelectors';
-
-/** Status dot colours, mapped from the shared image-status lifecycle. */
-const STATUS_DOT = {
-  finished: 'var(--ok)',
-  reviewable: 'var(--warn)',
-  in_progress: 'var(--warn)',
-  rejected: 'var(--rev)',
-  not_started: 'var(--t3)',
-};
 
 /**
  * Bottom image navigator.
@@ -20,6 +11,12 @@ const STATUS_DOT = {
  * Thumbnails load lazily through an IntersectionObserver rather than the old
  * gallery's fixed 200ms-apart timer chain, which fired a request for every
  * image in the dataset whether or not it was ever scrolled into view.
+ *
+ * Tiles carry the three-state coarse status, matching the pill in the toolbar
+ * above rather than the five-state lifecycle the dataset manager shows. That is
+ * the model this page is meant to use — while annotating, whether a mask is
+ * awaiting review or was sent back is noise against "is this image done?" — and
+ * three shapes stay legible on a 62x46 thumbnail where five colours did not.
  */
 const Filmstrip = () => {
   const { imageList, currentIndex, goToImage } = useWorkspaceImageNav();
@@ -102,7 +99,10 @@ const Filmstrip = () => {
       <div ref={stripRef} className="flex-1 min-w-0 flex items-center gap-[7px] overflow-x-auto py-[4px]">
         {imageList.map((image, index) => {
           const active = index === currentIndex;
-          const status = getImageStatus(image);
+          // Resolve through the detailed status first so legacy image shapes
+          // (a bare `finished` flag, a "completed" string) are still understood.
+          const status = getCoarseStatus(getImageStatus(image).key);
+          const StatusIcon = status.icon;
           return (
             <button
               key={image.id}
@@ -116,7 +116,7 @@ const Filmstrip = () => {
               type="button"
               onClick={() => goToImage(image)}
               aria-current={active}
-              title={image.name}
+              title={`${image.name} — ${status.label}`}
               className={`relative w-[62px] h-[46px] flex-none rounded-6 overflow-hidden transition-shadow ${
                 active
                   ? 'shadow-[0_0_0_2px_var(--accent)]'
@@ -134,10 +134,15 @@ const Filmstrip = () => {
                 <span className="block w-full h-full bg-well" />
               )}
 
+              {/* On its own disc: the tile behind it is arbitrary photography,
+                  so a bare icon would sit on whatever the thumbnail happens to
+                  be there and disappear against half of them. */}
               <span
-                className="absolute top-[3px] right-[3px] w-[6px] h-[6px] rounded-full"
-                style={{ background: STATUS_DOT[status.key] || STATUS_DOT.not_started }}
-              />
+                className={`absolute top-[3px] right-[3px] w-[14px] h-[14px] rounded-full
+                  flex items-center justify-center bg-p1 ${status.tone}`}
+              >
+                <StatusIcon size={10} strokeWidth={3} />
+              </span>
               <span className="absolute bottom-0 left-0 max-w-full px-[3px] font-mono text-badge text-white bg-black/60 truncate">
                 {image.name}
               </span>

--- a/src/components/annotationPage/workspace/RightPanel.jsx
+++ b/src/components/annotationPage/workspace/RightPanel.jsx
@@ -11,13 +11,21 @@ import {
   useObjectsList,
 } from '../../../stores/selectors/annotationSelectors';
 
+/**
+ * The panel lists what has been annotated, in every mode.
+ *
+ * Calibration deliberately does not appear here: it is a tool, not a product, so
+ * it lives on the left with the rail and the options drawer. Keeping the objects
+ * and the label taxonomy visible while calibrating also costs nothing — the
+ * canvas is the same canvas, and seeing what is annotated is still useful.
+ */
 const TABS = [
   { id: 'objects', label: 'Objects', icon: Layers },
   { id: 'labels', label: 'Labels', icon: Tag },
 ];
 
 /** The 38px strip the panel collapses to. */
-const CollapsedStrip = ({ onExpand, onPickTab, activeTab, objectCount }) => (
+const CollapsedStrip = ({ onExpand, onPickTab, activeTab, objectCount, tabs }) => (
   <div className="w-[38px] flex-none flex flex-col items-center gap-[4px] py-[6px] bg-p1 border-l border-ln">
     <Tooltip label="Expand panel" shortcut="⌥2" placement="bottomRight">
       <button
@@ -32,7 +40,7 @@ const CollapsedStrip = ({ onExpand, onPickTab, activeTab, objectCount }) => (
 
     <div className="w-[22px] h-px bg-ln2 my-[4px]" />
 
-    {TABS.map(({ id, label, icon: Icon }) => (
+    {tabs.map(({ id, label, icon: Icon }) => (
       <Tooltip key={id} label={label} placement="bottomRight">
         <button
           type="button"
@@ -69,13 +77,18 @@ const RightPanel = () => {
   const setTab = useSetRightTab();
   const objects = useObjectsList();
 
+  // A tab id left over from an earlier build (or an earlier mode) must not blank
+  // the panel out.
+  const activeTab = TABS.some((entry) => entry.id === tab) ? tab : TABS[0].id;
+
   if (!open) {
     return (
       <CollapsedStrip
         onExpand={toggleOpen}
         onPickTab={setTab}
-        activeTab={tab}
+        activeTab={activeTab}
         objectCount={objects.length}
+        tabs={TABS}
       />
     );
   }
@@ -87,7 +100,7 @@ const RightPanel = () => {
         className="h-[34px] flex-none flex items-center gap-[4px] px-[6px] border-b border-ln"
       >
         {TABS.map(({ id, label, icon: Icon }) => {
-          const active = tab === id;
+          const active = activeTab === id;
           return (
             <button
               key={id}
@@ -118,7 +131,7 @@ const RightPanel = () => {
         </button>
       </div>
 
-      {tab === 'objects' ? <ObjectsTab /> : <LabelsTab />}
+      {activeTab === 'objects' ? <ObjectsTab /> : <LabelsTab />}
     </div>
   );
 };

--- a/src/components/annotationPage/workspace/ShortcutSheet.jsx
+++ b/src/components/annotationPage/workspace/ShortcutSheet.jsx
@@ -26,7 +26,7 @@ const GROUPS = [
       { keys: 'E', label: 'Edit the selected contour' },
       { keys: 'R', label: 'Reject (review mode)' },
       { keys: '⌫', label: 'Remove last prompt, or delete the selection' },
-      { keys: 'esc', label: 'Clear the selection or leave focus mode' },
+      { keys: 'esc', label: 'Clear the selection, leave focus mode, or cancel a calibration measurement' },
     ],
   },
   {

--- a/src/components/annotationPage/workspace/StatusBar.jsx
+++ b/src/components/annotationPage/workspace/StatusBar.jsx
@@ -3,6 +3,7 @@ import useRailTools from './useRailTools';
 import { getRailTool } from './toolModel';
 import {
   useActiveLabelId,
+  useCalibrationEntries,
   useDatasetLabels,
   useZoomLevel,
   useCursorPosition,
@@ -10,6 +11,7 @@ import {
   useFilmstripOpen,
   useToggleFilmstrip,
   useImageScale,
+  useSetWorkspaceMode,
   useWebSocketIsReady,
 } from '../../../stores/selectors/annotationSelectors';
 
@@ -17,8 +19,12 @@ import {
  * Monospace status bar under the filmstrip.
  *
  * Reports the active tool and label, the scale calibration (clicking it
- * re-opens calibration, replacing the old ScaleControl button), zoom, cursor
- * position, object count and session health.
+ * re-opens calibration, replacing the old ScaleControl button), the wider
+ * calibration state, zoom, cursor position, object count and session health.
+ *
+ * The calibration readout is what keeps the Calibrate tab from having to be a
+ * gate: most sessions open the image to annotate, so the tab is where you go
+ * when something is wrong or new, and this is what tells you that it is.
  */
 const StatusBar = () => {
   const { railTool, setRailTool } = useRailTools();
@@ -31,9 +37,17 @@ const StatusBar = () => {
   const toggleFilmstrip = useToggleFilmstrip();
   const scale = useImageScale();
   const sessionReady = useWebSocketIsReady();
+  const calibrationEntries = useCalibrationEntries();
+  const setWorkspaceMode = useSetWorkspaceMode();
 
   const activeLabel = labels.find((label) => String(label.id) === String(activeLabelId));
   const calibrated = scale?.unit && scale.unit !== 'px' && scale.scaleX > 0;
+
+  // Entries only exist once the Calibrate tab has loaded them for this image, so
+  // the chip stays hidden rather than claiming "0 calibrated" on an image it has
+  // not looked at yet.
+  const calibratedCount = calibrationEntries.filter((entry) => entry.calibrated).length;
+  const uncalibratedCount = calibrationEntries.length - calibratedCount;
 
   return (
     <div className="h-6 flex-none flex items-center gap-[10px] px-[10px] bg-p1 border-t border-ln font-mono text-sect text-t3 whitespace-nowrap overflow-hidden">
@@ -51,6 +65,19 @@ const StatusBar = () => {
       >
         {calibrated ? `1px = ${scale.scaleX.toFixed(4)} ${scale.unit}` : 'uncalibrated'}
       </button>
+
+      {calibrationEntries.length > 0 && (
+        <button
+          type="button"
+          onClick={() => setWorkspaceMode('calibrate')}
+          title="Open the Calibrate tab"
+          className={`transition-colors duration-150 hover:text-ac ${
+            uncalibratedCount ? 'text-warn' : 'text-ok'
+          }`}
+        >
+          cal {calibratedCount}/{calibrationEntries.length}
+        </button>
+      )}
 
       <span className="tabular-nums">{Math.round(zoomLevel * 100)}%</span>
 

--- a/src/components/annotationPage/workspace/ToolRail.jsx
+++ b/src/components/annotationPage/workspace/ToolRail.jsx
@@ -1,28 +1,37 @@
 import React from 'react';
 import {
+  Check,
   Crosshair,
   Hand,
   Hexagon,
   MousePointer2,
   Paintbrush,
+  Palette,
   Ruler,
   Settings2,
+  SlidersHorizontal,
   Sparkles,
   Spline,
   Square,
+  X,
   ZoomIn,
 } from 'lucide-react';
 import Tooltip from './primitives/Tooltip';
-import { RAIL_TOOLS } from './toolModel';
+import { CALIBRATION_KIND_ICONS, railToolsForMode } from './toolModel';
 import useRailTools from './useRailTools';
 import useSupportedPromptTypes from './useSupportedPromptTypes';
 import {
+  useActiveCalibrationKind,
   useActiveLabelId,
+  useCalibrationEntries,
   useDatasetLabels,
   useLabelColorOverrides,
   useLeftDrawerOpen,
+  useSetActiveCalibrationKind,
+  useSetLeftDrawerOpen,
   useToggleLeftDrawer,
   useSetRightTab,
+  useWorkspaceMode,
 } from '../../../stores/selectors/annotationSelectors';
 import { resolveLabelColor } from './labelColorUtils';
 
@@ -36,6 +45,8 @@ const ICONS = {
   Hand,
   ZoomIn,
   Ruler,
+  Palette,
+  SlidersHorizontal,
 };
 
 const RailButton = ({ tool, active, unsupportedReason, onSelect }) => {
@@ -65,19 +76,81 @@ const RailButton = ({ tool, active, unsupportedReason, onSelect }) => {
   );
 };
 
+/** A rail button that selects a calibration rather than a drawing tool. */
+const CalibrationRailButton = ({ entry, active, onSelect }) => {
+  const Icon = ICONS[CALIBRATION_KIND_ICONS[entry.kind]] || SlidersHorizontal;
+
+  return (
+    <Tooltip
+      label={`${entry.label} — ${entry.calibrated ? 'calibrated' : 'not set'}`}
+    >
+      <button
+        type="button"
+        onClick={() => onSelect(entry.kind)}
+        aria-pressed={active}
+        aria-label={entry.label}
+        className={`relative w-8 h-8 flex items-center justify-center rounded-8 border transition-[background-color,color,border-color] duration-[140ms]
+          ${
+            active
+              ? 'bg-acS border-acLn text-ac'
+              : 'border-transparent text-t2 hover:bg-hv hover:text-t1'
+          }`}
+      >
+        <Icon size={17} strokeWidth={active ? 2 : 1.7} />
+        {/* A tick or a cross, so the rail answers "what is still missing on this
+            image" without opening anything. Shape rather than colour: a 5px dot
+            in two shades was unreadable at this size, and a tick reads at a
+            glance even where the badge sits over the icon behind it. The cross is
+            muted rather than red — uncalibrated is a normal state, not an error. */}
+        <span
+          className={`absolute -bottom-[2px] -right-[2px] w-[12px] h-[12px] rounded-full
+            flex items-center justify-center bg-p1 ${
+              entry.calibrated ? 'text-ok' : 'text-t3'
+            }`}
+        >
+          {entry.calibrated
+            ? <Check size={9} strokeWidth={3.5} />
+            : <X size={9} strokeWidth={3.5} />}
+        </span>
+      </button>
+    </Tooltip>
+  );
+};
+
 /**
  * The 46px tool rail.
  *
  * Holds shapes only; whether a shape becomes a model prompt or is committed as
  * drawn is decided by the AI-assist switch below the divider. See toolModel.js
  * for how a rail selection maps onto the store's tool state.
+ *
+ * Calibrate mode replaces the shape tools with one button per calibration kind
+ * and drops the AI-assist switch. Selecting a calibration opens its controls in
+ * the drawer, which is the same pick-here / configure-there shape the annotation
+ * rail already has — calibration is a tool, not a product, so it belongs on this
+ * side rather than in the panel that lists what has been annotated.
  */
 const ToolRail = () => {
   const { railTool, setRailTool, aiAssist, toggleAssist } = useRailTools();
   const supported = useSupportedPromptTypes();
   const leftDrawerOpen = useLeftDrawerOpen();
   const toggleLeftDrawer = useToggleLeftDrawer();
+  const setLeftDrawerOpen = useSetLeftDrawerOpen();
   const setRightTab = useSetRightTab();
+  const mode = useWorkspaceMode();
+
+  const calibrationEntries = useCalibrationEntries();
+  const activeCalibrationKind = useActiveCalibrationKind();
+  const setActiveCalibrationKind = useSetActiveCalibrationKind();
+
+  const tools = railToolsForMode(mode);
+  const calibrating = mode === 'calibrate';
+
+  // Picking a calibration is only useful if its controls are visible.
+  const selectCalibration = (kind) => {
+    setActiveCalibrationKind(kind);
+    if (activeCalibrationKind !== kind) setLeftDrawerOpen(true);
+  };
 
   const activeLabelId = useActiveLabelId();
   const labels = useDatasetLabels();
@@ -90,7 +163,7 @@ const ToolRail = () => {
 
   return (
     <div className="w-[46px] flex-none flex flex-col items-center gap-[3px] py-[6px] bg-p1 border-r border-ln">
-      {RAIL_TOOLS.map((tool) => (
+      {tools.map((tool) => (
         <div key={tool.id} className={tool.gapAfter ? 'mb-[9px]' : undefined}>
           <RailButton
             tool={tool}
@@ -105,31 +178,49 @@ const ToolRail = () => {
         </div>
       ))}
 
-      <div className="w-[22px] h-px bg-ln2 my-[6px]" />
+      {calibrating && calibrationEntries.length > 0 && (
+        <>
+          <div className="w-[22px] h-px bg-ln2 my-[6px]" />
+          {calibrationEntries.map((entry) => (
+            <CalibrationRailButton
+              key={entry.kind}
+              entry={entry}
+              active={activeCalibrationKind === entry.kind}
+              onSelect={selectCalibration}
+            />
+          ))}
+        </>
+      )}
 
-      <Tooltip
-        label={
-          aiAssist
-            ? 'AI assist on — shapes become model prompts'
-            : 'AI assist off — shapes are saved as drawn'
-        }
-        shortcut="A"
-      >
-        <button
-          type="button"
-          onClick={toggleAssist}
-          aria-pressed={aiAssist}
-          aria-label="Toggle AI assist"
-          className={`w-8 h-8 flex items-center justify-center rounded-8 border transition-[background-color,color,border-color] duration-[140ms]
-            ${
+      {!calibrating && (
+        <>
+          <div className="w-[22px] h-px bg-ln2 my-[6px]" />
+
+          <Tooltip
+            label={
               aiAssist
-                ? 'bg-acS border-acLn text-ac'
-                : 'border-transparent text-t2 hover:bg-hv hover:text-t1'
-            }`}
-        >
-          <Sparkles size={17} strokeWidth={aiAssist ? 2 : 1.7} />
-        </button>
-      </Tooltip>
+                ? 'AI assist on — shapes become model prompts'
+                : 'AI assist off — shapes are saved as drawn'
+            }
+            shortcut="A"
+          >
+            <button
+              type="button"
+              onClick={toggleAssist}
+              aria-pressed={aiAssist}
+              aria-label="Toggle AI assist"
+              className={`w-8 h-8 flex items-center justify-center rounded-8 border transition-[background-color,color,border-color] duration-[140ms]
+                ${
+                  aiAssist
+                    ? 'bg-acS border-acLn text-ac'
+                    : 'border-transparent text-t2 hover:bg-hv hover:text-t1'
+                }`}
+            >
+              <Sparkles size={17} strokeWidth={aiAssist ? 2 : 1.7} />
+            </button>
+          </Tooltip>
+        </>
+      )}
 
       <div className="flex-1" />
 
@@ -149,19 +240,23 @@ const ToolRail = () => {
         </button>
       </Tooltip>
 
-      <Tooltip
-        label={activeLabel ? `Active label — ${activeLabel.name}` : 'No label armed'}
-      >
-        <button
-          type="button"
-          onClick={() => setRightTab('labels')}
-          aria-label="Active label colour"
-          className="w-[26px] h-[26px] mt-[4px] rounded-6 border border-ln2 transition-transform hover:scale-105"
-          style={{ background: activeColor || 'transparent' }}
+      {/* The armed label has no meaning while calibrating, and the Labels tab it
+          jumps to is not among the panel's tabs in that mode. */}
+      {!calibrating && (
+        <Tooltip
+          label={activeLabel ? `Active label — ${activeLabel.name}` : 'No label armed'}
         >
-          {!activeColor && <span className="block w-full h-full rounded-6 bg-well" />}
-        </button>
-      </Tooltip>
+          <button
+            type="button"
+            onClick={() => setRightTab('labels')}
+            aria-label="Active label colour"
+            className="w-[26px] h-[26px] mt-[4px] rounded-6 border border-ln2 transition-transform hover:scale-105"
+            style={{ background: activeColor || 'transparent' }}
+          >
+            {!activeColor && <span className="block w-full h-full rounded-6 bg-well" />}
+          </button>
+        </Tooltip>
+      )}
     </div>
   );
 };

--- a/src/components/annotationPage/workspace/TopToolbar.jsx
+++ b/src/components/annotationPage/workspace/TopToolbar.jsx
@@ -292,9 +292,13 @@ const TopToolbar = () => {
         <ToolbarButton icon={Maximize} label="Reset view" onClick={resetView} />
       </Group>
 
-      {/* Annotate / Review mode */}
+      {/* Calibrate / Annotate / Review.
+          Three views of the same image sharing one canvas and one viewport —
+          switching keeps the zoom, the pan and the selection, which is the whole
+          reason calibration is a mode here rather than a separate page. */}
       <Group>
         {[
+          { id: 'calibrate', label: 'Calibrate' },
           { id: 'annotate', label: 'Annotate' },
           { id: 'review', label: 'Review' },
         ].map(({ id, label }) => {

--- a/src/components/annotationPage/workspace/WorkspaceShell.jsx
+++ b/src/components/annotationPage/workspace/WorkspaceShell.jsx
@@ -3,6 +3,7 @@ import { useParams } from 'react-router-dom';
 import TopToolbar from './TopToolbar';
 import ToolRail from './ToolRail';
 import ToolOptionsDrawer from './ToolOptionsDrawer';
+import CalibrationDrawer from './CalibrationDrawer';
 import RightPanel from './RightPanel';
 import ActionBar from './ActionBar';
 import Filmstrip from './Filmstrip';
@@ -11,6 +12,7 @@ import ReviewBanner from './ReviewBanner';
 import ShortcutSheet from './ShortcutSheet';
 import useWorkspaceShortcuts from './useWorkspaceShortcuts';
 import useArmedLabelAutoApply from './useArmedLabelAutoApply';
+import { useCalibrationSync } from './useCalibrationState';
 import MainCanvas from '../canvas/MainCanvas';
 import CorrectionBar from '../../correction/CorrectionBar';
 import RejectionBanner from '../RejectionBanner';
@@ -24,8 +26,13 @@ import {
   useFilmstripOpen,
   useCurrentImageId,
   useCurrentMaskId,
+  useCurrentTool,
+  useSetCurrentTool,
   useResetWorkspaceForImage,
 } from '../../../stores/selectors/annotationSelectors';
+
+/** The only tools the rail offers in Calibrate mode. See toolModel.js. */
+const CALIBRATE_TOOLS = ['pan', 'zoom', 'set_scale'];
 
 /**
  * The annotation workspace shell.
@@ -44,6 +51,8 @@ const WorkspaceShell = () => {
   const filmstripOpen = useFilmstripOpen();
   const currentImageId = useCurrentImageId();
   const maskId = useCurrentMaskId();
+  const currentTool = useCurrentTool();
+  const setCurrentTool = useSetCurrentTool();
   const resetForImage = useResetWorkspaceForImage();
   const { datasets } = useDataset();
   const { datasetId } = useParams();
@@ -52,12 +61,24 @@ const WorkspaceShell = () => {
   useWorkspaceShortcuts();
   // Applies the armed label to anything segmented while a class is armed.
   useArmedLabelAutoApply();
+  // Loads the image's calibrations here rather than in the Calibrate tab, so the
+  // status bar can report them without the tab ever having been opened.
+  useCalibrationSync();
 
   // Per-image view state (hidden rows, manual ordering, collapse) must not
   // carry over when the user steps to another image.
   useEffect(() => {
     resetForImage();
   }, [currentImageId, resetForImage]);
+
+  // Stepping to another image resets the tool to the annotation default, which
+  // in Calibrate mode is not on the rail at all. Put it back to a tool that is,
+  // so the rail keeps showing what is actually selected.
+  useEffect(() => {
+    if (mode === 'calibrate' && !CALIBRATE_TOOLS.includes(currentTool)) {
+      setCurrentTool('pan');
+    }
+  }, [mode, currentTool, setCurrentTool]);
 
   // RejectionBanner permission-checks against the dataset the route names —
   // `currentDataset` may still be the previously opened one.
@@ -80,7 +101,12 @@ const WorkspaceShell = () => {
 
       <div className="flex-1 min-h-0 flex">
         <ToolRail />
-        {leftDrawerOpen && <ToolOptionsDrawer />}
+        {/* The drawer is the rail's companion in both modes: it configures
+            whatever the rail selected. In Calibrate mode that is a calibration
+            rather than a drawing tool. */}
+        {leftDrawerOpen && (
+          mode === 'calibrate' ? <CalibrationDrawer /> : <ToolOptionsDrawer />
+        )}
 
         <div className="flex-1 min-w-0 flex flex-col bg-canvasbg">
           <div className="flex-1 relative overflow-hidden">

--- a/src/components/annotationPage/workspace/calibrationKindBodies.jsx
+++ b/src/components/annotationPage/workspace/calibrationKindBodies.jsx
@@ -1,0 +1,504 @@
+import React, { useEffect, useState } from 'react';
+import { Pipette, Ruler, Target } from 'lucide-react';
+import {
+  useActivePatchPick,
+  usePendingSamples,
+  useSetCurrentTool,
+  useStartCalibration,
+  useStartPatchPick,
+  useWedgeState,
+} from '../../../stores/selectors/annotationSelectors';
+
+/**
+ * The per-kind controls of the Calibrate drawer.
+ *
+ * Each body owns one kind's controls and hands finished parameters back through
+ * `onSave(params, source)`. Everything shared — header, status, provenance, the
+ * dataset/clear footer — lives in CalibrationDrawer.
+ *
+ * `source` is not cosmetic. A calibration derived from a reference measured in
+ * this frame ('measured') is a different claim from one typed in by hand
+ * ('manual'), and the distinction is what a later reader needs to judge it.
+ */
+
+const UNITS = ['cm', 'mm', 'µm', 'nm', 'm'];
+
+const fieldClass =
+  'h-7 px-[8px] rounded-6 bg-well border border-ln2 font-mono text-ctl text-t1 '
+  + 'outline-none focus:border-ac placeholder:text-t3 min-w-0';
+
+const selectClass =
+  'h-7 px-[6px] rounded-6 bg-well border border-ln2 text-ctl text-t1 '
+  + 'outline-none focus:border-ac w-full';
+
+const primaryButtonClass =
+  'h-7 px-[10px] rounded-7 bg-accent text-onAccent text-btn font-bold '
+  + 'hover:brightness-110 transition-[filter] disabled:opacity-40 '
+  + 'disabled:cursor-not-allowed disabled:hover:brightness-100';
+
+const secondaryButtonClass =
+  'h-7 px-[9px] flex items-center gap-[6px] rounded-7 border border-ln2 text-btn '
+  + 'font-semibold text-t2 hover:bg-hv hover:text-t1 transition-colors '
+  + 'disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-transparent';
+
+const NumberField = ({ label, value, onChange, step = 'any', placeholder }) => (
+  <label className="flex-1 min-w-0 flex flex-col gap-[3px]">
+    <span className="text-meta text-t3">{label}</span>
+    <input
+      type="number"
+      step={step}
+      value={value}
+      placeholder={placeholder}
+      onChange={(event) => onChange(event.target.value)}
+      className={fieldClass}
+    />
+  </label>
+);
+
+const Field = ({ label, help, children }) => (
+  <label className="flex flex-col gap-[3px]">
+    <span className="text-meta text-t3">{label}</span>
+    {children}
+    {help && <span className="text-meta text-t3 leading-[1.45]">{help}</span>}
+  </label>
+);
+
+const Swatch = ({ rgb, size = 18 }) => (
+  <span
+    className="rounded-5 border border-ln2 flex-none block"
+    style={{
+      width: size,
+      height: size,
+      background: rgb ? `rgb(${rgb.map((v) => Math.round(v)).join(',')})` : 'transparent',
+    }}
+  />
+);
+
+/** The value a sample should be read as. See the service: the median, not the mean. */
+const sampleRgb = (sample) => sample?.median_rgb || sample?.mean_rgb || null;
+
+// ---------------------------------------------------------------------------
+// scale
+// ---------------------------------------------------------------------------
+
+/**
+ * Scale: measured by drawing a line of known length, or typed in directly.
+ *
+ * "Measure on image" hands off to the existing draw-a-line overlay rather than
+ * reimplementing it — that flow already handles the two clicks, the live preview
+ * and the known-distance prompt, and it stays reachable from the status bar for
+ * people who never open this drawer.
+ */
+export const ScaleBody = ({ entry, onSave }) => {
+  const startCalibration = useStartCalibration();
+  const setCurrentTool = useSetCurrentTool();
+
+  const [scaleX, setScaleX] = useState('');
+  const [scaleY, setScaleY] = useState('');
+  const [unit, setUnit] = useState('mm');
+
+  useEffect(() => {
+    if (entry.params) {
+      setScaleX(String(entry.params.scale_x ?? ''));
+      setScaleY(String(entry.params.scale_y ?? ''));
+      setUnit(entry.params.unit || 'mm');
+    }
+  }, [entry.params]);
+
+  const linked = scaleX === scaleY;
+  const canSave = Number(scaleX) > 0 && Number(scaleY) > 0 && !!unit;
+
+  return (
+    <div className="flex flex-col gap-[8px]">
+      <button
+        type="button"
+        onClick={() => {
+          setCurrentTool('set_scale');
+          startCalibration();
+        }}
+        className={secondaryButtonClass}
+      >
+        <Ruler size={13} strokeWidth={1.9} />
+        Measure on image
+      </button>
+      <span className="text-meta text-t3 -mt-[4px] leading-[1.45]">
+        Draw a line across something of known length, then enter that length.
+      </span>
+
+      <div className="flex gap-[6px]">
+        <NumberField
+          label="Scale X"
+          value={scaleX}
+          onChange={(value) => {
+            setScaleX(value);
+            // Pixels are square on virtually every sensor this tool sees, so the
+            // two axes track together until deliberately separated.
+            if (linked) setScaleY(value);
+          }}
+          placeholder="0.01"
+        />
+        <NumberField label="Scale Y" value={scaleY} onChange={setScaleY} placeholder="0.01" />
+        <label className="w-[64px] flex flex-col gap-[3px]">
+          <span className="text-meta text-t3">Unit</span>
+          <select
+            value={unit}
+            onChange={(event) => setUnit(event.target.value)}
+            className={selectClass}
+          >
+            {UNITS.map((value) => <option key={value} value={value}>{value}</option>)}
+          </select>
+        </label>
+      </div>
+      <span className="text-meta text-t3 -mt-[4px]">Physical size of one pixel.</span>
+
+      <button
+        type="button"
+        disabled={!canSave}
+        onClick={() => onSave(
+          { scale_x: Number(scaleX), scale_y: Number(scaleY), unit }, 'manual',
+        )}
+        className={`${primaryButtonClass} self-start`}
+      >
+        Save scale
+      </button>
+    </div>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// response — reference card
+// ---------------------------------------------------------------------------
+
+/**
+ * One patch of a placed reference card. Clicking it re-places that patch alone.
+ *
+ * A single bad patch is the characteristic failure of this workflow — a glint, a
+ * shadow, a disc that landed on the border between two steps — so correcting one
+ * must not mean redoing the card.
+ */
+const WedgePatch = ({ index, name, sample, armed, onPick }) => (
+  <button
+    type="button"
+    onClick={() => onPick(index)}
+    title={sample
+      ? `${name}: ${sampleRgb(sample).map((v) => Math.round(v)).join(' / ')} — click to re-place`
+      : `${name}: not read yet`}
+    className={`w-[15px] h-[22px] rounded-[3px] border transition-transform hover:scale-110 ${
+      armed ? 'border-ac ring-1 ring-ac' : 'border-ln2'
+    }`}
+    style={{
+      background: sample
+        ? `rgb(${sampleRgb(sample).map((v) => Math.round(v)).join(',')})`
+        : 'var(--well)',
+    }}
+  />
+);
+
+const GrayWedgeControls = ({ entry, onSave, defaults }) => {
+  const wedge = useWedgeState();
+  const activePick = useActivePatchPick();
+  const startPatchPick = useStartPatchPick();
+
+  const [card, setCard] = useState(defaults?.card || entry.default_card);
+  const [fitModel, setFitModel] = useState(defaults?.fit_model || 'linear');
+
+  useEffect(() => {
+    if (entry.params?.card) setCard(entry.params.card);
+    if (entry.params?.fit_model) setFitModel(entry.params.fit_model);
+  }, [entry.params]);
+
+  const strategy = entry.strategies.find((item) => item.strategy === 'gray_wedge');
+  const cardProfile = entry.cards.find((item) => item.card === card);
+  const patchCount = cardProfile?.neutral_patch_count || 0;
+  const patchNames = (cardProfile?.patches || [])
+    .filter((patch) => patch.role === 'neutral' && patch.target_rgb)
+    .map((patch) => patch.name);
+
+  const placing = activePick?.mode === 'wedge_ends';
+  const placed = wedge.points.length === patchCount && patchCount > 0;
+  // Every disc needs its own reading: a re-placed patch drops the one it had, so
+  // "as many samples as points" is not the same as "all of them read".
+  const read = placed && wedge.points.every((_, index) => wedge.samples[index]);
+
+  return (
+    <div className="flex flex-col gap-[9px]">
+      <Field
+        label="Reference card"
+        help={cardProfile?.provenance}
+      >
+        <select value={card} onChange={(e) => setCard(e.target.value)} className={selectClass}>
+          {entry.cards.map((item) => (
+            <option key={item.card} value={item.card}>{item.label}</option>
+          ))}
+        </select>
+      </Field>
+
+      <Field
+        label="Fit"
+        help={strategy?.fit_models?.find((model) => model.key === fitModel)?.help}
+      >
+        <select
+          value={fitModel}
+          onChange={(e) => setFitModel(e.target.value)}
+          className={selectClass}
+        >
+          {(strategy?.fit_models || []).map((model) => (
+            <option key={model.key} value={model.key}>{model.label}</option>
+          ))}
+        </select>
+      </Field>
+
+      <button
+        type="button"
+        onClick={() => startPatchPick({ kind: 'response', mode: 'wedge_ends' })}
+        className={`${secondaryButtonClass} ${placing ? 'border-acLn text-ac bg-acS' : ''}`}
+      >
+        <Target size={13} strokeWidth={1.9} />
+        {placing
+          ? `Click patch ${wedge.ends.length === 0 ? '1' : patchCount} of ${patchCount}…`
+          : placed ? 'Re-place patches' : 'Place patches'}
+      </button>
+      <span className="text-meta text-t3 -mt-[5px] leading-[1.45]">
+        Click the centre of the lightest patch, then the darkest. The rest are
+        spaced evenly between them — check the discs on the image and nudge any
+        that landed badly.
+      </span>
+
+      {placed && (
+        <div className="flex flex-col gap-[5px]">
+          <div className="flex flex-wrap gap-[2px]">
+            {wedge.points.map((_, index) => (
+              <WedgePatch
+                key={index}
+                index={index}
+                name={patchNames[index] || String(index + 1)}
+                sample={wedge.samples[index]}
+                armed={activePick?.mode === 'wedge_patch' && activePick.index === index}
+                onPick={(i) => startPatchPick({ kind: 'response', mode: 'wedge_patch', index: i })}
+              />
+            ))}
+          </div>
+          <span className="text-meta text-t3">
+            {wedge.sampling
+              ? 'Reading the card…'
+              : read
+                ? `${patchCount} patches read — click one to re-place it.`
+                : 'Placed. Reading…'}
+          </span>
+        </div>
+      )}
+
+      <button
+        type="button"
+        disabled={!read || wedge.sampling}
+        onClick={() => onSave({
+          strategy: 'gray_wedge',
+          card,
+          fit_model: fitModel,
+          samples: wedge.samples.map(sampleRgb),
+        }, 'measured')}
+        className={`${primaryButtonClass} self-start`}
+      >
+        Save calibration
+      </button>
+    </div>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// response — two patch
+// ---------------------------------------------------------------------------
+
+const RoleButton = ({ role, sample, onPick, armed }) => (
+  <div className="flex flex-col gap-[4px]">
+    <button
+      type="button"
+      onClick={() => onPick(role.role)}
+      className={`${secondaryButtonClass} ${armed ? 'border-acLn text-ac bg-acS' : ''}`}
+    >
+      <Pipette size={13} strokeWidth={1.9} />
+      {armed ? 'Click the patch…' : role.label}
+    </button>
+    {sample ? (
+      <div className="flex items-center gap-[6px] pl-[2px]">
+        <Swatch rgb={sampleRgb(sample)} />
+        <span className="font-mono text-meta text-t3">
+          {sampleRgb(sample).map((v) => Math.round(v)).join(' / ')}
+          {sample.n_pixels ? ` · ${sample.n_pixels} px` : ''}
+        </span>
+      </div>
+    ) : (
+      <span className="text-meta text-t3 pl-[2px] leading-[1.45]">{role.help}</span>
+    )}
+  </div>
+);
+
+const TwoPatchControls = ({ entry, onSave }) => {
+  const pending = usePendingSamples().response || {};
+  const activePick = useActivePatchPick();
+  const startPatchPick = useStartPatchPick();
+  const params = entry.params || {};
+
+  const [gamma, setGamma] = useState('1');
+  useEffect(() => {
+    if (entry.params?.gamma != null) setGamma(String(entry.params.gamma));
+  }, [entry.params]);
+
+  const strategy = entry.strategies.find((item) => item.strategy === 'two_patch');
+
+  // A saved calibration counts as a value already in hand, so re-sampling one
+  // reference does not force the others to be taken again.
+  const black = pending.black
+    ? pending.black.median_intensity
+    : params.strategy === 'two_patch' ? params.black_level ?? null : null;
+  const white = pending.white
+    ? pending.white.median_intensity
+    : params.strategy === 'two_patch' ? params.white_level ?? null : null;
+
+  const gammaValue = Number(gamma);
+  const canSave = black != null && white != null && white - black >= 1
+    && Number.isFinite(gammaValue) && gammaValue >= 0.05 && gammaValue <= 10;
+
+  const pick = (role) => startPatchPick({ kind: 'response', mode: 'role', role });
+
+  return (
+    <div className="flex flex-col gap-[9px]">
+      {(strategy?.sample_roles || []).map((role) => (
+        <RoleButton
+          key={role.role}
+          role={role}
+          sample={pending[role.role]}
+          armed={activePick?.mode === 'role' && activePick.role === role.role}
+          onPick={pick}
+        />
+      ))}
+
+      <div className="flex items-center gap-[8px] font-mono text-ctl text-t2">
+        <span className="tabular-nums">{black == null ? '—' : black.toFixed(1)}</span>
+        <span className="text-t3">→</span>
+        <span className="tabular-nums">{white == null ? '—' : white.toFixed(1)}</span>
+      </div>
+
+      <div className="flex gap-[6px] items-end">
+        <NumberField label="Gamma" value={gamma} onChange={setGamma} step="0.1" />
+        <button
+          type="button"
+          onClick={() => setGamma('2.2')}
+          className={`${secondaryButtonClass} flex-none`}
+          title="Linearise sRGB-encoded data"
+        >
+          sRGB
+        </button>
+      </div>
+      <span className="text-meta text-t3 -mt-[5px] leading-[1.45]">
+        1.0 leaves the tone curve alone. Only useful here — a reference card with a
+        measured fit already carries the real curve.
+      </span>
+
+      <button
+        type="button"
+        disabled={!canSave}
+        onClick={() => onSave({
+          strategy: 'two_patch',
+          black_level: black,
+          white_level: white,
+          gamma: gammaValue,
+          neutral_rgb: pending.neutral ? sampleRgb(pending.neutral) : undefined,
+        }, pending.black || pending.white ? 'measured' : 'manual')}
+        className={`${primaryButtonClass} self-start`}
+      >
+        Save calibration
+      </button>
+      {black != null && white != null && white - black < 1 && (
+        <span className="text-meta text-err">
+          The two references must differ in brightness.
+        </span>
+      )}
+    </div>
+  );
+};
+
+/**
+ * Colour and intensity, estimated by the selected strategy.
+ *
+ * They were two separate calibrations at first. Merging them was not tidying: two
+ * estimates of one transform could be set inconsistently, or stacked on top of a
+ * card-based calibration that already accounted for both. Now the transform is one
+ * thing and the strategy is how it was measured.
+ */
+export const ResponseBody = ({ entry, onSave, onSaveDatasetDefault }) => {
+  const defaults = entry.dataset_defaults || {};
+  const [strategy, setStrategy] = useState(
+    entry.params?.strategy || defaults.strategy || entry.default_strategy,
+  );
+
+  useEffect(() => {
+    if (entry.params?.strategy) setStrategy(entry.params.strategy);
+  }, [entry.params]);
+
+  const active = entry.strategies.find((item) => item.strategy === strategy);
+  const isDatasetDefault = defaults.strategy === strategy;
+
+  return (
+    <div className="flex flex-col gap-[9px]">
+      <Field label="Strategy" help={active?.summary}>
+        <select
+          value={strategy}
+          onChange={(event) => setStrategy(event.target.value)}
+          className={selectClass}
+        >
+          {entry.strategies.map((item) => (
+            <option key={item.strategy} value={item.strategy}>{item.label}</option>
+          ))}
+        </select>
+      </Field>
+
+      {/* The strategy is normally a dataset-wide decision — one session, one
+          camera, one card — so it is chosen once here and inherited, with the
+          per-image override staying available for the frame that lost its card. */}
+      <button
+        type="button"
+        disabled={isDatasetDefault}
+        onClick={() => onSaveDatasetDefault({ strategy })}
+        className={`${secondaryButtonClass} self-start`}
+      >
+        {isDatasetDefault ? 'Dataset default' : 'Make dataset default'}
+      </button>
+
+      <div className="h-px bg-ln" />
+
+      {strategy === 'gray_wedge'
+        ? <GrayWedgeControls entry={entry} onSave={onSave} defaults={defaults} />
+        : <TwoPatchControls entry={entry} onSave={onSave} />}
+    </div>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// fallback
+// ---------------------------------------------------------------------------
+
+/**
+ * A kind this build has no controls for.
+ *
+ * The registry is the server's, so it can carry a kind added after this client
+ * shipped. Showing its parameters read-only is more useful — and more honest —
+ * than pretending it does not exist.
+ */
+export const FallbackBody = ({ entry }) => (
+  <div className="flex flex-col gap-[6px]">
+    <span className="text-meta text-t3 leading-[1.45]">
+      This build has no controls for this calibration. It is shown read-only.
+    </span>
+    {entry.params && (
+      <pre className="px-[8px] py-[6px] rounded-6 bg-well border border-ln2 font-mono text-meta text-t2 overflow-x-auto">
+        {JSON.stringify(entry.params, null, 2)}
+      </pre>
+    )}
+  </div>
+);
+
+export const BODIES = {
+  scale: ScaleBody,
+  response: ResponseBody,
+};

--- a/src/components/annotationPage/workspace/toolModel.js
+++ b/src/components/annotationPage/workspace/toolModel.js
@@ -47,6 +47,33 @@ export const RAIL_TOOLS = [
   { id: 'scale', name: 'Set scale', key: 'R', icon: 'Ruler' },
 ];
 
+/**
+ * The rail in Calibrate mode.
+ *
+ * Calibration is measurement, not annotation, so the shape tools are not offered
+ * there — a point or a polygon has nothing to contribute to a scale or a colour
+ * reference. What is left is the navigation needed to see a reference clearly.
+ *
+ * Below these, the rail shows one button per calibration kind: pick the
+ * calibration on the rail, configure it in the drawer, measure it on the canvas.
+ * That is the same shape as the annotation rail it stands in for, and it scales
+ * to a sixth calibration kind as a sixth icon rather than a sixth card to scroll
+ * past.
+ */
+export const CALIBRATE_RAIL_TOOL_IDS = ['pan', 'zoom'];
+
+export const railToolsForMode = (mode) => (
+  mode === 'calibrate'
+    ? RAIL_TOOLS.filter((tool) => CALIBRATE_RAIL_TOOL_IDS.includes(tool.id))
+    : RAIL_TOOLS
+);
+
+/** Icon per calibration kind, falling back for a kind this build predates. */
+export const CALIBRATION_KIND_ICONS = {
+  scale: 'Ruler',
+  response: 'Palette',
+};
+
 /** Prompt-shaped rail tools, i.e. the ones that drive `promptMode`. */
 const SHAPE_TOOLS = new Set(['point', 'box', 'polygon', 'freehand']);
 

--- a/src/components/annotationPage/workspace/useCalibrationState.js
+++ b/src/components/annotationPage/workspace/useCalibrationState.js
@@ -1,0 +1,292 @@
+import { useCallback, useEffect } from 'react';
+import {
+  applyCalibrationToDataset,
+  clearImageCalibration,
+  fetchCalibrationKinds,
+  fetchImageCalibrations,
+  sampleCalibrationPatch,
+  sampleCalibrationPatches,
+  setDatasetCalibrationDefaults,
+  setImageCalibration,
+} from '../../../api/calibration';
+import { useToast } from '../../../contexts/ToastContext';
+import {
+  useCalibrationEntries,
+  useCalibrationError,
+  useCalibrationKinds,
+  useCalibrationKindsLoaded,
+  useCalibrationLoading,
+  useClearPendingSamples,
+  useCurrentImageId,
+  useImageScale,
+  useResetCalibrationForImage,
+  useSampleRadius,
+  useSetCalibrationEntries,
+  useSetCalibrationError,
+  useSetCalibrationKinds,
+  useSetCalibrationLoading,
+  useSetImageScale,
+  useSetWedgeSample,
+  useSetWedgeSampling,
+  useSetWedgeSamples,
+  useWedgeState,
+} from '../../../stores/selectors/annotationSelectors';
+
+/**
+ * Owns every call to api/calibration.js for the Calibrate tab.
+ *
+ * Split in two on purpose:
+ *
+ * - `useCalibrationState` (this hook) is effect-free. It reads the store and
+ *   returns callbacks, so any number of components can use it.
+ * - `useCalibrationSync` below owns the fetching, and is mounted exactly once —
+ *   in WorkspaceShell, not in the tab. That matters: the status bar reports the
+ *   calibration state on every image, so the data cannot only load when someone
+ *   opens the tab, or the reminder to open it would only appear after they had.
+ *
+ * Each mutator re-reads the whole per-image state afterwards rather than patching
+ * the entry it changed: a calibration can invalidate stored measurements and (for
+ * scale) move values other parts of the workspace read, so a re-read is both
+ * simpler and less likely to drift.
+ */
+export default function useCalibrationState() {
+  const currentImageId = useCurrentImageId();
+  const { addToast } = useToast();
+
+  const kinds = useCalibrationKinds();
+  const entries = useCalibrationEntries();
+  const loading = useCalibrationLoading();
+  const error = useCalibrationError();
+  const sampleRadius = useSampleRadius();
+
+  const setEntries = useSetCalibrationEntries();
+  const setLoading = useSetCalibrationLoading();
+  const setError = useSetCalibrationError();
+  const clearPending = useClearPendingSamples();
+  const setImageScale = useSetImageScale();
+  const wedge = useWedgeState();
+  const setWedgeSamples = useSetWedgeSamples();
+  const setWedgeSample = useSetWedgeSample();
+  const setWedgeSampling = useSetWedgeSampling();
+
+  /**
+   * Keep `images.scale` in step with the scale entry the server just returned.
+   *
+   * Without this the status bar and the scale-bar indicator would keep showing
+   * the previous scale after a calibration made from this tab, since they read it
+   * from the older store location that predates the calibration system.
+   */
+  const mirrorScaleIntoImageState = useCallback((list) => {
+    const scale = (list || []).find((entry) => entry.kind === 'scale');
+    if (scale?.calibrated && scale.params) {
+      setImageScale(scale.params.scale_x, scale.params.scale_y, scale.params.unit);
+    } else {
+      setImageScale(1, 1, 'px');
+    }
+  }, [setImageScale]);
+
+  const refresh = useCallback(async () => {
+    if (!currentImageId) return null;
+    setLoading(true);
+    try {
+      const data = await fetchImageCalibrations(currentImageId);
+      setEntries(data.calibrations);
+      mirrorScaleIntoImageState(data.calibrations);
+      setLoading(false);
+      return data;
+    } catch (err) {
+      setError(err.message || 'Could not load calibrations.');
+      return null;
+    }
+  }, [currentImageId, setEntries, setLoading, setError, mirrorScaleIntoImageState]);
+
+  /** Report how many stored measurements a change flagged for recomputation. */
+  const reportInvalidated = useCallback((result, prefix) => {
+    const n = result?.metrics_invalidated || 0;
+    addToast({
+      message: n
+        ? `${prefix} ${n} stored measurement${n === 1 ? '' : 's'} flagged for recomputation.`
+        : prefix,
+      type: 'success',
+    });
+  }, [addToast]);
+
+  const save = useCallback(async (kind, params, source = 'manual') => {
+    if (!currentImageId) return false;
+    try {
+      const result = await setImageCalibration(currentImageId, kind, params, source);
+      clearPending(kind);
+      await refresh();
+      reportInvalidated(result, `${kind} calibration saved.`);
+      return true;
+    } catch (err) {
+      addToast({ message: err.message || 'Could not save the calibration.', type: 'error' });
+      return false;
+    }
+  }, [currentImageId, refresh, clearPending, addToast, reportInvalidated]);
+
+  const clear = useCallback(async (kind) => {
+    if (!currentImageId) return false;
+    try {
+      const result = await clearImageCalibration(currentImageId, kind);
+      clearPending(kind);
+      await refresh();
+      addToast({
+        message: result.cleared
+          ? `${kind} calibration removed.`
+          : `No ${kind} calibration was set.`,
+        type: 'success',
+      });
+      return true;
+    } catch (err) {
+      addToast({ message: err.message || 'Could not clear the calibration.', type: 'error' });
+      return false;
+    }
+  }, [currentImageId, refresh, clearPending, addToast]);
+
+  const applyToDataset = useCallback(async (datasetId, kind, params) => {
+    if (!datasetId) return false;
+    try {
+      const result = await applyCalibrationToDataset(datasetId, kind, params);
+      await refresh();
+      const images = result.images_updated;
+      const metrics = result.metrics_invalidated;
+      addToast({
+        message: `Applied to ${images} image${images === 1 ? '' : 's'}. `
+          + `${metrics} stored measurement${metrics === 1 ? '' : 's'} flagged for recomputation.`,
+        type: 'success',
+      });
+      return true;
+    } catch (err) {
+      addToast({ message: err.message || 'Could not apply to the dataset.', type: 'error' });
+      return false;
+    }
+  }, [refresh, addToast]);
+
+  /**
+   * Read a reference patch off the original file.
+   *
+   * `forKind` matters: the server replays every calibration stage ordered before
+   * that kind, so a colour patch is measured in the same tone space the colour
+   * gains will act on. Sampling raw and applying corrected would leave the gains
+   * wrong by whatever the intensity stage does.
+   */
+  const sample = useCallback(async (x, y, forKind) => {
+    if (!currentImageId) return null;
+    try {
+      return await sampleCalibrationPatch(currentImageId, x, y, sampleRadius, forKind);
+    } catch (err) {
+      addToast({ message: err.message || 'Could not sample that point.', type: 'error' });
+      return null;
+    }
+  }, [currentImageId, sampleRadius, addToast]);
+
+  /** Read every placed patch of a reference card in one request. */
+  const sampleWedge = useCallback(async (points, forKind) => {
+    if (!currentImageId || !points?.length) return false;
+    setWedgeSampling(true);
+    try {
+      const result = await sampleCalibrationPatches(
+        currentImageId, points.map((point) => [point.x, point.y]), sampleRadius, forKind,
+      );
+      setWedgeSamples(result.samples);
+      return true;
+    } catch (err) {
+      setWedgeSampling(false);
+      addToast({ message: err.message || 'Could not read the card.', type: 'error' });
+      return false;
+    }
+  }, [currentImageId, sampleRadius, setWedgeSampling, setWedgeSamples, addToast]);
+
+  /** Re-read a single patch after it was moved, leaving the rest alone. */
+  const resampleWedgePatch = useCallback(async (index, point, forKind) => {
+    if (!currentImageId) return false;
+    setWedgeSampling(true);
+    try {
+      const result = await sampleCalibrationPatch(
+        currentImageId, point.x, point.y, sampleRadius, forKind,
+      );
+      setWedgeSample(index, result);
+      return true;
+    } catch (err) {
+      setWedgeSampling(false);
+      addToast({ message: err.message || 'Could not read that patch.', type: 'error' });
+      return false;
+    }
+  }, [currentImageId, sampleRadius, setWedgeSampling, setWedgeSample, addToast]);
+
+  const saveDatasetDefaults = useCallback(async (datasetId, kind, defaults) => {
+    if (!datasetId) return false;
+    try {
+      await setDatasetCalibrationDefaults(datasetId, kind, defaults);
+      await refresh();
+      addToast({
+        message: 'Dataset calibration defaults saved. Existing calibrations are unchanged.',
+        type: 'success',
+      });
+      return true;
+    } catch (err) {
+      addToast({ message: err.message || 'Could not save the defaults.', type: 'error' });
+      return false;
+    }
+  }, [refresh, addToast]);
+
+  return {
+    kinds, entries, loading, error, wedge,
+    refresh, save, clear, applyToDataset, saveDatasetDefaults,
+    sample, sampleWedge, resampleWedgePatch,
+  };
+}
+
+/**
+ * Loads calibration state and keeps it current. Mount once, in WorkspaceShell.
+ *
+ * Three concerns:
+ *   1. the kind registry, which is server-wide and fetched once per session,
+ *   2. the per-image state, which is reset and re-read on every image change,
+ *   3. drift, because the draw-a-line scale overlay writes straight into
+ *      `images.scale` and knows nothing about this system. Watching that value
+ *      and re-reading when it disagrees with the stored entry keeps the cards and
+ *      the status bar right after a calibration made from the rail. It converges
+ *      after one pass: the refresh mirrors the two back together.
+ */
+export function useCalibrationSync() {
+  const { entries, loading, refresh } = useCalibrationState();
+  const currentImageId = useCurrentImageId();
+  const scale = useImageScale();
+
+  const kindsLoaded = useCalibrationKindsLoaded();
+  const setKinds = useSetCalibrationKinds();
+  const setError = useSetCalibrationError();
+  const resetForImage = useResetCalibrationForImage();
+
+  useEffect(() => {
+    if (kindsLoaded) return undefined;
+    let cancelled = false;
+    fetchCalibrationKinds()
+      .then((data) => { if (!cancelled) setKinds(data.kinds); })
+      .catch((err) => {
+        if (!cancelled) setError(err.message || 'Could not load calibration kinds.');
+      });
+    return () => { cancelled = true; };
+  }, [kindsLoaded, setKinds, setError]);
+
+  useEffect(() => {
+    resetForImage();
+    if (currentImageId) refresh();
+    // `refresh` already closes over currentImageId; listing it here too would
+    // re-run this on every identity change of the callback rather than on an
+    // actual image change, wiping pending samples mid-edit.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentImageId]);
+
+  useEffect(() => {
+    if (loading || !entries.length) return;
+    const scaleEntry = entries.find((entry) => entry.kind === 'scale');
+    const entryUnit = scaleEntry?.params?.unit ?? 'px';
+    const entryScaleX = scaleEntry?.params?.scale_x ?? 1;
+    const drifted =
+      scale.unit !== entryUnit || Math.abs((scale.scaleX ?? 1) - entryScaleX) > 1e-12;
+    if (drifted) refresh();
+  }, [scale.unit, scale.scaleX, entries, loading, refresh]);
+}

--- a/src/components/annotationPage/workspace/useWorkspaceShortcuts.js
+++ b/src/components/annotationPage/workspace/useWorkspaceShortcuts.js
@@ -2,7 +2,7 @@ import { useEffect } from 'react';
 import useRailTools from './useRailTools';
 import useWorkspaceImageNav from './useWorkspaceImageNav';
 import useObjectActions from './useObjectActions';
-import { RAIL_TOOL_BY_KEY, getRailTool } from './toolModel';
+import { RAIL_TOOL_BY_KEY, getRailTool, railToolsForMode } from './toolModel';
 import { MAX_ZOOM, MIN_ZOOM, ZOOM_STEP } from './constants';
 import annotationSession from '../../../services/annotationSession';
 import {
@@ -89,7 +89,13 @@ export default function useWorkspaceShortcuts() {
       const railTool =
         upper === 'R' && mode === 'review' ? undefined : RAIL_TOOL_BY_KEY[upper];
 
-      if (railTool && !getRailTool(railTool).unavailable) {
+      // A shortcut must not reach a tool the current mode's rail does not offer —
+      // otherwise `P` would arm the point tool in Calibrate mode, where the rail
+      // deliberately has no shape tools at all.
+      const inThisMode = railTool
+        && railToolsForMode(mode).some((tool) => tool.id === railTool);
+
+      if (inThisMode && !getRailTool(railTool).unavailable) {
         event.preventDefault();
         setRailTool(railTool);
         return;
@@ -97,8 +103,11 @@ export default function useWorkspaceShortcuts() {
 
       switch (upper) {
         case 'A':
-          event.preventDefault();
-          toggleAssist();
+          // AI assist has nothing to act on while calibrating.
+          if (mode !== 'calibrate') {
+            event.preventDefault();
+            toggleAssist();
+          }
           break;
         case 'L':
           if (selectedIds.length > 0) {

--- a/src/stores/initialState.js
+++ b/src/stores/initialState.js
@@ -19,7 +19,9 @@ export const initialState = {
   // retired independently once nothing reads them.
   workspace: {
     theme: 'dark',              // 'dark' | 'light'
-    mode: 'annotate',           // 'annotate' | 'review'
+    // The workspace tab. All three share one canvas and one viewport; they differ
+    // in the rail's tools and which side panel is in front. See setWorkspaceMode.
+    mode: 'annotate',           // 'calibrate' | 'annotate' | 'review'
     /** When false, drawn shapes are committed as-is instead of becoming model prompts. */
     aiAssist: true,
     leftDrawerOpen: true,
@@ -140,6 +142,49 @@ export const initialState = {
     },
   },
   
+  // Calibration State — the Calibrate tab's view of the current image.
+  //
+  // Only the scale sub-object under `images.scale` above is duplicated here in
+  // spirit: that one stays as-is because the status bar, the scale-bar indicator
+  // and the draw-a-line overlay all read it, and it is refreshed from the same
+  // backend response this slice loads.
+  calibration: {
+    /** Registry metadata from the server; fetched once and reused per image. */
+    kinds: [],
+    kindsLoaded: false,
+    /** One entry per kind for the current image, calibrated or not. */
+    entries: [],
+    loading: false,
+    error: null,
+    /** Which calibration the rail has selected in Calibrate mode. */
+    activeKind: null,
+    /**
+     * What the canvas is currently capturing clicks for, if anything.
+     *   { kind, mode: 'role',        role }   — one named reference (two-patch)
+     *   { kind, mode: 'wedge_ends'         }  — the two ends of a reference card
+     *   { kind, mode: 'wedge_patch', index }  — one card patch, to re-read it
+     */
+    activePick: null,
+    /** Radius of the sampled disc, in image pixels. */
+    sampleRadius: 8,
+    /** Sampled-but-unsaved named references: { [kind]: { [role]: sample } }. */
+    pending: {},
+    /**
+     * Reference-card placement for the current image.
+     *
+     * The card's patches are evenly spaced along a rigid strip, so clicking the
+     * first and last patch centres is enough to place all of them — 2 clicks
+     * instead of 20. `points` is what that produced, `samples` what they read,
+     * and either can be corrected one patch at a time when a disc lands badly.
+     */
+    wedge: {
+      ends: [],       // [{x, y}, {x, y}] in image pixels, as clicked
+      points: [],     // derived patch centres, image pixels
+      samples: [],    // one sample per point, aligned by index
+      sampling: false,
+    },
+  },
+
   // Model State
   models: {
     promptedModel: null, // Store model ID as string, not object

--- a/src/stores/selectors/annotationSelectors.js
+++ b/src/stores/selectors/annotationSelectors.js
@@ -242,6 +242,38 @@ export const useStartCalibration = () => useAnnotationStore(state => state.start
 export const useSetCalibrationPoint = () => useAnnotationStore(state => state.setCalibrationPoint);
 export const useCancelCalibration = () => useAnnotationStore(state => state.cancelCalibration);
 
+// Calibration selectors — the Calibrate tab. Distinct from the four above,
+// which are the *scale* kind's draw-a-line interaction and predate the tab.
+export const useCalibrationKinds = () => useAnnotationStore(state => state.calibration.kinds);
+export const useCalibrationKindsLoaded = () => useAnnotationStore(state => state.calibration.kindsLoaded);
+export const useCalibrationEntries = () => useAnnotationStore(state => state.calibration.entries);
+export const useCalibrationLoading = () => useAnnotationStore(state => state.calibration.loading);
+export const useCalibrationError = () => useAnnotationStore(state => state.calibration.error);
+export const useActiveCalibrationKind = () => useAnnotationStore(state => state.calibration.activeKind);
+export const useActivePatchPick = () => useAnnotationStore(state => state.calibration.activePick);
+export const useSampleRadius = () => useAnnotationStore(state => state.calibration.sampleRadius);
+export const usePendingSamples = () => useAnnotationStore(state => state.calibration.pending);
+export const useWedgeState = () => useAnnotationStore(state => state.calibration.wedge);
+
+// Calibration action selectors
+export const useSetCalibrationKinds = () => useAnnotationStore(state => state.setCalibrationKinds);
+export const useSetCalibrationEntries = () => useAnnotationStore(state => state.setCalibrationEntries);
+export const useSetCalibrationLoading = () => useAnnotationStore(state => state.setCalibrationLoading);
+export const useSetCalibrationError = () => useAnnotationStore(state => state.setCalibrationError);
+export const useSetActiveCalibrationKind = () => useAnnotationStore(state => state.setActiveCalibrationKind);
+export const useStartPatchPick = () => useAnnotationStore(state => state.startPatchPick);
+export const useCancelPatchPick = () => useAnnotationStore(state => state.cancelPatchPick);
+export const useSetSampleRadius = () => useAnnotationStore(state => state.setSampleRadius);
+export const useSetPendingSample = () => useAnnotationStore(state => state.setPendingSample);
+export const useClearPendingSamples = () => useAnnotationStore(state => state.clearPendingSamples);
+export const useResetCalibrationForImage = () => useAnnotationStore(state => state.resetCalibrationForImage);
+export const useAddWedgeEnd = () => useAnnotationStore(state => state.addWedgeEnd);
+export const useSetWedgePoint = () => useAnnotationStore(state => state.setWedgePoint);
+export const useSetWedgeSampling = () => useAnnotationStore(state => state.setWedgeSampling);
+export const useSetWedgeSamples = () => useAnnotationStore(state => state.setWedgeSamples);
+export const useSetWedgeSample = () => useAnnotationStore(state => state.setWedgeSample);
+export const useClearWedge = () => useAnnotationStore(state => state.clearWedge);
+
 // Workspace shell selectors
 export const useWorkspaceTheme = () => useAnnotationStore(state => state.workspace.theme);
 export const useWorkspaceMode = () => useAnnotationStore(state => state.workspace.mode);

--- a/src/stores/slices/calibrationSlice.js
+++ b/src/stores/slices/calibrationSlice.js
@@ -1,0 +1,181 @@
+/**
+ * Calibration slice — the Calibrate mode's state for the current image.
+ *
+ * Presentation and in-flight state only. The stored calibrations themselves live
+ * on the server; `entries` is a cache of the last response and is refreshed by
+ * `useCalibrationState`, which owns every call to api/calibration.js.
+ *
+ * Three things are worth knowing about the shape:
+ *
+ * - `activeKind` is what the rail selects in Calibrate mode. The rail picks the
+ *   calibration, the drawer configures it, the canvas measures it.
+ * - `activePick` is what makes a control in the drawer and an overlay on the
+ *   canvas one interaction. Whoever finishes (or cancels) clears it.
+ * - `wedge` holds a reference card's placement and readings before they are
+ *   saved, so a bad patch can be corrected without redoing the whole card.
+ */
+
+const emptyWedge = () => ({ ends: [], points: [], samples: [], sampling: false });
+
+/**
+ * Patch centres evenly spaced from the first to the last, inclusive.
+ *
+ * The patches on a step wedge are equally spaced along a rigid strip, so the two
+ * end centres determine all of them. This is an approximation under perspective —
+ * a card tilted steeply away from the sensor will drift — which is why the derived
+ * discs are drawn on the canvas and any single one can be re-placed.
+ */
+const interpolatePoints = (start, end, count) => {
+  if (!start || !end || count < 2) return [];
+  return Array.from({ length: count }, (_, index) => {
+    const t = index / (count - 1);
+    return { x: start.x + (end.x - start.x) * t, y: start.y + (end.y - start.y) * t };
+  });
+};
+
+export const createCalibrationSlice = (set) => ({
+  /** Registry metadata — kinds, their strategies, cards and affected metrics. */
+  setCalibrationKinds: (kinds) => set((state) => {
+    state.calibration.kinds = Array.isArray(kinds) ? kinds : [];
+    state.calibration.kindsLoaded = true;
+  }),
+
+  /** Replace the per-kind state after a fetch or a successful mutation. */
+  setCalibrationEntries: (entries) => set((state) => {
+    state.calibration.entries = Array.isArray(entries) ? entries : [];
+    state.calibration.error = null;
+  }),
+
+  setCalibrationLoading: (loading) => set((state) => {
+    state.calibration.loading = !!loading;
+  }),
+
+  setCalibrationError: (error) => set((state) => {
+    state.calibration.error = error || null;
+    state.calibration.loading = false;
+  }),
+
+  /**
+   * Select which calibration the drawer configures. Re-picking closes it, so the
+   * rail behaves like the annotation rail it sits in place of.
+   */
+  setActiveCalibrationKind: (kind) => set((state) => {
+    const next = state.calibration.activeKind === kind ? null : kind;
+    state.calibration.activeKind = next;
+    // Leaving a kind must not leave its overlay above the canvas eating clicks.
+    if (state.calibration.activePick?.kind !== next) state.calibration.activePick = null;
+  }),
+
+  /**
+   * Arm the canvas to capture clicks. Re-arming the same thing disarms it — the
+   * overlay is above the canvas while a pick is live, so there has to be a way out
+   * that is not the Escape key.
+   */
+  startPatchPick: (pick) => set((state) => {
+    const current = state.calibration.activePick;
+    const same = current
+      && current.kind === pick.kind
+      && current.mode === pick.mode
+      && current.role === pick.role
+      && current.index === pick.index;
+    state.calibration.activePick = same ? null : pick;
+    if (!same && pick.mode === 'wedge_ends') {
+      // Re-placing starts from nothing: half-old, half-new ends would silently
+      // interpolate a card that was never on the image.
+      state.calibration.wedge.ends = [];
+    }
+  }),
+
+  cancelPatchPick: () => set((state) => {
+    state.calibration.activePick = null;
+  }),
+
+  setSampleRadius: (radius) => set((state) => {
+    const parsed = Number(radius);
+    if (Number.isFinite(parsed) && parsed >= 1) {
+      state.calibration.sampleRadius = Math.min(Math.round(parsed), 256);
+    }
+  }),
+
+  /** Record a named reference (two-patch) and disarm the canvas. */
+  setPendingSample: (kind, role, sample) => set((state) => {
+    if (!state.calibration.pending[kind]) state.calibration.pending[kind] = {};
+    state.calibration.pending[kind][role] = sample;
+    state.calibration.activePick = null;
+  }),
+
+  /** Drop a kind's unsaved references — after saving them, or on an explicit reset. */
+  clearPendingSamples: (kind) => set((state) => {
+    if (kind) delete state.calibration.pending[kind];
+    else state.calibration.pending = {};
+  }),
+
+  // -- Reference card placement ------------------------------------------
+
+  /**
+   * Record one end of the card. On the second, derive every patch centre between
+   * them and disarm, so the caller can go straight to reading them.
+   */
+  addWedgeEnd: (point, patchCount) => set((state) => {
+    const wedge = state.calibration.wedge;
+    wedge.ends = [...wedge.ends, point].slice(-2);
+    if (wedge.ends.length === 2) {
+      wedge.points = interpolatePoints(wedge.ends[0], wedge.ends[1], patchCount);
+      wedge.samples = [];
+      state.calibration.activePick = null;
+    }
+  }),
+
+  /**
+   * Move one patch's disc, leaving the rest of the placement alone.
+   *
+   * Drops that patch's reading, which is what makes the sampler pick it up: a
+   * moved disc's old value describes a place the disc no longer is.
+   */
+  setWedgePoint: (index, point) => set((state) => {
+    const wedge = state.calibration.wedge;
+    if (index < 0 || index >= wedge.points.length) return;
+    wedge.points[index] = point;
+    wedge.samples[index] = null;
+    state.calibration.activePick = null;
+  }),
+
+  setWedgeSampling: (sampling) => set((state) => {
+    state.calibration.wedge.sampling = !!sampling;
+  }),
+
+  /** Store the readings for the whole card. */
+  setWedgeSamples: (samples) => set((state) => {
+    state.calibration.wedge.samples = Array.isArray(samples) ? samples : [];
+    state.calibration.wedge.sampling = false;
+  }),
+
+  /** Replace one patch's reading after it was re-placed and re-read. */
+  setWedgeSample: (index, sample) => set((state) => {
+    const wedge = state.calibration.wedge;
+    if (index < 0 || index >= wedge.points.length) return;
+    wedge.samples[index] = sample;
+    wedge.sampling = false;
+  }),
+
+  clearWedge: () => set((state) => {
+    state.calibration.wedge = emptyWedge();
+    if (state.calibration.activePick?.mode?.startsWith('wedge')) {
+      state.calibration.activePick = null;
+    }
+  }),
+
+  /**
+   * Called when the image changes. Entries, references, placement and any armed
+   * pick all belong to the image that was open; the registry metadata does not,
+   * so it survives and is not re-fetched.
+   */
+  resetCalibrationForImage: () => set((state) => {
+    state.calibration.entries = [];
+    state.calibration.pending = {};
+    state.calibration.wedge = emptyWedge();
+    state.calibration.activePick = null;
+    state.calibration.error = null;
+    state.calibration.loading = false;
+  }),
+});

--- a/src/stores/slices/workspaceSlice.js
+++ b/src/stores/slices/workspaceSlice.js
@@ -46,10 +46,41 @@ export const createWorkspaceSlice = (set) => ({
     persistTheme(next);
   }),
 
+  /**
+   * Switch the workspace between Calibrate / Annotate / Review.
+   *
+   * The three modes share one canvas, one image and one viewport — what changes
+   * is the chrome around it: which tools the rail offers and which panel is in
+   * front. That is why this is a mode rather than a route: navigating away and
+   * back would lose the zoom, the pan and the selection, and calibration is
+   * something you do *while looking at* the image.
+   *
+   * Entering and leaving Calibrate has to tidy up after itself. An armed
+   * patch-pick or a live scale calibration keeps an overlay above the canvas
+   * swallowing clicks, so both are cancelled on the way out; and the annotation
+   * tools are meaningless here, so the tool drops to pan on the way in.
+   */
   setWorkspaceMode: (mode) => set((state) => {
+    const previous = state.workspace.mode;
+    if (previous === mode) return;
     state.workspace.mode = mode;
+
     // Leaving review mode should not strand the "show approved" escape hatch on.
     if (mode !== 'review') state.workspace.showApproved = false;
+
+    if (mode === 'calibrate') {
+      // The calibration controls live in the left drawer, so opening the mode
+      // with it collapsed would show a rail with nowhere to configure anything.
+      state.workspace.leftDrawerOpen = true;
+      state.ui.currentTool = 'pan';
+      state.workspace.picker = null;
+    } else if (previous === 'calibrate') {
+      state.calibration.activePick = null;
+      state.calibration.activeKind = null;
+      state.images.scale.isCalibrating = false;
+      state.images.scale.calibrationPoints = null;
+      state.ui.currentTool = 'ai_annotation';
+    }
   }),
 
   setAiAssist: (on) => set((state) => {

--- a/src/stores/useAnnotationStore.js
+++ b/src/stores/useAnnotationStore.js
@@ -15,6 +15,7 @@ import { createEditModeSlice } from './slices/editModeSlice';
 import { createAIAnnotationSlice } from './slices/aiAnnotationSlice';
 import { createObjectsSlice } from './slices/objectsSlice';
 import { createWorkspaceSlice, readStoredTheme } from './slices/workspaceSlice';
+import { createCalibrationSlice } from './slices/calibrationSlice';
 
 /**
  * Combined annotation store using Zustand with Immer middleware
@@ -30,6 +31,7 @@ import { createWorkspaceSlice, readStoredTheme } from './slices/workspaceSlice';
  * - Edit Mode: Contour editing mode
  * - AI Annotation: AI prompts and undo/redo
  * - Objects: Annotation objects, selection, visibility
+ * - Calibration: The Calibrate tab's per-image calibration state
  */
 const useAnnotationStore = create()(
   devtools(
@@ -51,6 +53,7 @@ const useAnnotationStore = create()(
         ...createAIAnnotationSlice(set),
         ...createObjectsSlice(set),
         ...createWorkspaceSlice(set),
+        ...createCalibrationSlice(set),
       }))
     ),
     { name: 'annotation-store' }

--- a/src/utils/imageStatus.js
+++ b/src/utils/imageStatus.js
@@ -1,4 +1,4 @@
-import { Circle, Clock, Eye, CheckCircle2, RotateCcw } from 'lucide-react';
+import { Check, Circle, Clock, Eye, CheckCircle2, RotateCcw, X } from 'lucide-react';
 
 /**
  * The annotation statuses an image's mask can have, with the colors/icons used
@@ -86,21 +86,33 @@ export const getImageStatus = (image) => {
  * image done?". The dataset manager keeps the full five-way breakdown, which is
  * where the review pipeline is actually managed from.
  */
+/**
+ * `icon` and `tone` are for surfaces too small to carry a label — the filmstrip
+ * tiles, at 6-10px. Shape does the work there rather than colour: three shades of
+ * the same dot are not distinguishable at that size, whereas a cross, a ring and
+ * a tick are, and they still read for anyone who cannot separate the hues.
+ */
 export const COARSE_STATUSES = [
   {
     key: 'not_started',
     label: 'Not started',
     badge: 'bg-well text-t1',
+    icon: X,
+    tone: 'text-t3',
   },
   {
     key: 'in_progress',
     label: 'In progress',
     badge: 'bg-acS text-ac',
+    icon: Circle,
+    tone: 'text-warn',
   },
   {
     key: 'finished',
     label: 'Finished',
     badge: 'bg-okBg text-ok',
+    icon: Check,
+    tone: 'text-ok',
   },
 ];
 


### PR DESCRIPTION
Added calibration tab in the canvas plus calibration methods in the tool rail. Completely new tool rail, easily expandable with new calibrations. Calibrations show status indicators (Not calibrated/Calibrated). Additionally, replaced status indicators in the film strip to be more readable (LED status lights were too small).

closes #164 