### PR TITLE
Feat/instance training updates

### DIFF
--- a/src/components/annotationPage/modals/InstanceWarningModal.jsx
+++ b/src/components/annotationPage/modals/InstanceWarningModal.jsx
@@ -2,9 +2,8 @@ import React from 'react';
 import { AlertTriangle, X } from 'lucide-react';
 
 /**
- * Confirms an instance-segmentation run, which replaces every contour on the
- * mask. Destructive enough to warrant the danger treatment rather than the
- * primary one.
+ * Lets the annotator choose how instance-segmentation predictions are written.
+ * Patch is the safe default; Override is deliberately treated as destructive.
  */
 const InstanceWarningModal = ({ isOpen, onClose, onConfirm }) => {
   if (!isOpen) return null;
@@ -18,9 +17,8 @@ const InstanceWarningModal = ({ isOpen, onClose, onConfirm }) => {
     >
       <div className="w-[360px] max-w-[calc(100%-32px)] rounded-12 bg-p1 border border-ln2 shadow-modal animate-dcPop">
         <div className="flex items-center gap-[8px] px-[14px] py-[12px] border-b border-ln">
-          <AlertTriangle size={15} className="text-warn flex-none" />
           <h2 className="flex-1 text-modaltitle font-bold text-t1">
-            Replace all annotations?
+            Choose how to apply predictions
           </h2>
           <button
             type="button"
@@ -33,14 +31,20 @@ const InstanceWarningModal = ({ isOpen, onClose, onConfirm }) => {
         </div>
 
         <div className="px-[14px] py-[12px] flex flex-col gap-[10px]">
-          <p className="text-row leading-[1.55] text-t2">
-            Running instance segmentation{' '}
-            <span className="font-semibold text-warn">overrides every contour</span>{' '}
-            currently on this image.
-          </p>
-          <p className="text-row leading-[1.55] text-t2">
-            This cannot be undone. Do you want to proceed?
-          </p>
+          <div className="rounded-8 border border-ln2 bg-well px-[10px] py-[8px]">
+            <p className="text-row leading-[1.55] text-t2">
+              <span className="font-semibold text-ac">Patch (recommended)</span>{' '}
+              keeps existing annotations and adds only non-overlapping predictions.
+            </p>
+          </div>
+
+          <div className="flex items-start gap-[7px] rounded-8 border border-errLn bg-errBg px-[10px] py-[8px]">
+            <AlertTriangle size={14} className="mt-[2px] flex-none text-err" />
+            <p className="text-row leading-[1.55] text-t2">
+              <span className="font-semibold text-err">Override</span>{' '}
+              replaces all current contours with the new predictions. This cannot be undone.
+            </p>
+          </div>
         </div>
 
         <div className="flex justify-end gap-[7px] px-[14px] py-[11px] border-t border-ln">
@@ -53,10 +57,18 @@ const InstanceWarningModal = ({ isOpen, onClose, onConfirm }) => {
           </button>
           <button
             type="button"
-            onClick={onConfirm}
+            autoFocus
+            onClick={() => onConfirm('patch')}
+            className="h-7 px-[11px] rounded-7 bg-ac text-btn font-bold text-onAccent hover:brightness-110 transition-[filter]"
+          >
+            Patch and run
+          </button>
+          <button
+            type="button"
+            onClick={() => onConfirm('override')}
             className="h-7 px-[11px] rounded-7 border border-errLn bg-errBg2 text-btn font-bold text-err hover:brightness-110 transition-[filter]"
           >
-            Replace and run
+            Override and run
           </button>
         </div>
       </div>

--- a/src/components/annotationPage/modals/InstanceWarningModal.test.jsx
+++ b/src/components/annotationPage/modals/InstanceWarningModal.test.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import InstanceWarningModal from './InstanceWarningModal';
+
+describe('InstanceWarningModal', () => {
+  test('offers patch as the safe default and passes patch mode', () => {
+    const onConfirm = jest.fn();
+
+    render(
+      <InstanceWarningModal isOpen onClose={jest.fn()} onConfirm={onConfirm} />
+    );
+
+    expect(
+      screen.getByText(/keeps existing annotations and adds only non-overlapping predictions/i)
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Patch and run' }));
+
+    expect(onConfirm).toHaveBeenCalledWith('patch');
+  });
+
+  test('clearly warns before passing override mode', () => {
+    const onConfirm = jest.fn();
+
+    render(
+      <InstanceWarningModal isOpen onClose={jest.fn()} onConfirm={onConfirm} />
+    );
+
+    expect(
+      screen.getByText(/replaces all current contours with the new predictions/i)
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Override and run' }));
+
+    expect(onConfirm).toHaveBeenCalledWith('override');
+  });
+});

--- a/src/components/annotationPage/modals/InstanceWarningModal.test.jsx
+++ b/src/components/annotationPage/modals/InstanceWarningModal.test.jsx
@@ -1,13 +1,14 @@
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
+import { vi } from 'vitest';
 import InstanceWarningModal from './InstanceWarningModal';
 
 describe('InstanceWarningModal', () => {
   test('offers patch as the safe default and passes patch mode', () => {
-    const onConfirm = jest.fn();
+    const onConfirm = vi.fn();
 
     render(
-      <InstanceWarningModal isOpen onClose={jest.fn()} onConfirm={onConfirm} />
+      <InstanceWarningModal isOpen onClose={vi.fn()} onConfirm={onConfirm} />
     );
 
     expect(
@@ -20,10 +21,10 @@ describe('InstanceWarningModal', () => {
   });
 
   test('clearly warns before passing override mode', () => {
-    const onConfirm = jest.fn();
+    const onConfirm = vi.fn();
 
     render(
-      <InstanceWarningModal isOpen onClose={jest.fn()} onConfirm={onConfirm} />
+      <InstanceWarningModal isOpen onClose={vi.fn()} onConfirm={onConfirm} />
     );
 
     expect(

--- a/src/components/annotationPage/workspace/useAnnotationServices.js
+++ b/src/components/annotationPage/workspace/useAnnotationServices.js
@@ -32,14 +32,14 @@ const getFirstModelId = (models) => {
 
 /**
  * Model lists, selections, defaults, preloading and the instance-segmentation
- * warning flow for the three annotation services.
+ * write-mode flow for the three annotation services.
  *
  * Lifted verbatim from the old Services component so the options drawer only
  * has to render. The behaviour it preserves:
  *  - fetch each model list once,
  *  - force a deterministic default selection as soon as a list arrives,
  *  - push every selection change to the backend so the model is warm,
- *  - open the instance warning modal both from its Run button and from the
+ *  - open the instance write-mode modal both from its Run button and from the
  *    `3` shortcut, which sets `instanceRunRequested` in the store.
  */
 export default function useAnnotationServices() {
@@ -132,11 +132,11 @@ export default function useAnnotationServices() {
     setInstanceWarningModalOpen(false);
   };
 
-  const confirmInstanceRun = () => {
+  const confirmInstanceRun = (writeMode = 'patch') => {
     setShowInstanceWarning(false);
     setInstanceRunRequested(false);
     setInstanceWarningModalOpen(false);
-    runInstance();
+    runInstance(writeMode);
   };
 
   const services = [

--- a/src/components/models/ModelDetailPanel.jsx
+++ b/src/components/models/ModelDetailPanel.jsx
@@ -19,6 +19,7 @@ import {
   Zap,
   Gauge,
   MemoryStick,
+  Database,
   Layers,
   Scale,
   Maximize,
@@ -101,8 +102,14 @@ const ModelDetailPanel = ({ model, isFavorite = false, onToggleFavorite, onActio
 
   const tags = (Array.isArray(model.tags) ? model.tags : []).filter((t) => {
     const key = String(t.key || "").toLowerCase();
-    return key !== "task" && key !== "tasks" && !key.startsWith("task_");
+    return key !== "task" && key !== "tasks" && !key.startsWith("task_")
+      && !["publisher", "trained_label_names", "trained_on_dataset_id", "trained_on_dataset_name", "dataset_id", "dataset_name"]
+        .includes(key);
   });
+
+  const labelNames = Array.isArray(model.predictedLabelNames) ? model.predictedLabelNames : [];
+  const predictedLabels = labelNames.filter(Boolean);
+  const trainedOnDataset = model.trainedOnDatasetName || null;
 
   const capabilities = [
     model.pretrained && { label: "Pretrained", className: "bg-okBg text-ok" },
@@ -141,7 +148,8 @@ const ModelDetailPanel = ({ model, isFavorite = false, onToggleFavorite, onActio
     formatResolution(model.inputResolution) ||
     promptTypes.length > 0 ||
     model.refinementSupported ||
-    (Array.isArray(model.labelIds) && model.labelIds.length > 0) ||
+    predictedLabels.length > 0 ||
+    trainedOnDataset ||
     tags.length > 0;
 
   return (
@@ -300,9 +308,10 @@ const ModelDetailPanel = ({ model, isFavorite = false, onToggleFavorite, onActio
                 {model.refinementSupported ? "Supported" : null}
               </SpecRow>
               <SpecRow Icon={Hash} label="Predicted labels">
-                {Array.isArray(model.labelIds) && model.labelIds.length > 0
-                  ? model.labelIds.join(", ")
-                  : null}
+                {predictedLabels.length > 0 ? predictedLabels.join(", ") : null}
+              </SpecRow>
+              <SpecRow Icon={Database} label="Trained on dataset">
+                {trainedOnDataset}
               </SpecRow>
               {tags.length > 0 && (
                 <SpecRow Icon={Sparkles} label="Tags">

--- a/src/components/models/ModelDetailPanel.test.jsx
+++ b/src/components/models/ModelDetailPanel.test.jsx
@@ -1,0 +1,59 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import ModelDetailPanel from "./ModelDetailPanel";
+
+const baseModel = {
+  name: "Custom cell model",
+  identifier: "trained-mask2former",
+  tasks: ["instance-segmentation"],
+  status: "ready",
+  pretrained: true,
+  trainable: false,
+};
+
+describe("ModelDetailPanel trained-model provenance", () => {
+  it("shows label names and the training dataset", () => {
+    render(
+      <ModelDetailPanel
+        model={{
+          ...baseModel,
+          labelIds: [5, 6],
+          predictedLabelNames: ["cell", "nucleus"],
+          trainedOnDatasetId: "4",
+          trainedOnDatasetName: "Cells dataset",
+        }}
+      />
+    );
+
+    expect(screen.getByText("cell, nucleus")).toBeInTheDocument();
+    expect(screen.getByText("Cells dataset")).toBeInTheDocument();
+  });
+
+  it("hides publisher metadata from the specifications", () => {
+    render(
+      <ModelDetailPanel
+        model={{
+          ...baseModel,
+          tags: [{ key: "publisher", value: "facebook, dfki" }],
+        }}
+      />
+    );
+
+    expect(screen.queryByText("facebook, dfki")).not.toBeInTheDocument();
+  });
+
+  it("does not show IDs when readable provenance names are unavailable", () => {
+    render(
+      <ModelDetailPanel
+        model={{
+          ...baseModel,
+          labelIds: [5, 6],
+          trainedOnDatasetId: "4",
+        }}
+      />
+    );
+
+    expect(screen.queryByText("5, 6")).not.toBeInTheDocument();
+    expect(screen.queryByText("Dataset 4")).not.toBeInTheDocument();
+  });
+});

--- a/src/hooks/useInstanceSegmentation.js
+++ b/src/hooks/useInstanceSegmentation.js
@@ -14,7 +14,7 @@ export function useInstanceSegmentation(onSuccess, onError) {
   const setIsRunning = useSetIsRunningInstance();
   const instanceModelId = useInstanceModel(); // This is a string ID, not an object
 
-  const runInstance = useCallback(async () => {
+  const runInstance = useCallback(async (writeMode = 'patch') => {
     if (!instanceModelId) {
       const error = new Error('Please select an instance segmentation model first');
       if (onError) {
@@ -42,7 +42,8 @@ export function useInstanceSegmentation(onSuccess, onError) {
       // Call WebSocket method - objects will be added automatically via OBJECT_ADDED messages
       // instanceModelId is already the string identifier we need
       const response = await annotationSession.runInstance(
-        instanceModelId  // Model identifier (string)
+        instanceModelId, // Model identifier (string)
+        writeMode
       );
 
       if (!response.success) {

--- a/src/pages/ModelTrainingPage.jsx
+++ b/src/pages/ModelTrainingPage.jsx
@@ -32,6 +32,12 @@ const STATE_STYLE = {
 
 const fmtTime = (ms) => (ms ? new Date(ms).toLocaleString() : "—");
 const lastLoss = (snap) => (snap?.loss?.length ? snap.loss[snap.loss.length - 1].value : null);
+const formatScore = (value) => {
+  const numeric = Number(value);
+  return value == null || value === "" || !Number.isFinite(numeric)
+    ? "—"
+    : `${(numeric * 100).toFixed(1)}%`;
+};
 const RUN_NAME_PATTERN = /^[\p{L}\p{N}_\-\s]{1,80}$/u;
 
 const mergeRunSnapshot = (run, snapshot) => ({
@@ -44,6 +50,9 @@ const mergeRunSnapshot = (run, snapshot) => ({
   training_parameters: Object.keys(snapshot.training_parameters || {}).length
     ? snapshot.training_parameters
     : run.training_parameters,
+  validation_metrics: snapshot.validation_metrics ?? run.validation_metrics,
+  validation_metrics_unavailable: snapshot.validation_metrics_unavailable
+    ?? run.validation_metrics_unavailable,
   start_time: snapshot.start_time ?? run.start_time,
 });
 
@@ -84,7 +93,104 @@ function RunCard({ run, selected, onClick }) {
   );
 }
 
-function ProgressPanel({ snapshot, onStop, isStopping }) {
+function ValidationMetrics({ metrics, labels }) {
+  if (!metrics) return null;
+  const labelNames = new Map((labels || []).map((label) => [Number(label.id), label.name]));
+  const rows = Array.isArray(metrics.per_label) ? metrics.per_label : [];
+  const hasInstanceMetrics = [metrics.ap, metrics.ap50, metrics.ap75]
+    .some((value) => value != null && value !== "");
+
+  return (
+    <div className="p-4 rounded-lg border border-ln bg-well">
+      <h3 className="text-sm font-semibold text-t1">Performance metrics</h3>
+      <p className="text-[11px] text-t3 mt-1 mb-3">
+        Checked on images that were not used during training. For every score below, higher is better.
+      </p>
+      {hasInstanceMetrics && (
+        <div className="mb-4">
+          <h4 className="text-xs font-semibold text-t1">Instance metrics</h4>
+          <p className="text-[11px] text-t3 mt-1 mb-3">
+            AP (average precision) shows how well the model finds complete objects while balancing missed objects and extra detections.
+          </p>
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 items-stretch">
+            <div className="p-3 rounded-lg bg-p1 border border-acLn">
+              <span className="block text-[11px] text-t3">AP (primary instance score)</span>
+              <span className="block mt-1 text-2xl font-semibold text-t1">{formatScore(metrics.ap)}</span>
+            </div>
+            <div className="p-3 rounded-lg bg-p1 border border-ln">
+              <span className="block text-[11px] text-t3">AP50 · 50% overlap match</span>
+              <span className="block mt-1 text-2xl font-semibold text-t1">{formatScore(metrics.ap50)}</span>
+            </div>
+            <div className="p-3 rounded-lg bg-p1 border border-ln">
+              <span className="block text-[11px] text-t3">AP75 · 75% overlap match</span>
+              <span className="block mt-1 text-2xl font-semibold text-t1">{formatScore(metrics.ap75)}</span>
+            </div>
+          </div>
+        </div>
+      )}
+      <div className="border-t border-ln pt-4">
+        <h4 className="text-xs font-semibold text-t1">Pixel/mask-area metrics</h4>
+        <p className="text-[11px] text-t3 mt-1 mb-3">
+          These scores compare the predicted mask area with the real mask area.
+        </p>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-1 text-[11px] text-t3 mb-4">
+          <p><span className="font-medium text-t2">IoU:</span> how much the predicted area overlaps the real area.</p>
+          <p><span className="font-medium text-t2">F1 score:</span> balance between missed and extra predicted area.</p>
+          <p><span className="font-medium text-t2">Pixel precision:</span> how much of the predicted area is correct.</p>
+          <p><span className="font-medium text-t2">Recall:</span> how much of the real area the model found.</p>
+        </div>
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-4">
+          <div className="p-3 rounded-lg bg-p1 border border-ln">
+            <span className="block h-8 text-[11px] text-t3">Overall IoU (higher is better)</span>
+            <span className="text-lg font-semibold text-t1">{formatScore(metrics.macro_iou)}</span>
+          </div>
+          <div className="p-3 rounded-lg bg-p1 border border-ln">
+            <span className="block h-8 text-[11px] text-t3">Overall F1 (higher is better)</span>
+            <span className="text-lg font-semibold text-t1">{formatScore(metrics.macro_f1)}</span>
+          </div>
+          <div className="p-3 rounded-lg bg-p1 border border-ln">
+            <span className="block h-8 text-[11px] text-t3">Pixel precision (higher is better)</span>
+            <span className="text-lg font-semibold text-t1">{formatScore(metrics.macro_precision)}</span>
+          </div>
+          <div className="p-3 rounded-lg bg-p1 border border-ln">
+            <span className="block h-8 text-[11px] text-t3">Overall recall (higher is better)</span>
+            <span className="text-lg font-semibold text-t1">{formatScore(metrics.macro_recall)}</span>
+          </div>
+        </div>
+      </div>
+      {rows.length > 0 && (
+        <div className="overflow-x-auto">
+          <table className="w-full text-xs">
+            <thead>
+              <tr className="text-left text-t3 border-b border-ln">
+                <th className="py-2 pr-3 font-medium">Label</th>
+                <th className="py-2 px-3 font-medium text-right">IoU</th>
+                <th className="py-2 px-3 font-medium text-right">F1 score</th>
+                <th className="py-2 px-3 font-medium text-right">Precision</th>
+                <th className="py-2 pl-3 font-medium text-right">Recall</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((row) => (
+                <tr key={row.label_id} className="border-b border-ln last:border-0">
+                  <td className="py-2 pr-3 text-t1">
+                    {labelNames.get(Number(row.label_id)) || `Label ${row.label_id}`}
+                  </td>
+                  <td className="py-2 px-3 text-right text-t2">{formatScore(row.iou)}</td>
+                  <td className="py-2 px-3 text-right text-t2">{formatScore(row.f1)}</td>
+                  <td className="py-2 px-3 text-right text-t2">{formatScore(row.precision)}</td>
+                  <td className="py-2 pl-3 text-right text-t2">{formatScore(row.recall)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ProgressPanel({ snapshot, labels, onStop, isStopping }) {
   const { colors } = useThemeColors();
   const total = snapshot.total_epochs || 0;
   const current = snapshot.epoch || 0;
@@ -132,7 +238,7 @@ function ProgressPanel({ snapshot, onStop, isStopping }) {
         <div>
           <h3 className="text-sm font-semibold text-t1">Training loss</h3>
           <p className="text-[11px] text-t3 mb-2">
-            Mask2Former combined loss (classification + mask + dice), averaged per epoch. Lower is better.
+            Mask2Former training loss, averaged per epoch. Lower is better. This is a debugging signal, not the model-quality score.
           </p>
           <div className="w-full h-64">
             <ResponsiveContainer width="100%" height="100%">
@@ -163,6 +269,14 @@ function ProgressPanel({ snapshot, onStop, isStopping }) {
         <p className="text-sm text-t3">No loss logged yet.</p>
       )}
 
+      {snapshot.validation_metrics ? (
+        <ValidationMetrics metrics={snapshot.validation_metrics} labels={labels} />
+      ) : snapshot.validation_metrics_unavailable ? (
+        <p className="text-sm text-t3">
+          Validation metrics are unavailable because this dataset does not have enough images for a held-out set.
+        </p>
+      ) : null}
+
       {isActive && (
         <button
           onClick={onStop}
@@ -183,7 +297,9 @@ export default function ModelTrainingPage() {
 
   const [labels, setLabels] = useState([]);
   const [models, setModels] = useState([]);
-  const [modelKey, setModelKey] = useState("mask2former");
+  const [modelKey, setModelKey] = useState("");
+  const [modelLoadStatus, setModelLoadStatus] = useState("loading");
+  const [modelLoadError, setModelLoadError] = useState(null);
   const [selectedLabelIds, setSelectedLabelIds] = useState(() => new Set());
   const [hyperValues, setHyperValues] = useState({});
   const [showAdvanced, setShowAdvanced] = useState(true);
@@ -226,6 +342,10 @@ export default function ModelTrainingPage() {
   // Initial load: labels, models, runs.
   useEffect(() => {
     if (!datasetId) return;
+    setModels([]);
+    setModelKey("");
+    setModelLoadStatus("loading");
+    setModelLoadError(null);
     setAnnotationCountStatus("loading");
     setAnnotationCounts({});
     (async () => {
@@ -250,11 +370,20 @@ export default function ModelTrainingPage() {
       }
       try {
         const modelRes = await getInstanceModels();
-        const list = Array.isArray(modelRes?.result) ? modelRes.result : [];
+        const list = Array.isArray(modelRes?.result)
+          ? modelRes.result.filter((model) => model?.registry_key && model.trainable === true)
+          : [];
+        if (modelRes?.success !== true || list.length === 0) {
+          throw new Error("No trainable instance segmentation models are available.");
+        }
         setModels(list);
-        if (list.length > 0) setModelKey(list[0].registry_key);
+        setModelKey(list[0].registry_key);
+        setModelLoadStatus("success");
       } catch (e) {
-        // fall back to default key
+        setModels([]);
+        setModelKey("");
+        setModelLoadStatus("error");
+        setModelLoadError(e.message || "Unable to load trainable instance segmentation models.");
       }
     })();
     loadRuns();
@@ -304,7 +433,7 @@ export default function ModelTrainingPage() {
   });
 
   const handleStart = async () => {
-    if (getRunNameError(modelRunName)) return;
+    if (modelLoadStatus !== "success" || !selectedModel || getRunNameError(modelRunName)) return;
     setError(null);
     setIsStarting(true);
     try {
@@ -430,10 +559,32 @@ export default function ModelTrainingPage() {
 
             {mode === "run" && selectedRun ? (
               <div className="max-w-3xl">
-                <ProgressPanel snapshot={selectedRun} onStop={handleStop} isStopping={isStopping} />
+                <ProgressPanel snapshot={selectedRun} labels={labels} onStop={handleStop} isStopping={isStopping} />
               </div>
             ) : (
-              <div className="max-w-2xl space-y-6">
+              <div className="max-w-2xl">
+                {modelLoadStatus === "loading" && (
+                  <div className="p-4 rounded-xl border border-ln bg-well" role="status">
+                    <button
+                      type="button"
+                      disabled
+                      className="inline-flex items-center gap-2 px-3 py-2 text-sm font-medium rounded-lg bg-hv text-t3 cursor-not-allowed"
+                    >
+                      <Loader2 className="w-4 h-4 animate-spin" />
+                      Loading models…
+                    </button>
+                  </div>
+                )}
+
+                {modelLoadStatus === "error" && (
+                  <div className="p-4 rounded-xl border border-errLn bg-errBg text-sm text-err" role="alert">
+                    <p className="font-medium">Unable to load model configuration.</p>
+                    <p className="mt-1">{modelLoadError}</p>
+                  </div>
+                )}
+
+                {modelLoadStatus === "success" && (
+                  <div className="space-y-6">
                 {/* Model */}
                 <div>
                   <label className="block text-sm font-medium text-t1 mb-1">Model</label>
@@ -442,7 +593,6 @@ export default function ModelTrainingPage() {
                     onChange={(e) => setModelKey(e.target.value)}
                     className="w-full px-3 py-2 text-sm border border-ln2 rounded-lg focus:ring-2 focus:ring-ac focus:border-transparent"
                   >
-                    {models.length === 0 && <option value="mask2former">Mask2Former</option>}
                     {models.map((m) => (
                       <option key={m.registry_key} value={m.registry_key}>{m.name || m.registry_key}</option>
                     ))}
@@ -565,12 +715,14 @@ export default function ModelTrainingPage() {
 
                 <button
                   onClick={handleStart}
-                  disabled={isStarting || selectedLabelIds.size === 0 || noAnnotations || Boolean(runNameError)}
+                  disabled={modelLoadStatus !== "success" || !selectedModel || isStarting || selectedLabelIds.size === 0 || noAnnotations || Boolean(runNameError)}
                   className="inline-flex items-center gap-2 px-5 py-2.5 text-sm font-medium text-onAccent bg-accent rounded-lg hover:brightness-110 transition-colors disabled:opacity-60"
                 >
                   {isStarting ? <Loader2 className="w-4 h-4 animate-spin" /> : <GraduationCap className="w-4 h-4" />}
                   {isStarting ? "Starting…" : "Start Training"}
                 </button>
+                  </div>
+                )}
               </div>
             )}
           </main>

--- a/src/pages/ModelTrainingPage.jsx
+++ b/src/pages/ModelTrainingPage.jsx
@@ -20,15 +20,33 @@ import {
 } from "../api";
 import useThemeColors from "../hooks/useThemeColors";
 
-const TERMINAL = new Set(["SUCCESS", "FAILED", "CANCELLED"]);
+const TERMINAL = new Set(["SUCCESS", "FAILED", "CANCELLED", "TIMED_OUT"]);
+
+const STATE_LABEL = {
+  STARTING: "Starting",
+  PROGRESS: "In progress",
+  SUCCESS: "Completed",
+  FAILED: "Failed",
+  CANCELLED: "Cancelled",
+  TIMED_OUT: "Timed out",
+  starting: "Starting",
+};
 
 const STATE_STYLE = {
+  STARTING: "bg-well text-t2",
   PROGRESS: "bg-acS text-ac",
   SUCCESS: "bg-okBg text-ok",
   FAILED: "bg-errBg text-err",
   CANCELLED: "bg-warnBg text-warn",
+  TIMED_OUT: "bg-errBg text-err",
   starting: "bg-well text-t2",
 };
+
+const STARTING_WARNING_AFTER_MS = 60_000;
+const STARTING_WARNING_TEXT =
+  "This is taking longer than usual. Training will be cancelled if a worker does not become available in time.";
+const FALLBACK_TIMEOUT_MESSAGE =
+  "Training did not start before the queue deadline.";
 
 const fmtTime = (ms) => (ms ? new Date(ms).toLocaleString() : "—");
 const lastLoss = (snap) => (snap?.loss?.length ? snap.loss[snap.loss.length - 1].value : null);
@@ -54,7 +72,10 @@ const mergeRunSnapshot = (run, snapshot) => ({
   validation_metrics_unavailable: snapshot.validation_metrics_unavailable
     ?? run.validation_metrics_unavailable,
   start_time: snapshot.start_time ?? run.start_time,
+  queued_at: snapshot.queued_at ?? run.queued_at,
+  start_deadline: snapshot.start_deadline ?? run.start_deadline,
 });
+
 
 const getRunNameError = (value) => {
   if (value.length === 0) return null;
@@ -66,6 +87,9 @@ const getRunNameError = (value) => {
 };
 
 function RunCard({ run, selected, onClick }) {
+  const displayLabel = STATE_LABEL[run.state] || run.state || "Unknown";
+  const badgeStyle = STATE_STYLE[run.state] || STATE_STYLE.STARTING;
+
   return (
     <button
       onClick={onClick}
@@ -74,8 +98,8 @@ function RunCard({ run, selected, onClick }) {
       }`}
     >
       <div className="flex items-center justify-between mb-1">
-        <span className={`text-[11px] font-semibold px-2 py-0.5 rounded-full ${STATE_STYLE[run.state] || STATE_STYLE.starting}`}>
-          {run.state}
+        <span className={`text-[11px] font-semibold px-2 py-0.5 rounded-full ${badgeStyle}`}>
+          {displayLabel}
         </span>
         <span className="text-[11px] text-t3 flex items-center gap-1">
           <Clock size={11} /> {fmtTime(run.start_time)}
@@ -197,22 +221,79 @@ function ProgressPanel({ snapshot, labels, onStop, isStopping }) {
   const percent = total ? Math.min(100, Math.round((current / total) * 100)) : 0;
   const lossData = (snapshot.loss || []).map((d) => ({ epoch: d.epoch, loss: d.value }));
   const trainingParameters = snapshot.training_parameters || {};
-  const isActive = !TERMINAL.has(snapshot.state) && snapshot.state !== "starting";
+
+  const isTerminal = TERMINAL.has(snapshot.state);
+  const isStarting = snapshot.state === "STARTING" || snapshot.state === "starting";
+  const canStop = !isTerminal && Boolean(snapshot.task_id);
+
+  const displayLabel = STATE_LABEL[snapshot.state] || snapshot.state || "Unknown";
+  const badgeStyle = STATE_STYLE[snapshot.state] || STATE_STYLE.STARTING;
+
+  // Delayed-start warning interval: updates every second while in STARTING state
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    if (!isStarting) return;
+    const interval = setInterval(() => {
+      setNow(Date.now());
+    }, 1000);
+    return () => clearInterval(interval);
+  }, [isStarting]);
+
+  const queuedMs = snapshot.queued_at != null
+    ? snapshot.queued_at * 1000
+    : snapshot.start_time;
+  const elapsedMs = queuedMs != null ? now - queuedMs : 0;
+  const showSlowStartWarning = isStarting && elapsedMs >= STARTING_WARNING_AFTER_MS;
+
+  // Terminal message resolution
+  let terminalMessage = null;
+  if (snapshot.state === "TIMED_OUT") {
+    terminalMessage = snapshot.message || FALLBACK_TIMEOUT_MESSAGE;
+  } else if (snapshot.state === "FAILED") {
+    terminalMessage = snapshot.message || "Training failed.";
+  } else if (snapshot.state === "CANCELLED") {
+    terminalMessage = snapshot.message || "Training cancelled.";
+  }
 
   return (
     <div className="space-y-4">
       <div className="flex items-center gap-2 text-sm text-t2">
-        <span className={`text-xs font-semibold px-2 py-0.5 rounded-full ${STATE_STYLE[snapshot.state] || STATE_STYLE.starting}`}>
-          {snapshot.state}
+        <span className={`text-xs font-semibold px-2 py-0.5 rounded-full ${badgeStyle}`}>
+          {displayLabel}
         </span>
-        {snapshot.state === "starting" ? (
-          <span className="flex items-center gap-1"><Loader2 className="w-4 h-4 animate-spin" /> Waiting for worker…</span>
-        ) : (
+        {isStarting ? (
+          <span className="flex items-center gap-1">
+            <Loader2 className="w-4 h-4 animate-spin" /> Waiting for worker…
+          </span>
+        ) : snapshot.state === "PROGRESS" ? (
           <span className="flex items-center gap-1">
             <Cpu className="w-4 h-4 text-ac" /> Epoch {current}{total ? ` / ${total}` : ""}
           </span>
-        )}
+        ) : null}
       </div>
+
+      {showSlowStartWarning && (
+        <div
+          role="status"
+          className="flex items-center gap-2 p-3 bg-warnBg border border-warnLn rounded-lg text-sm text-warn"
+        >
+          <AlertTriangle className="w-4 h-4 shrink-0" />
+          <span>{STARTING_WARNING_TEXT}</span>
+        </div>
+      )}
+
+      {isTerminal && terminalMessage && (
+        <div
+          role={snapshot.state === "FAILED" || snapshot.state === "TIMED_OUT" ? "alert" : "status"}
+          className={`p-3 rounded-lg border text-sm ${
+            snapshot.state === "CANCELLED"
+              ? "bg-warnBg border-warnLn text-warn"
+              : "bg-errBg border-errLn text-err"
+          }`}
+        >
+          <p className="font-medium">{terminalMessage}</p>
+        </div>
+      )}
 
       {Object.keys(trainingParameters).length > 0 && (
         <div className="p-3 rounded-lg border border-ln bg-well">
@@ -277,7 +358,7 @@ function ProgressPanel({ snapshot, labels, onStop, isStopping }) {
         </p>
       ) : null}
 
-      {isActive && (
+      {canStop && (
         <button
           onClick={onStop}
           disabled={isStopping}
@@ -316,6 +397,7 @@ export default function ModelTrainingPage() {
   const [modelRunName, setModelRunName] = useState("");
 
   const streamRef = useRef(null);
+  const restoredDatasetIdRef = useRef(null);
 
   const selectedModel = useMemo(
     () => models.find((m) => m.registry_key === modelKey) || null,
@@ -326,6 +408,10 @@ export default function ModelTrainingPage() {
     try {
       const res = await getInstanceTrainingRuns(datasetId);
       const serverRuns = Array.isArray(res?.runs) ? res.runs : [];
+      const sortedServerRuns = [...serverRuns].sort(
+        (a, b) => (b.start_time || 0) - (a.start_time || 0)
+      );
+
       setRuns((currentRuns) => {
         const serverTaskIds = new Set(serverRuns.map((run) => run.task_id).filter(Boolean));
         const pendingLocalRuns = currentRuns.filter(
@@ -334,6 +420,19 @@ export default function ModelTrainingPage() {
         return [...serverRuns, ...pendingLocalRuns]
           .sort((a, b) => (b.start_time || 0) - (a.start_time || 0));
       });
+
+      // Restore active run only once per dataset load
+      if (restoredDatasetIdRef.current !== datasetId) {
+        restoredDatasetIdRef.current = datasetId;
+        const newestActiveRun = sortedServerRuns.find(
+          (run) => !TERMINAL.has(run.state) && Boolean(run.task_id)
+        );
+        if (newestActiveRun) {
+          setMode("run");
+          setSelectedRun(newestActiveRun);
+          setActiveTaskId(newestActiveRun.task_id);
+        }
+      }
     } catch (e) {
       // non-fatal
     }
@@ -342,6 +441,7 @@ export default function ModelTrainingPage() {
   // Initial load: labels, models, runs.
   useEffect(() => {
     if (!datasetId) return;
+    restoredDatasetIdRef.current = null;
     setModels([]);
     setModelKey("");
     setModelLoadStatus("loading");
@@ -449,7 +549,9 @@ export default function ModelTrainingPage() {
       const optimisticRun = {
         task_id: res.task_id,
         run_id: null,
-        state: "starting",
+        state: "STARTING",
+        training_state: "starting",
+        queued_at: Date.now() / 1000,
         epoch: 0,
         total_epochs: hyperValues.epochs ? Number(hyperValues.epochs) : null,
         loss: [],
@@ -474,10 +576,11 @@ export default function ModelTrainingPage() {
   };
 
   const handleStop = async () => {
-    if (!activeTaskId) return;
+    const targetTaskId = activeTaskId || selectedRun?.task_id;
+    if (!targetTaskId) return;
     setIsStopping(true);
     try {
-      const snapshot = await cancelInstanceTraining(activeTaskId);
+      const snapshot = await cancelInstanceTraining(targetTaskId);
       setSelectedRun((currentRun) => (currentRun ? mergeRunSnapshot(currentRun, snapshot) : snapshot));
     } catch (err) {
       setError(err.message || "Failed to stop training.");
@@ -495,6 +598,7 @@ export default function ModelTrainingPage() {
     // Keep streaming a still-running run; otherwise show its static snapshot.
     setActiveTaskId(!TERMINAL.has(run.state) && run.task_id ? run.task_id : null);
   };
+
 
   const handleNewTraining = () => {
     setActiveTaskId(null);
@@ -544,7 +648,12 @@ export default function ModelTrainingPage() {
                 <RunCard
                   key={run.run_id || run.task_id}
                   run={run}
-                  selected={mode === "run" && selectedRun && (selectedRun.run_id === run.run_id)}
+                  selected={
+                    mode === "run" &&
+                    selectedRun &&
+                    ((selectedRun.run_id && selectedRun.run_id === run.run_id) ||
+                      (selectedRun.task_id && selectedRun.task_id === run.task_id))
+                  }
                   onClick={() => handleSelectRun(run)}
                 />
               ))}

--- a/src/pages/ModelTrainingPage.jsx
+++ b/src/pages/ModelTrainingPage.jsx
@@ -398,6 +398,9 @@ export default function ModelTrainingPage() {
 
   const streamRef = useRef(null);
   const restoredDatasetIdRef = useRef(null);
+  const currentDatasetIdRef = useRef(datasetId);
+  const activeTaskDatasetIdRef = useRef(null);
+  currentDatasetIdRef.current = datasetId;
 
   const selectedModel = useMemo(
     () => models.find((m) => m.registry_key === modelKey) || null,
@@ -407,6 +410,7 @@ export default function ModelTrainingPage() {
   const loadRuns = useCallback(async () => {
     try {
       const res = await getInstanceTrainingRuns(datasetId);
+      if (currentDatasetIdRef.current !== datasetId) return;
       const serverRuns = Array.isArray(res?.runs) ? res.runs : [];
       const sortedServerRuns = [...serverRuns].sort(
         (a, b) => (b.start_time || 0) - (a.start_time || 0)
@@ -430,6 +434,7 @@ export default function ModelTrainingPage() {
         if (newestActiveRun) {
           setMode("run");
           setSelectedRun(newestActiveRun);
+          activeTaskDatasetIdRef.current = datasetId;
           setActiveTaskId(newestActiveRun.task_id);
         }
       }
@@ -441,7 +446,16 @@ export default function ModelTrainingPage() {
   // Initial load: labels, models, runs.
   useEffect(() => {
     if (!datasetId) return;
+    streamRef.current?.abort();
+    streamRef.current = null;
     restoredDatasetIdRef.current = null;
+    setRuns([]);
+    setMode("config");
+    setSelectedRun(null);
+    activeTaskDatasetIdRef.current = null;
+    setActiveTaskId(null);
+    setIsStarting(false);
+    setIsStopping(false);
     setModels([]);
     setModelKey("");
     setModelLoadStatus("loading");
@@ -499,7 +513,7 @@ export default function ModelTrainingPage() {
 
   // Stream progress for the active task; tear down on change/unmount.
   useEffect(() => {
-    if (!activeTaskId) return;
+    if (!activeTaskId || activeTaskDatasetIdRef.current !== datasetId) return;
     const controller = streamInstanceTrainingProgress(
       activeTaskId,
       (snap) => {
@@ -514,6 +528,7 @@ export default function ModelTrainingPage() {
           ));
         });
         if (TERMINAL.has(snap.state)) {
+          activeTaskDatasetIdRef.current = null;
           setActiveTaskId(null);
           loadRuns();
         }
@@ -522,7 +537,7 @@ export default function ModelTrainingPage() {
     );
     streamRef.current = controller;
     return () => controller.abort();
-  }, [activeTaskId, loadRuns]);
+  }, [activeTaskId, datasetId, loadRuns]);
 
   const setHyper = (key, value) => setHyperValues((prev) => ({ ...prev, [key]: value }));
 
@@ -566,6 +581,7 @@ export default function ModelTrainingPage() {
       ]);
       setMode("run");
       setSelectedRun(optimisticRun);
+      activeTaskDatasetIdRef.current = datasetId;
       setActiveTaskId(res.task_id);
       loadRuns();
     } catch (err) {
@@ -588,6 +604,7 @@ export default function ModelTrainingPage() {
     } finally {
       setIsStopping(false);
     }
+    activeTaskDatasetIdRef.current = null;
     setActiveTaskId(null);
     loadRuns();
   };
@@ -596,11 +613,14 @@ export default function ModelTrainingPage() {
     setMode("run");
     setSelectedRun(run);
     // Keep streaming a still-running run; otherwise show its static snapshot.
-    setActiveTaskId(!TERMINAL.has(run.state) && run.task_id ? run.task_id : null);
+    const nextTaskId = !TERMINAL.has(run.state) && run.task_id ? run.task_id : null;
+    activeTaskDatasetIdRef.current = nextTaskId ? datasetId : null;
+    setActiveTaskId(nextTaskId);
   };
 
 
   const handleNewTraining = () => {
+    activeTaskDatasetIdRef.current = null;
     setActiveTaskId(null);
     setSelectedRun(null);
     setMode("config");

--- a/src/pages/ModelTrainingPage.test.js
+++ b/src/pages/ModelTrainingPage.test.js
@@ -1,0 +1,107 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import ModelTrainingPage from "./ModelTrainingPage";
+import {
+  cancelInstanceTraining,
+  fetchLabels,
+  getInstanceLabelAnnotationCounts,
+  getInstanceModels,
+  getInstanceTrainingRuns,
+  startInstanceTraining,
+  streamInstanceTrainingProgress,
+} from "../api";
+
+jest.mock("react-router-dom", () => ({
+  useParams: () => ({ datasetId: "42" }),
+}), { virtual: true });
+
+jest.mock("../contexts/DatasetContext", () => ({
+  useDataset: () => ({ currentDataset: { name: "Test dataset" } }),
+}));
+
+jest.mock("../components/datasets/gallery/DatasetManagementLayout", () => ({ children }) => (
+  <div>{children}</div>
+));
+
+jest.mock("../components/datasets/training/DynamicHyperParameter", () => () => null);
+
+jest.mock("../api", () => ({
+  cancelInstanceTraining: jest.fn(),
+  fetchLabels: jest.fn(),
+  getInstanceLabelAnnotationCounts: jest.fn(),
+  getInstanceModels: jest.fn(),
+  getInstanceTrainingRuns: jest.fn(),
+  startInstanceTraining: jest.fn(),
+  streamInstanceTrainingProgress: jest.fn(),
+}));
+
+describe("ModelTrainingPage model loading", () => {
+  beforeEach(() => {
+    fetchLabels.mockResolvedValue({ labels: { id_to_label_object: {} } });
+    getInstanceLabelAnnotationCounts.mockResolvedValue({
+      success: true,
+      reviewed_annotation_counts: {},
+    });
+    getInstanceTrainingRuns.mockResolvedValue({ runs: [] });
+    cancelInstanceTraining.mockResolvedValue({});
+    startInstanceTraining.mockResolvedValue({ task_id: "task-1" });
+    streamInstanceTrainingProgress.mockReturnValue({ abort: jest.fn() });
+  });
+
+  it("keeps the configuration unavailable while models are loading", async () => {
+    let resolveModels;
+    getInstanceModels.mockReturnValue(new Promise((resolve) => {
+      resolveModels = resolve;
+    }));
+
+    render(<ModelTrainingPage />);
+
+    expect(screen.getByRole("button", { name: /loading models/i })).toBeDisabled();
+    expect(screen.queryByRole("button", { name: /start training/i })).not.toBeInTheDocument();
+
+    resolveModels({
+      success: true,
+      result: [{ registry_key: "real-model", name: "Real model", trainable: true, training_parameters: [] }],
+    });
+    await waitFor(() => expect(screen.getByRole("combobox")).toHaveValue("real-model"));
+  });
+
+  it("excludes trained output models from the training-model selector", async () => {
+    getInstanceModels.mockResolvedValue({
+      success: true,
+      result: [
+        { registry_key: "trained-output", name: "My trained model", trainable: false },
+        { registry_key: "mask2former", name: "Mask2Former", trainable: true, training_parameters: [] },
+      ],
+    });
+
+    render(<ModelTrainingPage />);
+
+    const selector = await screen.findByRole("combobox");
+    expect(selector).toHaveValue("mask2former");
+    expect(screen.queryByRole("option", { name: "My trained model" })).not.toBeInTheDocument();
+  });
+
+  it("shows a model error instead of falling back when loading fails", async () => {
+    getInstanceModels.mockRejectedValue(new Error("Registry unavailable"));
+
+    render(<ModelTrainingPage />);
+
+    const error = await screen.findByRole("alert");
+    expect(error).toHaveTextContent("Unable to load model configuration.");
+    expect(error).toHaveTextContent("Registry unavailable");
+    expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /start training/i })).not.toBeInTheDocument();
+  });
+
+  it("shows a no-model state when the registry returns no trainable models", async () => {
+    getInstanceModels.mockResolvedValue({ success: true, result: [] });
+
+    render(<ModelTrainingPage />);
+
+    const error = await screen.findByRole("alert");
+    expect(error).toHaveTextContent("No trainable instance segmentation models are available.");
+    expect(screen.queryByText("Mask2Former")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /start training/i })).not.toBeInTheDocument();
+  });
+});

--- a/src/pages/ModelTrainingPage.test.js
+++ b/src/pages/ModelTrainingPage.test.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, fireEvent, act } from "@testing-library/react";
 import ModelTrainingPage from "./ModelTrainingPage";
 import {
   cancelInstanceTraining,
@@ -37,6 +37,7 @@ jest.mock("../api", () => ({
 
 describe("ModelTrainingPage model loading", () => {
   beforeEach(() => {
+    jest.clearAllMocks();
     fetchLabels.mockResolvedValue({ labels: { id_to_label_object: {} } });
     getInstanceLabelAnnotationCounts.mockResolvedValue({
       success: true,
@@ -103,5 +104,390 @@ describe("ModelTrainingPage model loading", () => {
     expect(error).toHaveTextContent("No trainable instance segmentation models are available.");
     expect(screen.queryByText("Mask2Former")).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /start training/i })).not.toBeInTheDocument();
+  });
+});
+
+describe("Task 3: Frontend lifecycle presentation normalization", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    fetchLabels.mockResolvedValue({
+      labels: {
+        id_to_label_object: { 1: { id: 1, name: "cell" } },
+      },
+    });
+    getInstanceLabelAnnotationCounts.mockResolvedValue({
+      success: true,
+      reviewed_annotation_counts: { 1: 5 },
+    });
+    getInstanceModels.mockResolvedValue({
+      success: true,
+      result: [{ registry_key: "mask2former", name: "Mask2Former", trainable: true, training_parameters: [] }],
+    });
+    cancelInstanceTraining.mockResolvedValue({});
+    startInstanceTraining.mockResolvedValue({ task_id: "task-start-123" });
+    streamInstanceTrainingProgress.mockReturnValue({ abort: jest.fn() });
+  });
+
+  it("renders friendly display labels for all canonical lifecycle states", async () => {
+    const historicalRuns = [
+      { task_id: "t1", run_id: "r1", state: "STARTING", start_time: 1000, label_ids: [1] },
+      { task_id: "t2", run_id: "r2", state: "PROGRESS", start_time: 2000, label_ids: [1] },
+      { task_id: "t3", run_id: "r3", state: "SUCCESS", start_time: 3000, label_ids: [1] },
+      { task_id: "t4", run_id: "r4", state: "FAILED", start_time: 4000, label_ids: [1] },
+      { task_id: "t5", run_id: "r5", state: "CANCELLED", start_time: 5000, label_ids: [1] },
+      { task_id: "t6", run_id: "r6", state: "TIMED_OUT", start_time: 6000, label_ids: [1] },
+      { task_id: "t7", run_id: "r7", state: "CUSTOM_UNKNOWN", start_time: 7000, label_ids: [1] },
+    ];
+    getInstanceTrainingRuns.mockResolvedValue({ runs: historicalRuns });
+
+    render(<ModelTrainingPage />);
+
+    // Check RunCard state labels in the history sidebar
+    expect(await screen.findByText("Starting")).toBeInTheDocument();
+    expect(screen.getByText("In progress")).toBeInTheDocument();
+    expect(screen.getByText("Completed")).toBeInTheDocument();
+    expect(screen.getByText("Failed")).toBeInTheDocument();
+    expect(screen.getByText("Cancelled")).toBeInTheDocument();
+    expect(screen.getByText("Timed out")).toBeInTheDocument();
+    expect(screen.getAllByText("CUSTOM_UNKNOWN")[0]).toBeInTheDocument();
+  });
+
+  it("treats TIMED_OUT as a terminal state and hides Stop Training", async () => {
+    const timedOutRun = {
+      task_id: "t-timeout",
+      run_id: "r-timeout",
+      state: "TIMED_OUT",
+      message: "Training did not start before the queue deadline.",
+      start_time: 1000,
+      label_ids: [1],
+    };
+    getInstanceTrainingRuns.mockResolvedValue({ runs: [timedOutRun] });
+
+    render(<ModelTrainingPage />);
+
+    const runCard = await screen.findByText("Timed out");
+    fireEvent.click(runCard);
+
+    expect(screen.queryByRole("button", { name: /stop training/i })).not.toBeInTheDocument();
+    expect(streamInstanceTrainingProgress).not.toHaveBeenCalled();
+  });
+
+  it("shows Stop Training button for non-terminal STARTING runs and hides it for terminal runs", async () => {
+    const runs = [
+      { task_id: "t-start", run_id: "r-start", state: "STARTING", start_time: 2000, label_ids: [1] },
+      { task_id: "t-done", run_id: "r-done", state: "SUCCESS", start_time: 1000, label_ids: [1] },
+    ];
+    getInstanceTrainingRuns.mockResolvedValue({ runs });
+
+    render(<ModelTrainingPage />);
+
+    // By default, newest active run (t-start) is restored
+    expect(await screen.findByRole("button", { name: /stop training/i })).toBeInTheDocument();
+
+    // Select the completed run
+    const completedCard = screen.getByText("Completed");
+    fireEvent.click(completedCard);
+
+    expect(screen.queryByRole("button", { name: /stop training/i })).not.toBeInTheDocument();
+  });
+
+  it("uses optimistic STARTING state and opens progress stream on start", async () => {
+    getInstanceTrainingRuns.mockResolvedValue({ runs: [] });
+    render(<ModelTrainingPage />);
+
+    const startBtn = await screen.findByRole("button", { name: /start training/i });
+    fireEvent.click(startBtn);
+
+    await waitFor(() => {
+      expect(streamInstanceTrainingProgress).toHaveBeenCalledWith(
+        "task-start-123",
+        expect.any(Function),
+        expect.any(Function)
+      );
+    });
+
+    expect(await screen.findByText("Waiting for worker…")).toBeInTheDocument();
+  });
+});
+
+describe("Task 4: Active run restoration after refresh", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    fetchLabels.mockResolvedValue({
+      labels: { id_to_label_object: { 1: { id: 1, name: "cell" } } },
+    });
+    getInstanceLabelAnnotationCounts.mockResolvedValue({
+      success: true,
+      reviewed_annotation_counts: { 1: 5 },
+    });
+    getInstanceModels.mockResolvedValue({
+      success: true,
+      result: [{ registry_key: "mask2former", name: "Mask2Former", trainable: true, training_parameters: [] }],
+    });
+    streamInstanceTrainingProgress.mockReturnValue({ abort: jest.fn() });
+  });
+
+  it("restores an active STARTING run on page load and starts progress streaming", async () => {
+    const runs = [
+      { task_id: "task-starting-99", run_id: "run-99", state: "STARTING", start_time: 5000, label_ids: [1] },
+    ];
+    getInstanceTrainingRuns.mockResolvedValue({ runs });
+
+    render(<ModelTrainingPage />);
+
+    await waitFor(() => {
+      expect(streamInstanceTrainingProgress).toHaveBeenCalledWith(
+        "task-starting-99",
+        expect.any(Function),
+        expect.any(Function)
+      );
+    });
+
+    expect(await screen.findByText("Waiting for worker…")).toBeInTheDocument();
+  });
+
+  it("restores an active PROGRESS run on page load", async () => {
+    const runs = [
+      { task_id: "task-prog-1", run_id: "run-prog-1", state: "PROGRESS", epoch: 3, total_epochs: 10, start_time: 5000, label_ids: [1] },
+    ];
+    getInstanceTrainingRuns.mockResolvedValue({ runs });
+
+    render(<ModelTrainingPage />);
+
+    await waitFor(() => {
+      expect(streamInstanceTrainingProgress).toHaveBeenCalledWith(
+        "task-prog-1",
+        expect.any(Function),
+        expect.any(Function)
+      );
+    });
+
+    expect(await screen.findByText(/epoch 3 \/ 10/i)).toBeInTheDocument();
+  });
+
+  it("does not start streaming when only terminal runs are present", async () => {
+    const runs = [
+      { task_id: "t-done", run_id: "r-done", state: "SUCCESS", start_time: 1000, label_ids: [1] },
+      { task_id: "t-failed", run_id: "r-failed", state: "FAILED", start_time: 2000, label_ids: [1] },
+    ];
+    getInstanceTrainingRuns.mockResolvedValue({ runs });
+
+    render(<ModelTrainingPage />);
+
+    await screen.findByRole("button", { name: /start training/i });
+    expect(streamInstanceTrainingProgress).not.toHaveBeenCalled();
+  });
+
+  it("restores only the newest active run when multiple active runs exist", async () => {
+    const runs = [
+      { task_id: "task-older", run_id: "run-older", state: "STARTING", start_time: 1000, label_ids: [1] },
+      { task_id: "task-newer", run_id: "run-newer", state: "PROGRESS", start_time: 5000, label_ids: [1] },
+    ];
+    getInstanceTrainingRuns.mockResolvedValue({ runs });
+
+    render(<ModelTrainingPage />);
+
+    await waitFor(() => expect(streamInstanceTrainingProgress).toHaveBeenCalledTimes(1));
+    expect(streamInstanceTrainingProgress).toHaveBeenCalledWith(
+      "task-newer",
+      expect.any(Function),
+      expect.any(Function)
+    );
+  });
+
+  it("aborts active stream controller on unmount", async () => {
+    const abortMock = jest.fn();
+    streamInstanceTrainingProgress.mockReturnValue({ abort: abortMock });
+
+    const runs = [
+      { task_id: "task-active", run_id: "run-active", state: "STARTING", start_time: 5000, label_ids: [1] },
+    ];
+    getInstanceTrainingRuns.mockResolvedValue({ runs });
+
+    const { unmount } = render(<ModelTrainingPage />);
+
+    await waitFor(() => expect(streamInstanceTrainingProgress).toHaveBeenCalled());
+    unmount();
+    expect(abortMock).toHaveBeenCalled();
+  });
+});
+
+describe("Task 5: Slow-start warning and terminal messages", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    fetchLabels.mockResolvedValue({
+      labels: { id_to_label_object: { 1: { id: 1, name: "cell" } } },
+    });
+    getInstanceLabelAnnotationCounts.mockResolvedValue({
+      success: true,
+      reviewed_annotation_counts: { 1: 5 },
+    });
+    getInstanceModels.mockResolvedValue({
+      success: true,
+      result: [{ registry_key: "mask2former", name: "Mask2Former", trainable: true, training_parameters: [] }],
+    });
+    cancelInstanceTraining.mockResolvedValue({
+      task_id: "task-cancel-1",
+      state: "CANCELLED",
+      message: "Training cancelled by user.",
+    });
+    streamInstanceTrainingProgress.mockReturnValue({ abort: jest.fn() });
+  });
+
+  it("shows slow-start warning only after 60 seconds of STARTING and removes it on PROGRESS", async () => {
+    let streamCallback;
+    streamInstanceTrainingProgress.mockImplementation((taskId, onSnap) => {
+      streamCallback = onSnap;
+      return { abort: jest.fn() };
+    });
+
+    jest.useFakeTimers();
+    try {
+      const baseTime = 1000000;
+      jest.setSystemTime(baseTime);
+
+      const startingRun = {
+        task_id: "task-slow",
+        run_id: "run-slow",
+        state: "STARTING",
+        queued_at: baseTime / 1000, // Unix seconds
+        start_time: baseTime,
+        label_ids: [1],
+      };
+      getInstanceTrainingRuns.mockResolvedValue({ runs: [startingRun] });
+
+      render(<ModelTrainingPage />);
+
+      // Flush mount promises
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(screen.getByText("Waiting for worker…")).toBeInTheDocument();
+
+      // At 59 seconds: no warning
+      act(() => {
+        jest.advanceTimersByTime(59000);
+      });
+      expect(screen.queryByText(/This is taking longer than usual/i)).not.toBeInTheDocument();
+
+      // At 60 seconds: warning is shown
+      act(() => {
+        jest.advanceTimersByTime(1000);
+      });
+      expect(screen.getByText(/This is taking longer than usual/i)).toBeInTheDocument();
+
+      // When state transitions to PROGRESS: warning disappears
+      act(() => {
+        streamCallback({
+          task_id: "task-slow",
+          run_id: "run-slow",
+          state: "PROGRESS",
+          epoch: 1,
+          total_epochs: 10,
+        });
+      });
+      expect(screen.queryByText(/This is taking longer than usual/i)).not.toBeInTheDocument();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it("displays server message and fallback message for TIMED_OUT runs", async () => {
+    const timedOutRunWithMessage = {
+      task_id: "task-to-1",
+      run_id: "run-to-1",
+      state: "TIMED_OUT",
+      message: "Custom timeout from backend.",
+      start_time: 1000,
+      label_ids: [1],
+    };
+    getInstanceTrainingRuns.mockResolvedValue({ runs: [timedOutRunWithMessage] });
+
+    render(<ModelTrainingPage />);
+
+    const runCard = await screen.findByText("Timed out");
+    fireEvent.click(runCard);
+
+    expect(screen.getByRole("alert")).toHaveTextContent("Custom timeout from backend.");
+  });
+
+  it("displays fallback message for TIMED_OUT runs when message is omitted", async () => {
+    const timedOutRunNoMessage = {
+      task_id: "task-to-2",
+      run_id: "run-to-2",
+      state: "TIMED_OUT",
+      start_time: 1000,
+      label_ids: [1],
+    };
+    getInstanceTrainingRuns.mockResolvedValue({ runs: [timedOutRunNoMessage] });
+
+    render(<ModelTrainingPage />);
+
+    const runCard = await screen.findByText("Timed out");
+    fireEvent.click(runCard);
+
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "Training did not start before the queue deadline."
+    );
+  });
+
+  it("stops active streaming and reloads history on terminal SSE snapshot", async () => {
+    let streamCallback;
+    streamInstanceTrainingProgress.mockImplementation((taskId, onSnap) => {
+      streamCallback = onSnap;
+      return { abort: jest.fn() };
+    });
+
+    const runs = [
+      { task_id: "task-live", run_id: "run-live", state: "STARTING", start_time: 5000, label_ids: [1] },
+    ];
+    getInstanceTrainingRuns.mockResolvedValue({ runs });
+
+    render(<ModelTrainingPage />);
+
+    await waitFor(() => expect(streamInstanceTrainingProgress).toHaveBeenCalled());
+
+    // Stream receives terminal SUCCESS snapshot
+    act(() => {
+      streamCallback({
+        task_id: "task-live",
+        run_id: "run-live",
+        state: "SUCCESS",
+        training_state: "completed",
+        epoch: 10,
+        total_epochs: 10,
+      });
+    });
+
+    await waitFor(() => {
+      // History should have been reloaded
+      expect(getInstanceTrainingRuns).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it("invokes cancellation and displays cancelled state when Stop Training is clicked on a STARTING run", async () => {
+    const runs = [
+      { task_id: "task-to-cancel", run_id: "run-to-cancel", state: "STARTING", start_time: 5000, label_ids: [1] },
+    ];
+    getInstanceTrainingRuns.mockResolvedValue({ runs });
+    cancelInstanceTraining.mockResolvedValue({
+      task_id: "task-to-cancel",
+      run_id: "run-to-cancel",
+      state: "CANCELLED",
+      training_state: "cancelled",
+      message: "Training cancelled by user.",
+    });
+
+    render(<ModelTrainingPage />);
+
+    const stopBtn = await screen.findByRole("button", { name: /stop training/i });
+    fireEvent.click(stopBtn);
+
+    await waitFor(() => {
+      expect(cancelInstanceTraining).toHaveBeenCalledWith("task-to-cancel");
+    });
+
+    expect(await screen.findByText("Training cancelled by user.")).toBeInTheDocument();
   });
 });

--- a/src/pages/ModelTrainingPage.test.jsx
+++ b/src/pages/ModelTrainingPage.test.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { render, screen, waitFor, fireEvent, act } from "@testing-library/react";
+import { vi } from "vitest";
 import ModelTrainingPage from "./ModelTrainingPage";
 import {
   cancelInstanceTraining,
@@ -11,33 +12,43 @@ import {
   streamInstanceTrainingProgress,
 } from "../api";
 
-jest.mock("react-router-dom", () => ({
-  useParams: () => ({ datasetId: "42" }),
-}), { virtual: true });
+const { mockRoute } = vi.hoisted(() => ({
+  mockRoute: { datasetId: "42" },
+}));
 
-jest.mock("../contexts/DatasetContext", () => ({
+vi.mock("react-router-dom", () => ({
+  useParams: () => ({ datasetId: mockRoute.datasetId }),
+}));
+
+vi.mock("../contexts/DatasetContext", () => ({
   useDataset: () => ({ currentDataset: { name: "Test dataset" } }),
 }));
 
-jest.mock("../components/datasets/gallery/DatasetManagementLayout", () => ({ children }) => (
-  <div>{children}</div>
-));
-
-jest.mock("../components/datasets/training/DynamicHyperParameter", () => () => null);
-
-jest.mock("../api", () => ({
-  cancelInstanceTraining: jest.fn(),
-  fetchLabels: jest.fn(),
-  getInstanceLabelAnnotationCounts: jest.fn(),
-  getInstanceModels: jest.fn(),
-  getInstanceTrainingRuns: jest.fn(),
-  startInstanceTraining: jest.fn(),
-  streamInstanceTrainingProgress: jest.fn(),
+vi.mock("../components/datasets/gallery/DatasetManagementLayout", () => ({
+  default: ({ children }) => <div>{children}</div>,
 }));
+
+vi.mock("../components/datasets/training/DynamicHyperParameter", () => ({
+  default: () => null,
+}));
+
+vi.mock("../api", () => ({
+  cancelInstanceTraining: vi.fn(),
+  fetchLabels: vi.fn(),
+  getInstanceLabelAnnotationCounts: vi.fn(),
+  getInstanceModels: vi.fn(),
+  getInstanceTrainingRuns: vi.fn(),
+  startInstanceTraining: vi.fn(),
+  streamInstanceTrainingProgress: vi.fn(),
+}));
+
+beforeEach(() => {
+  mockRoute.datasetId = "42";
+});
 
 describe("ModelTrainingPage model loading", () => {
   beforeEach(() => {
-    jest.clearAllMocks();
+    vi.clearAllMocks();
     fetchLabels.mockResolvedValue({ labels: { id_to_label_object: {} } });
     getInstanceLabelAnnotationCounts.mockResolvedValue({
       success: true,
@@ -46,7 +57,7 @@ describe("ModelTrainingPage model loading", () => {
     getInstanceTrainingRuns.mockResolvedValue({ runs: [] });
     cancelInstanceTraining.mockResolvedValue({});
     startInstanceTraining.mockResolvedValue({ task_id: "task-1" });
-    streamInstanceTrainingProgress.mockReturnValue({ abort: jest.fn() });
+    streamInstanceTrainingProgress.mockReturnValue({ abort: vi.fn() });
   });
 
   it("keeps the configuration unavailable while models are loading", async () => {
@@ -109,7 +120,7 @@ describe("ModelTrainingPage model loading", () => {
 
 describe("Task 3: Frontend lifecycle presentation normalization", () => {
   beforeEach(() => {
-    jest.clearAllMocks();
+    vi.clearAllMocks();
     fetchLabels.mockResolvedValue({
       labels: {
         id_to_label_object: { 1: { id: 1, name: "cell" } },
@@ -125,7 +136,7 @@ describe("Task 3: Frontend lifecycle presentation normalization", () => {
     });
     cancelInstanceTraining.mockResolvedValue({});
     startInstanceTraining.mockResolvedValue({ task_id: "task-start-123" });
-    streamInstanceTrainingProgress.mockReturnValue({ abort: jest.fn() });
+    streamInstanceTrainingProgress.mockReturnValue({ abort: vi.fn() });
   });
 
   it("renders friendly display labels for all canonical lifecycle states", async () => {
@@ -212,7 +223,7 @@ describe("Task 3: Frontend lifecycle presentation normalization", () => {
 
 describe("Task 4: Active run restoration after refresh", () => {
   beforeEach(() => {
-    jest.clearAllMocks();
+    vi.clearAllMocks();
     fetchLabels.mockResolvedValue({
       labels: { id_to_label_object: { 1: { id: 1, name: "cell" } } },
     });
@@ -224,7 +235,7 @@ describe("Task 4: Active run restoration after refresh", () => {
       success: true,
       result: [{ registry_key: "mask2former", name: "Mask2Former", trainable: true, training_parameters: [] }],
     });
-    streamInstanceTrainingProgress.mockReturnValue({ abort: jest.fn() });
+    streamInstanceTrainingProgress.mockReturnValue({ abort: vi.fn() });
   });
 
   it("restores an active STARTING run on page load and starts progress streaming", async () => {
@@ -296,7 +307,7 @@ describe("Task 4: Active run restoration after refresh", () => {
   });
 
   it("aborts active stream controller on unmount", async () => {
-    const abortMock = jest.fn();
+    const abortMock = vi.fn();
     streamInstanceTrainingProgress.mockReturnValue({ abort: abortMock });
 
     const runs = [
@@ -310,11 +321,41 @@ describe("Task 4: Active run restoration after refresh", () => {
     unmount();
     expect(abortMock).toHaveBeenCalled();
   });
+
+  it("clears the active run and aborts its stream when the dataset changes", async () => {
+    const abortMock = vi.fn();
+    streamInstanceTrainingProgress.mockReturnValue({ abort: abortMock });
+    getInstanceTrainingRuns.mockImplementation((datasetId) => Promise.resolve({
+      runs: datasetId === "42"
+        ? [{
+            task_id: "task-dataset-42",
+            run_id: "run-dataset-42",
+            state: "STARTING",
+            start_time: 5000,
+            label_ids: [1],
+          }]
+        : [],
+    }));
+
+    const { rerender } = render(<ModelTrainingPage />);
+
+    await waitFor(() => expect(streamInstanceTrainingProgress).toHaveBeenCalledTimes(1));
+    expect(await screen.findByText("Waiting for worker…")).toBeInTheDocument();
+
+    mockRoute.datasetId = "43";
+    rerender(<ModelTrainingPage />);
+
+    await waitFor(() => expect(getInstanceTrainingRuns).toHaveBeenCalledWith("43"));
+    await waitFor(() => expect(abortMock).toHaveBeenCalled());
+    expect(streamInstanceTrainingProgress).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText("Waiting for worker…")).not.toBeInTheDocument();
+    expect(await screen.findByRole("button", { name: /start training/i })).toBeInTheDocument();
+  });
 });
 
 describe("Task 5: Slow-start warning and terminal messages", () => {
   beforeEach(() => {
-    jest.clearAllMocks();
+    vi.clearAllMocks();
     fetchLabels.mockResolvedValue({
       labels: { id_to_label_object: { 1: { id: 1, name: "cell" } } },
     });
@@ -331,20 +372,20 @@ describe("Task 5: Slow-start warning and terminal messages", () => {
       state: "CANCELLED",
       message: "Training cancelled by user.",
     });
-    streamInstanceTrainingProgress.mockReturnValue({ abort: jest.fn() });
+    streamInstanceTrainingProgress.mockReturnValue({ abort: vi.fn() });
   });
 
   it("shows slow-start warning only after 60 seconds of STARTING and removes it on PROGRESS", async () => {
     let streamCallback;
     streamInstanceTrainingProgress.mockImplementation((taskId, onSnap) => {
       streamCallback = onSnap;
-      return { abort: jest.fn() };
+      return { abort: vi.fn() };
     });
 
-    jest.useFakeTimers();
+    vi.useFakeTimers();
     try {
       const baseTime = 1000000;
-      jest.setSystemTime(baseTime);
+      vi.setSystemTime(baseTime);
 
       const startingRun = {
         task_id: "task-slow",
@@ -367,13 +408,13 @@ describe("Task 5: Slow-start warning and terminal messages", () => {
 
       // At 59 seconds: no warning
       act(() => {
-        jest.advanceTimersByTime(59000);
+        vi.advanceTimersByTime(59000);
       });
       expect(screen.queryByText(/This is taking longer than usual/i)).not.toBeInTheDocument();
 
       // At 60 seconds: warning is shown
       act(() => {
-        jest.advanceTimersByTime(1000);
+        vi.advanceTimersByTime(1000);
       });
       expect(screen.getByText(/This is taking longer than usual/i)).toBeInTheDocument();
 
@@ -389,7 +430,7 @@ describe("Task 5: Slow-start warning and terminal messages", () => {
       });
       expect(screen.queryByText(/This is taking longer than usual/i)).not.toBeInTheDocument();
     } finally {
-      jest.useRealTimers();
+      vi.useRealTimers();
     }
   });
 
@@ -436,7 +477,7 @@ describe("Task 5: Slow-start warning and terminal messages", () => {
     let streamCallback;
     streamInstanceTrainingProgress.mockImplementation((taskId, onSnap) => {
       streamCallback = onSnap;
-      return { abort: jest.fn() };
+      return { abort: vi.fn() };
     });
 
     const runs = [

--- a/src/pages/ModelZooPage.jsx
+++ b/src/pages/ModelZooPage.jsx
@@ -44,6 +44,25 @@ const normalizeTagEntries = (tags) => {
   return [];
 };
 
+const getTagValue = (tags, key) => {
+  if (!tags) return null;
+  if (Array.isArray(tags)) {
+    const entry = tags.find((tag) => tag?.key === key);
+    return entry?.value ?? null;
+  }
+  return typeof tags === "object" ? tags[key] ?? null : null;
+};
+
+const parseTagList = (value) => {
+  if (!value) return [];
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed) ? parsed.map(String) : [];
+  } catch {
+    return [];
+  }
+};
+
 // Transform a merged backend model into the card's UI shape. `tasks` is the
 // array of task keys the model serves (already merged in getAllModels).
 const transformModel = (model) => ({
@@ -66,6 +85,11 @@ const transformModel = (model) => ({
     : model.label_id != null
     ? [model.label_id]
     : [],
+  predictedLabelNames: parseTagList(getTagValue(model.tags, "trained_label_names")),
+  trainedOnDatasetId: getTagValue(model.tags, "trained_on_dataset_id")
+    || getTagValue(model.tags, "dataset_id"),
+  trainedOnDatasetName: getTagValue(model.tags, "trained_on_dataset_name")
+    || getTagValue(model.tags, "dataset_name"),
   trainable: model.trainable === true,
   pretrained: model.pretrained !== false,
   architecture: model.architecture || null,

--- a/src/services/annotationSession.js
+++ b/src/services/annotationSession.js
@@ -538,9 +538,10 @@ class AnnotationSession {
   /**
    * Run instance segmentation inference
    * @param {string} modelKey - Instance model key
+   * @param {'patch'|'override'} writeMode - How predictions are applied to existing contours
    * @returns {Promise<Object>} Response with added objects (objects are added via OBJECT_ADDED WebSocket messages)
    */
-  async runInstance(modelKey) {
+  async runInstance(modelKey, writeMode = 'patch') {
     this._ensureReady();
 
     // Check if instance service is available
@@ -548,7 +549,7 @@ class AnnotationSession {
       throw new Error('Instance segmentation service is not available. Please check your connection.');
     }
 
-    const message = MessageBuilders.runInstance(modelKey);
+    const message = MessageBuilders.runInstance(modelKey, writeMode);
     return websocketService.send(message, true);
   }
 
@@ -710,6 +711,5 @@ class AnnotationSession {
 const annotationSession = new AnnotationSession();
 
 export default annotationSession;
-
 
 

--- a/src/utils/messageTypes.js
+++ b/src/utils/messageTypes.js
@@ -46,6 +46,14 @@ export const CLIENT_MESSAGE_TYPES = {
   FINISH_ANNOTATION: 'finish_annotation',
 };
 
+/**
+ * How interactive instance-segmentation predictions are written.
+ */
+export const INSTANCE_WRITE_MODES = {
+  PATCH: 'patch',
+  OVERRIDE: 'override',
+};
+
 // ==================== SERVER MESSAGE TYPES ====================
 
 /**
@@ -277,11 +285,13 @@ export const MessageBuilders = {
   /**
    * Request instance segmentation inference
    * @param {string} modelKey - Instance model key
+   * @param {'patch'|'override'} writeMode - How predictions are applied to existing contours
    */
-  runInstance: (modelKey) => createMessage(
+  runInstance: (modelKey, writeMode = INSTANCE_WRITE_MODES.PATCH) => createMessage(
     CLIENT_MESSAGE_TYPES.INSTANCE_INFERENCE,
     {
       model_registry_key: modelKey,
+      write_mode: writeMode,
     }
   ),
 
@@ -350,5 +360,4 @@ export const extractError = (message) => ({
   data: message?.data || null,
   id: message?.id || null,
 });
-
 

--- a/src/utils/messageTypes.test.js
+++ b/src/utils/messageTypes.test.js
@@ -1,0 +1,21 @@
+import { INSTANCE_WRITE_MODES, MessageBuilders } from './messageTypes';
+
+describe('MessageBuilders.runInstance', () => {
+  test('defaults interactive inference to patch mode', () => {
+    const message = MessageBuilders.runInstance('instance-model');
+
+    expect(message.data).toEqual({
+      model_registry_key: 'instance-model',
+      write_mode: INSTANCE_WRITE_MODES.PATCH,
+    });
+  });
+
+  test('preserves override mode in the websocket payload', () => {
+    const message = MessageBuilders.runInstance(
+      'instance-model',
+      INSTANCE_WRITE_MODES.OVERRIDE
+    );
+
+    expect(message.data.write_mode).toBe('override');
+  });
+});


### PR DESCRIPTION
- Adds Patch and Override choices with clear explanations.
- Shows understandable training states.
- Restores an active training run after refreshing the page.
- Shows a warning when training is taking longer than usual to start.
- Displays clear messages for failed, cancelled, and timed-out runs.
- Allows training to be stopped while it is waiting or running.
- Displays useful quality results such as IoU, F1, precision, recall, and per-label results.
- Displays custom trained-model names in the Model Zoo.
- Prevents a training run from the previous dataset remaining active after switching datasets.