### PR TITLE
perf: optimize dataset overview loading and annotation progress queries

### DIFF
--- a/src/api/datasets.js
+++ b/src/api/datasets.js
@@ -96,61 +96,19 @@ export const getAnnotationProgress = async (datasetId) => {
 export const getSampleImages = async (datasetId, limit = 4) => {
     try {
         const response = await fetch(
-            `${API_BASE_URL}/datasets/${datasetId}/images`,
+            `${API_BASE_URL}/datasets/${datasetId}/thumbnails/b64?limit=${limit}`,
             {
                 headers: getAuthHeaders(),
             }
         );
         const data = await handleApiError(response);
 
-        
-        const imageList = data.image_data || data.images || [];
-        
-        if (data.success && imageList.length > 0) {
-            // Get the first few images as samples
-            const sampleImages = imageList.slice(0, limit);
-
-            // Fetch the actual image data for each sample
-            const imagePromises = sampleImages.map(async (imageItem) => {
-                
-                const imageId = imageItem.image_id || imageItem.id;
-                const filename = imageItem.filename || `image_${imageId}`;
-                
-                try {
-                    const imageData = await getImageById(imageId, true);
-                    
-                    // The backend returns the image_id as a dynamic key in the response
-                    // Try multiple ways to access it (numeric, string, or check all keys)
-                    let base64 = imageData[imageId] || imageData[String(imageId)];
-                    
-                    // If still not found, try to find it by checking all keys
-                    if (!base64) {
-                        const keys = Object.keys(imageData);
-                        
-                        // Try to find any key that isn't 'success' or 'message'
-                        const dataKey = keys.find(key => key !== 'success' && key !== 'message');
-                        if (dataKey) {
-                            base64 = imageData[dataKey];
-                        }
-                    }
-                    
-                    if (!base64) {
-                        return null;
-                    }
-                    
-                    return {
-                        id: imageId,
-                        base64: base64,
-                        filename: filename,
-                    };
-                } catch (error) {
-                    return null;
-                }
-            });
-
-            const resolvedImages = await Promise.all(imagePromises);
-            const validImages = resolvedImages.filter((img) => img !== null);
-            return validImages;
+        if (data.success && data.images) {
+            return Object.entries(data.images).map(([id, base64]) => ({
+                id: Number(id) || id,
+                base64: base64,
+                filename: `image_${id}`,
+            }));
         }
 
         return [];

--- a/src/components/datasets/DatasetsOverview.jsx
+++ b/src/components/datasets/DatasetsOverview.jsx
@@ -63,48 +63,61 @@ const DatasetsOverview = ({ onOpenDataset }) => {
   useEffect(() => {
     console.log("Is Creating", isCreating);
   }, [isCreating]);
-  // Fetch sample images and annotation stats for all datasets
+  // Fetch sample images immediately so cards display thumbnails without waiting for
+  // progress calculations, and load annotation progress stats in the background.
   useEffect(() => {
-    const fetchDatasetData = async () => {
-      if (datasets.length === 0) return;
+    if (datasets.length === 0) {
+      setLoadingData(false);
+      return;
+    }
 
-      setLoadingData(true);
-      const imagesData = {};
-      const statsData = {};
+    let isCancelled = false;
 
+    // 1. Fetch sample thumbnails immediately for all datasets
+    const thumbnailPromises = datasets.map(async (dataset) => {
       try {
-        // Fetch data for all datasets in parallel
-        const promises = datasets.map(async (dataset) => {
-          try {
-            const [images, stats] = await Promise.all([
-              getSampleImages(dataset.id, 4),
-              getAnnotationProgress(dataset.id),
-            ]);
-
-            imagesData[dataset.id] = images;
-            statsData[dataset.id] = stats;
-          } catch (err) {
-            console.error(
-              `Error fetching data for dataset ${dataset.id}:`,
-              err
-            );
-            imagesData[dataset.id] = [];
-            statsData[dataset.id] = { ...emptyPhaseCounts(), total: 0 };
-          }
-        });
-
-        await Promise.all(promises);
-
-        setDatasetImages(imagesData);
-        setDatasetStats(statsData);
+        const images = await getSampleImages(dataset.id, 4);
+        if (!isCancelled) {
+          setDatasetImages((prev) => ({ ...prev, [dataset.id]: images }));
+        }
       } catch (err) {
-        console.error("Error fetching dataset data:", err);
-      } finally {
+        console.error(`Error fetching images for dataset ${dataset.id}:`, err);
+        if (!isCancelled) {
+          setDatasetImages((prev) => ({ ...prev, [dataset.id]: [] }));
+        }
+      }
+    });
+
+    // 2. Fetch annotation progress in the background progressively
+    setLoadingData(true);
+    const progressPromises = datasets.map(async (dataset) => {
+      try {
+        const stats = await getAnnotationProgress(dataset.id);
+        if (!isCancelled) {
+          setDatasetStats((prev) => ({ ...prev, [dataset.id]: stats }));
+        }
+      } catch (err) {
+        console.error(`Error fetching stats for dataset ${dataset.id}:`, err);
+        if (!isCancelled) {
+          setDatasetStats((prev) => ({
+            ...prev,
+            [dataset.id]: { ...emptyPhaseCounts(), total: 0 },
+          }));
+        }
+      }
+    });
+
+    Promise.allSettled(thumbnailPromises);
+
+    Promise.allSettled(progressPromises).finally(() => {
+      if (!isCancelled) {
         setLoadingData(false);
       }
-    };
+    });
 
-    fetchDatasetData();
+    return () => {
+      isCancelled = true;
+    };
   }, [datasets, getSampleImages, getAnnotationProgress]);
 
   const handleOpenDataset = async (dataset) => {


### PR DESCRIPTION
## Summary

Improve dataset overview loading by decoupling thumbnail loading from annotation progress calculations.

- Fetch dataset thumbnails through the bulk thumbnail endpoint.
- Load thumbnails independently from annotation progress requests.
- Update dataset cards progressively as thumbnail requests complete.
- Load annotation progress in the background.
- Guard against stale requests after dataset changes or component unmount.
- Clear the loading state when the dataset list becomes empty.
- Fixes Iquana-tool/iquana-tool#50