### PR TITLE
feat: add dataset model orchestration UI

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -16,6 +16,7 @@ import DocumentationPage from "./pages/DocumentationPage";
 import QuantificationPage from "./pages/QuantificationPage";
 import ModelZooPage from "./pages/ModelZooPage";
 import ModelTrainingPage from "./pages/ModelTrainingPage";
+import ModelOrchestrationPage from "./pages/ModelOrchestrationPage";
 import BatchInferencePage from "./pages/BatchInferencePage";
 import AcceptInvitePage from "./pages/AcceptInvitePage";
 import AnnotationViewerPage from "./pages/AnnotationViewerPage";
@@ -157,6 +158,15 @@ function App() {
               element={
                 <ProtectedRoute>
                   <ModelTrainingPage />
+                </ProtectedRoute>
+              }
+            />
+            {/* Model orchestration: configure task and label default models and routing */}
+            <Route
+              path="/dataset/:datasetId/model-orchestration"
+              element={
+                <ProtectedRoute>
+                  <ModelOrchestrationPage />
                 </ProtectedRoute>
               }
             />

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -1,8 +1,10 @@
+import React from 'react';
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders Coral Segmentation header', () => {
+test('renders landing page with sign-in form', () => {
   render(<App />);
-  const headerElement = screen.getByRole('heading', { name: /Coral Segmentation - Image Viewer with Prompting/i });
-  expect(headerElement).toBeInTheDocument();
+  expect(screen.getByLabelText(/username/i)).toBeInTheDocument();
+  expect(screen.getByLabelText(/password/i)).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: /sign in/i })).toBeInTheDocument();
 });

--- a/src/api/inference.js
+++ b/src/api/inference.js
@@ -164,3 +164,78 @@ export const streamInferenceJob = (jobId, onMessage, onError) => {
 
     return controller;
 };
+
+/**
+ * Get the single saved model routing policy for a dataset.
+ * Returns null when 204 No Content.
+ */
+export const getInferenceRoutingPolicy = async (datasetId) => {
+    const params = new URLSearchParams({ dataset_id: String(datasetId) });
+    const response = await fetch(`${API_BASE_URL}/inference/config?${params.toString()}`, {
+        headers: getAuthHeaders(),
+    });
+    if (response.status === 204) {
+        return null;
+    }
+    return handleApiError(response);
+};
+
+export const getInferenceConfig = getInferenceRoutingPolicy;
+
+/**
+ * Save or replace the single model routing policy for a dataset.
+ * Expects { dataset_id: number, bindings: Array<ModelRoutingBinding> }
+ */
+export const updateInferenceRoutingPolicy = async (body) => {
+    const response = await fetch(`${API_BASE_URL}/inference/config`, {
+        method: "PUT",
+        headers: jsonHeaders(),
+        body: JSON.stringify({
+            dataset_id: Number(body.dataset_id),
+            bindings: body.bindings || [],
+        }),
+    });
+    return handleApiError(response);
+};
+
+export const saveInferenceConfig = updateInferenceRoutingPolicy;
+
+/**
+ * Delete the model routing policy for a dataset.
+ */
+export const deleteInferenceRoutingPolicy = async (datasetId) => {
+    const params = new URLSearchParams({ dataset_id: String(datasetId) });
+    const response = await fetch(`${API_BASE_URL}/inference/config?${params.toString()}`, {
+        method: "DELETE",
+        headers: getAuthHeaders(),
+    });
+    return handleApiError(response);
+};
+
+export const deleteInferenceConfig = deleteInferenceRoutingPolicy;
+
+/**
+ * Run one routed model step for a single image with patch semantics.
+ */
+export const suggestModelRoutingStep = async ({
+    datasetId,
+    imageId,
+    maskId = null,
+    labelId,
+    task = "cross-image-suggestion",
+}) => {
+    const response = await fetch(`${API_BASE_URL}/inference/config/suggest`, {
+        method: "POST",
+        headers: jsonHeaders(),
+        body: JSON.stringify({
+            dataset_id: Number(datasetId),
+            image_id: Number(imageId),
+            mask_id: maskId != null ? Number(maskId) : null,
+            label_id: Number(labelId),
+            task: task || "cross-image-suggestion",
+        }),
+    });
+    return handleApiError(response);
+};
+
+export const suggestInferenceConfigStep = suggestModelRoutingStep;

--- a/src/components/annotationPage/canvas/ObjectContextMenu.jsx
+++ b/src/components/annotationPage/canvas/ObjectContextMenu.jsx
@@ -18,8 +18,6 @@ import {
   useFocusModeActive,
   useFocusModeObjectId,
   useExitFocusMode,
-  useSuggestionModel,
-  useWebSocketIsReady,
   useEnterEditMode,
   useStartLineEdit,
   useSelectObject,
@@ -30,7 +28,7 @@ import { useZoomToObject } from '../../../hooks/useZoomToObject';
 import { useLabelSelection } from '../../../hooks/useLabelSelection';
 import { useLabelsHierarchy } from '../../../hooks/useLabelsHierarchy';
 import { getChildLabels, resolveParentLabelId } from '../../../utils/labelHierarchy';
-import { useSuggestionSegmentation } from '../../../hooks/useSuggestionSegmentation';
+import useSuggestSimilar from '../workspace/useSuggestSimilar';
 import { useDataset } from '../../../contexts/DatasetContext';
 import { calculateRenderedImageDimensions } from '../../../utils/canvasUtils';
 import { deleteObject } from '../../../utils/objectOperations';
@@ -61,7 +59,6 @@ const ObjectContextMenu = () => {
   const focusModeActive = useFocusModeActive();
   const focusModeObjectId = useFocusModeObjectId();
   const exitFocusMode = useExitFocusMode();
-  const suggestionModel = useSuggestionModel();
   
   // Use the same zoom hook as refinement mode
   const { zoomToObject } = useZoomToObject({
@@ -69,7 +66,6 @@ const ObjectContextMenu = () => {
     maxZoom: 4,
     minZoom: 1,
   });
-  const wsIsReady = useWebSocketIsReady();
   const enterEditMode = useEnterEditMode();
   const startLineEdit = useStartLineEdit();
   const selectObject = useSelectObject();
@@ -137,11 +133,7 @@ const ObjectContextMenu = () => {
     [flatLabels, parentLabelId]
   );
   
-  // Use suggestion segmentation hook
-  const { runSuggestion, isRunning: isRunningSuggestion } = useSuggestionSegmentation(
-    null, // onSuccess: objects are automatically added via WebSocket
-    (error) => alert(`Failed to suggest similar instances: ${error.message || 'Unknown error'}`)
-  );
+  const suggestSimilar = useSuggestSimilar();
 
   // Adjust position to keep menu within container bounds and place it intuitively next to the object
   useEffect(() => {
@@ -391,37 +383,8 @@ const ObjectContextMenu = () => {
   };
 
   const handleSuggestSimilar = async () => {
-    if (targetObjects.length === 0) {
-      hideContextMenu();
-      return;
-    }
-
-    // Get all contour IDs from selected objects
-    const contourIds = targetObjects
-      .map(obj => obj.contour_id)
-      .filter(id => id !== null && id !== undefined);
-    
-    if (contourIds.length === 0) {
-      alert('Could not find contour IDs for selected objects');
-      hideContextMenu();
-      return;
-    }
-
-    // Check if WebSocket is ready
-    if (!wsIsReady) {
-      alert('WebSocket connection is not ready. Please wait or refresh the page.');
-      hideContextMenu();
-      return;
-    }
-
     hideContextMenu();
-    
-    // Use the suggestion hook with all selected contour IDs as seeds
-    // For multiple seeds, we'll use the first object's labelId as the default
-    const labelId = targetObjects[0]?.labelId;
-    
-    // Pass contour IDs (hook handles both single and array)
-    await runSuggestion(contourIds.length === 1 ? contourIds[0] : contourIds, labelId);
+    await suggestSimilar.run();
   };
 
   const handleLineEditContour = (lineMode = 'reshape') => {
@@ -680,17 +643,14 @@ const ObjectContextMenu = () => {
       {/* Suggest Similar Instances Option */}
       <ContextMenuItem
         onClick={handleSuggestSimilar}
-        disabled={isRunningSuggestion || !suggestionModel || !wsIsReady}
+        disabled={!suggestSimilar.eligible}
         title={
-          !suggestionModel 
-            ? 'Select a suggestion model first' 
-            : !wsIsReady 
-              ? 'WebSocket not ready' 
-              : isMultiSelect
-                ? `Use ${targetObjects.length} objects as seeds for suggestion segmentation`
-                : 'Find similar instances using suggestion segmentation'
+          suggestSimilar.reason ||
+          (isMultiSelect
+            ? `Use ${targetObjects.length} objects as seeds for suggestion segmentation`
+            : 'Find similar instances using suggestion segmentation')
         }
-        label={isRunningSuggestion ? 'Finding similar...' : 'Suggest Similar Instances'}
+        label={suggestSimilar.isRunning ? 'Finding similar...' : 'Suggest Similar Instances'}
         icon={
           <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4" />
@@ -724,4 +684,3 @@ const ObjectContextMenu = () => {
 };
 
 export default ObjectContextMenu;
-

--- a/src/components/annotationPage/workspace/CrossImageSuggestionCard.jsx
+++ b/src/components/annotationPage/workspace/CrossImageSuggestionCard.jsx
@@ -1,0 +1,164 @@
+import React, { useMemo, useState } from 'react';
+import { ChevronDown, ChevronUp, Loader2, Sparkles } from 'lucide-react';
+import { useInferenceConfigSuggestion } from './useInferenceConfigSuggestion';
+import {
+  useActiveLabelId,
+  useDatasetLabels,
+  useSetActiveLabelId,
+  useLabelColorOverrides,
+} from '../../../stores/selectors/annotationSelectors';
+import { resolveLabelColor } from './labelColorUtils';
+
+/**
+ * Annotation Service card for single-image cross-image AI suggestions.
+ * Located in the tool-options drawer under Instance Segmentation.
+ */
+const CrossImageSuggestionCard = () => {
+  const [open, setOpen] = useState(false);
+  const [infoOpen, setInfoOpen] = useState(false);
+
+  const labels = useDatasetLabels();
+  const activeLabelId = useActiveLabelId();
+  const setActiveLabelId = useSetActiveLabelId();
+  const colorOverrides = useLabelColorOverrides();
+
+  const {
+    isLoadingConfig,
+    configError,
+    isConfigured,
+    getResolvedBinding,
+    isRunning,
+    isAnyRunning,
+    suggestLabel,
+  } = useInferenceConfigSuggestion();
+
+  // Selected label: currently armed/active label if it belongs to this dataset, otherwise fallback to first dataset label
+  const isArmedValid = Array.isArray(labels) && labels.some((l) => Number(l.id) === Number(activeLabelId));
+  const selectedLabelId = isArmedValid ? activeLabelId : (labels?.[0]?.id ?? null);
+  const selectedLabel = labels.find((l) => Number(l.id) === Number(selectedLabelId)) || null;
+
+  const resolved = useMemo(
+    () => (selectedLabelId != null ? getResolvedBinding(selectedLabelId) : null),
+    [getResolvedBinding, selectedLabelId]
+  );
+
+  const configured = Boolean(selectedLabelId && isConfigured(selectedLabelId));
+  const running = Boolean(selectedLabelId && isRunning(selectedLabelId));
+
+  const modelName = resolved?.model?.name || resolved?.binding?.model_registry_key || null;
+  const color = selectedLabel ? resolveLabelColor(selectedLabel, colorOverrides) : '#888';
+
+  return (
+    <div className="rounded-9 border border-ln2 bg-well px-[10px] py-[9px]">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="w-full flex items-center gap-[7px] text-left"
+      >
+        <span
+          className="w-[6px] h-[6px] rounded-full flex-none"
+          style={{
+            background: configured ? '#22c55e' : '#6d757d',
+            boxShadow: `0 0 0 3px ${configured ? '#22c55e29' : '#6d757d29'}`,
+          }}
+          title={configured ? 'Suggestion model ready' : 'No suggestion model configured'}
+        />
+        <span className="flex-1 text-row font-bold text-t1 truncate">Cross-Image Suggestion</span>
+        {running && <Loader2 size={13} className="text-ac animate-spin" />}
+        {open ? (
+          <ChevronUp size={13} strokeWidth={1.9} className="text-t3" />
+        ) : (
+          <ChevronDown size={13} strokeWidth={1.9} className="text-t3" />
+        )}
+      </button>
+
+      {open && (
+        <div className="mt-[8px] flex flex-col gap-[7px]">
+          {isLoadingConfig ? (
+            <div className="h-[27px] rounded-6 bg-hv animate-pulse" />
+          ) : configError ? (
+            <p className="px-[8px] py-[5px] rounded-6 bg-errBg text-ctl text-err">
+              {configError}
+            </p>
+          ) : (
+            <>
+              {/* Target Label Picker */}
+              <div>
+                <label className="block text-meta font-semibold text-t3 uppercase tracking-wider mb-1">
+                  Target Label
+                </label>
+                {labels.length > 0 ? (
+                  <div className="flex items-center gap-1.5">
+                    <span
+                      className="w-[10px] h-[10px] rounded-[3px] flex-none border border-black/20"
+                      style={{ background: color }}
+                    />
+                    <select
+                      value={selectedLabelId || ''}
+                      onChange={(e) => setActiveLabelId(Number(e.target.value))}
+                      aria-label="Target label for suggestion"
+                      className="flex-1 h-[27px] px-[8px] rounded-6 border border-ln2 bg-well2 text-row text-t1 outline-none focus:border-ac"
+                    >
+                      {labels.map((lbl) => (
+                        <option key={lbl.id} value={lbl.id}>
+                          {lbl.name}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                ) : (
+                  <p className="text-sect text-t3">No labels created in dataset.</p>
+                )}
+              </div>
+
+              {/* Model Info */}
+              {selectedLabel && (
+                <div className="flex items-center justify-between text-sect text-t2 px-1">
+                  <span className="text-t3">Model:</span>
+                  <span className="font-medium truncate max-w-[140px]" title={modelName || "Not configured"}>
+                    {modelName || "None (configure in Orchestration)"}
+                  </span>
+                </div>
+              )}
+
+              {/* Action Button & Info */}
+              <div className="flex items-center justify-between mt-[4px] gap-[8px]">
+                <button
+                  type="button"
+                  onClick={() => suggestLabel(selectedLabelId)}
+                  disabled={!configured || isAnyRunning || !selectedLabel}
+                  aria-label={`Suggest ${selectedLabel?.name || 'label'}`}
+                  className="inline-flex items-center gap-[6px] h-[26px] px-[10px] rounded-6 bg-accent text-onAccent text-row font-bold transition-[filter] hover:brightness-110 disabled:opacity-40 disabled:cursor-not-allowed"
+                >
+                  {running ? (
+                    <Loader2 size={13} className="animate-spin" />
+                  ) : (
+                    <Sparkles size={13} />
+                  )}
+                  <span>{running ? 'Suggesting…' : `Suggest ${selectedLabel?.name || ''}`}</span>
+                </button>
+
+                <button
+                  type="button"
+                  onClick={() => setInfoOpen((v) => !v)}
+                  className="inline-flex items-center gap-[4px] h-[22px] px-[7px] rounded-5 text-meta font-semibold text-t3 hover:bg-hv hover:text-t2 transition-colors"
+                >
+                  Info
+                  {infoOpen ? <ChevronUp size={12} /> : <ChevronDown size={12} />}
+                </button>
+              </div>
+
+              {infoOpen && (
+                <div className="mt-[4px] pt-[6px] border-t border-ln text-sect leading-[1.5] text-t3">
+                  Runs the model configured in Model Orchestration for {selectedLabel?.name || 'the target label'}, retrieving annotated exemplars across the dataset and patching candidate predictions onto the active image.
+                </div>
+              )}
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default CrossImageSuggestionCard;

--- a/src/components/annotationPage/workspace/CrossImageSuggestionCard.test.jsx
+++ b/src/components/annotationPage/workspace/CrossImageSuggestionCard.test.jsx
@@ -1,0 +1,141 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import CrossImageSuggestionCard from "./CrossImageSuggestionCard";
+import * as useInferenceConfigSuggestionModule from "./useInferenceConfigSuggestion";
+import * as annotationSelectors from "../../../stores/selectors/annotationSelectors";
+
+describe("CrossImageSuggestionCard", () => {
+    const setActiveLabelId = vi.fn();
+    const suggestLabel = vi.fn();
+
+    const mockLabels = [
+        { id: 1, name: "Coral", color: "#FF0000" },
+        { id: 2, name: "Bleached", color: "#00FF00" },
+    ];
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+
+        vi.spyOn(annotationSelectors, "useDatasetLabels").mockReturnValue(mockLabels);
+        vi.spyOn(annotationSelectors, "useActiveLabelId").mockReturnValue(1);
+        vi.spyOn(annotationSelectors, "useSetActiveLabelId").mockReturnValue(setActiveLabelId);
+        vi.spyOn(annotationSelectors, "useLabelColorOverrides").mockReturnValue({});
+    });
+
+    it("renders closed by default and expands on toggle", () => {
+        vi.spyOn(useInferenceConfigSuggestionModule, "useInferenceConfigSuggestion").mockReturnValue({
+            isLoadingConfig: false,
+            configError: null,
+            isConfigured: vi.fn().mockReturnValue(true),
+            getResolvedBinding: vi.fn().mockReturnValue({
+                model: { name: "SAM 3 - Suggestion" },
+                binding: { model_registry_key: "sam3" },
+            }),
+            isRunning: vi.fn().mockReturnValue(false),
+            isAnyRunning: false,
+            suggestLabel,
+        });
+
+        render(<CrossImageSuggestionCard />);
+
+        const headerBtn = screen.getByRole("button", { name: /cross-image suggestion/i });
+        expect(headerBtn).toBeInTheDocument();
+        expect(screen.queryByText("SAM 3 - Suggestion")).not.toBeInTheDocument();
+
+        // Expand card
+        fireEvent.click(headerBtn);
+        expect(screen.getByText("SAM 3 - Suggestion")).toBeInTheDocument();
+    });
+
+    it("renders configured model and executes suggestLabel on click", () => {
+        vi.spyOn(useInferenceConfigSuggestionModule, "useInferenceConfigSuggestion").mockReturnValue({
+            isLoadingConfig: false,
+            configError: null,
+            isConfigured: vi.fn().mockReturnValue(true),
+            getResolvedBinding: vi.fn().mockReturnValue({
+                model: { name: "SAM 3 - Suggestion" },
+                binding: { model_registry_key: "sam3" },
+            }),
+            isRunning: vi.fn().mockReturnValue(false),
+            isAnyRunning: false,
+            suggestLabel,
+        });
+
+        render(<CrossImageSuggestionCard />);
+
+        // Open card
+        fireEvent.click(screen.getByRole("button", { name: /cross-image suggestion/i }));
+
+        const suggestBtn = screen.getByRole("button", { name: "Suggest Coral" });
+        expect(suggestBtn).toBeInTheDocument();
+        expect(suggestBtn).not.toBeDisabled();
+
+        fireEvent.click(suggestBtn);
+        expect(suggestLabel).toHaveBeenCalledWith(1);
+    });
+
+    it("disables suggest button when model is not configured for label", () => {
+        vi.spyOn(useInferenceConfigSuggestionModule, "useInferenceConfigSuggestion").mockReturnValue({
+            isLoadingConfig: false,
+            configError: null,
+            isConfigured: vi.fn().mockReturnValue(false),
+            getResolvedBinding: vi.fn().mockReturnValue(null),
+            isRunning: vi.fn().mockReturnValue(false),
+            isAnyRunning: false,
+            suggestLabel,
+        });
+
+        render(<CrossImageSuggestionCard />);
+
+        // Open card
+        fireEvent.click(screen.getByRole("button", { name: /cross-image suggestion/i }));
+
+        const suggestBtn = screen.getByRole("button", { name: "Suggest Coral" });
+        expect(suggestBtn).toBeDisabled();
+    });
+
+    it("shows loading state when suggestion is running", () => {
+        vi.spyOn(useInferenceConfigSuggestionModule, "useInferenceConfigSuggestion").mockReturnValue({
+            isLoadingConfig: false,
+            configError: null,
+            isConfigured: vi.fn().mockReturnValue(true),
+            getResolvedBinding: vi.fn().mockReturnValue({
+                model: { name: "SAM 3" },
+            }),
+            isRunning: vi.fn().mockReturnValue(true),
+            isAnyRunning: true,
+            suggestLabel,
+        });
+
+        render(<CrossImageSuggestionCard />);
+
+        // Open card
+        fireEvent.click(screen.getByRole("button", { name: /cross-image suggestion/i }));
+
+        expect(screen.getByText("Suggesting…")).toBeInTheDocument();
+    });
+
+    it("changing target label dropdown switches active label", () => {
+        vi.spyOn(useInferenceConfigSuggestionModule, "useInferenceConfigSuggestion").mockReturnValue({
+            isLoadingConfig: false,
+            configError: null,
+            isConfigured: vi.fn().mockReturnValue(true),
+            getResolvedBinding: vi.fn().mockReturnValue({
+                model: { name: "SAM 3" },
+            }),
+            isRunning: vi.fn().mockReturnValue(false),
+            isAnyRunning: false,
+            suggestLabel,
+        });
+
+        render(<CrossImageSuggestionCard />);
+
+        // Open card
+        fireEvent.click(screen.getByRole("button", { name: /cross-image suggestion/i }));
+
+        const select = screen.getByLabelText("Target label for suggestion");
+        fireEvent.change(select, { target: { value: "2" } });
+        expect(setActiveLabelId).toHaveBeenCalledWith(2);
+    });
+});

--- a/src/components/annotationPage/workspace/LabelsTab.jsx
+++ b/src/components/annotationPage/workspace/LabelsTab.jsx
@@ -61,6 +61,7 @@ const LabelsTab = () => {
   const { currentDataset } = useDataset();
   const { addToast } = useToast();
 
+
   const [collapsed, setCollapsed] = useState({});
   const [swatchFor, setSwatchFor] = useState(null);
   const [creating, setCreating] = useState(false);
@@ -135,6 +136,8 @@ const LabelsTab = () => {
           </button>
         </div>
       )}
+
+
 
       <div className="flex-1 min-h-0 overflow-y-auto px-[8px] pb-[10px]">
         {rows.length === 0 ? (
@@ -211,6 +214,8 @@ const LabelsTab = () => {
                   <span className="font-mono text-meta text-t3 tabular-nums flex-none">
                     {count}
                   </span>
+
+
 
                   <button
                     type="button"

--- a/src/components/annotationPage/workspace/LabelsTab.test.jsx
+++ b/src/components/annotationPage/workspace/LabelsTab.test.jsx
@@ -1,0 +1,108 @@
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import LabelsTab from "./LabelsTab";
+import * as DatasetContext from "../../../contexts/DatasetContext";
+import * as ToastContext from "../../../contexts/ToastContext";
+import * as annotationSelectors from "../../../stores/selectors/annotationSelectors";
+import * as labelsApi from "../../../api/labels";
+
+vi.mock("../../../api/labels", () => ({
+    createLabel: vi.fn(),
+    fetchLabels: vi.fn(),
+}));
+
+describe("LabelsTab taxonomy rendering and interactions", () => {
+    const setActiveLabelId = vi.fn();
+    const toggleVisibility = vi.fn();
+    const addToast = vi.fn();
+
+    const mockLabels = [
+        { id: 1, name: "Coral", color: "#FF0000", parent_id: null },
+        { id: 2, name: "Bleached", color: "#00FF00", parent_id: null },
+    ];
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+
+        vi.spyOn(DatasetContext, "useDataset").mockReturnValue({
+            currentDataset: { id: 10, name: "Test Dataset" },
+        });
+        vi.spyOn(ToastContext, "useToast").mockReturnValue({ addToast });
+
+        vi.spyOn(annotationSelectors, "useDatasetLabels").mockReturnValue(mockLabels);
+        vi.spyOn(annotationSelectors, "useSetDatasetLabels").mockReturnValue(vi.fn());
+        vi.spyOn(annotationSelectors, "useObjectsList").mockReturnValue([
+            { id: 100, labelId: 1 },
+            { id: 101, labelId: 1 },
+        ]);
+        vi.spyOn(annotationSelectors, "useObjectsVisibility").mockReturnValue({ labels: { 1: true, 2: false } });
+        vi.spyOn(annotationSelectors, "useToggleVisibility").mockReturnValue(toggleVisibility);
+        vi.spyOn(annotationSelectors, "useActiveLabelId").mockReturnValue(1);
+        vi.spyOn(annotationSelectors, "useSetActiveLabelId").mockReturnValue(setActiveLabelId);
+        vi.spyOn(annotationSelectors, "useLabelColorOverrides").mockReturnValue({});
+        vi.spyOn(annotationSelectors, "useSetLabelColorOverride").mockReturnValue(vi.fn());
+    });
+
+    it("renders label rows with counts and active badge", () => {
+        render(<LabelsTab />);
+
+        expect(screen.getAllByText("Coral").length).toBeGreaterThanOrEqual(1);
+        expect(screen.getByText("Bleached")).toBeInTheDocument();
+        expect(screen.getByText("ACTIVE")).toBeInTheDocument();
+        expect(screen.getByText("2")).toBeInTheDocument(); // count for Coral
+    });
+
+    it("clicking a label arms it as active label", () => {
+        render(<LabelsTab />);
+
+        fireEvent.click(screen.getByText("Bleached"));
+        expect(setActiveLabelId).toHaveBeenCalledWith(2);
+    });
+
+    it("clicking visibility button toggles class visibility", () => {
+        render(<LabelsTab />);
+
+        const hideButton = screen.getByRole("button", { name: "Hide Coral" });
+        fireEvent.click(hideButton);
+        expect(toggleVisibility).toHaveBeenCalledWith(1);
+    });
+
+    it("creates a new label and displays success toast", async () => {
+        labelsApi.createLabel.mockResolvedValue({ id: 3, name: "Algae" });
+        labelsApi.fetchLabels.mockResolvedValue({
+            labels: {
+                id_to_label_object: {
+                    1: { id: 1, name: "Coral" },
+                    2: { id: 2, name: "Bleached" },
+                    3: { id: 3, name: "Algae" },
+                },
+            },
+        });
+
+        render(<LabelsTab />);
+
+        const newLabelBtn = screen.getByRole("button", { name: "New label" });
+        fireEvent.click(newLabelBtn);
+
+        const input = screen.getByPlaceholderText("Label name");
+        expect(input).toBeInTheDocument();
+
+        fireEvent.change(input, { target: { value: "Algae" } });
+        expect(input.value).toBe("Algae");
+
+        const addBtn = screen.getByRole("button", { name: "Add" });
+        fireEvent.click(addBtn);
+
+        await waitFor(() => {
+            expect(labelsApi.createLabel).toHaveBeenCalledWith(
+                { name: "Algae", parent_id: null },
+                10
+            );
+            expect(addToast).toHaveBeenCalledWith({
+                type: "success",
+                message: "Label “Algae” created.",
+            });
+        });
+    });
+});

--- a/src/components/annotationPage/workspace/ServiceCard.test.jsx
+++ b/src/components/annotationPage/workspace/ServiceCard.test.jsx
@@ -1,0 +1,55 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import ServiceCard from "./ServiceCard";
+import * as annotationSelectors from "../../../stores/selectors/annotationSelectors";
+
+describe("ServiceCard", () => {
+    const mockSetFavorite = vi.fn();
+    const mockClearFavorite = vi.fn();
+
+    const sampleService = {
+        key: "prompted",
+        task: "prompted-segmentation",
+        name: "Prompted Segmentation",
+        selectedModel: "sam2-cell",
+        models: [
+            { id: "sam2-cell", name: "SAM 2 Cell", model_status: "ready" },
+            { id: "sam2-generic", name: "SAM 2 Generic", model_status: "ready" },
+        ],
+        onSelectModel: vi.fn(),
+        isRunning: false,
+    };
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.spyOn(annotationSelectors, "useSetFavoriteModel").mockReturnValue(mockSetFavorite);
+        vi.spyOn(annotationSelectors, "useClearFavoriteModel").mockReturnValue(mockClearFavorite);
+    });
+
+    it("renders favorite star and calls setFavoriteModel when not favorited", () => {
+        vi.spyOn(annotationSelectors, "useModelFavorites").mockReturnValue({});
+
+        render(<ServiceCard service={sampleService} />);
+
+        const starBtn = screen.getByRole("button", { name: "Set as default model" });
+        expect(starBtn).toBeInTheDocument();
+
+        fireEvent.click(starBtn);
+        expect(mockSetFavorite).toHaveBeenCalledWith("prompted-segmentation", "sam2-cell");
+    });
+
+    it("calls clearFavoriteModel when model is currently favorited", () => {
+        vi.spyOn(annotationSelectors, "useModelFavorites").mockReturnValue({
+            "prompted-segmentation": "sam2-cell",
+        });
+
+        render(<ServiceCard service={sampleService} />);
+
+        const starBtn = screen.getByRole("button", { name: "Remove default model" });
+        expect(starBtn).toBeInTheDocument();
+
+        fireEvent.click(starBtn);
+        expect(mockClearFavorite).toHaveBeenCalledWith("prompted-segmentation");
+    });
+});

--- a/src/components/annotationPage/workspace/ToolOptionsDrawer.jsx
+++ b/src/components/annotationPage/workspace/ToolOptionsDrawer.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Ban, ChevronLeft, Pencil, Sparkles } from 'lucide-react';
 import ServiceCard from './ServiceCard';
+import CrossImageSuggestionCard from './CrossImageSuggestionCard';
 import useAnnotationServices from './useAnnotationServices';
 import useRailTools from './useRailTools';
 import { PROMPT_ACTIONS, getPromptAction, getRailTool } from './toolModel';
@@ -20,8 +21,14 @@ const ACTION_ICONS = { Ban, Sparkles, Pencil };
 const ToolOptionsDrawer = () => {
   const toggleDrawer = useToggleLeftDrawer();
   const { railTool, promptAction, changePromptAction } = useRailTools();
-  const { services, showInstanceWarning, closeInstanceWarning, confirmInstanceRun } =
-    useAnnotationServices();
+  const {
+    services,
+    policyLoading,
+    policyError,
+    showInstanceWarning,
+    closeInstanceWarning,
+    confirmInstanceRun,
+  } = useAnnotationServices();
 
   const toolName = getRailTool(railTool).name;
 
@@ -97,10 +104,23 @@ const ToolOptionsDrawer = () => {
             <Sparkles size={14} className="text-ac flex-none" />
             <span className="text-row font-bold text-t1">Annotation services</span>
           </div>
+          {policyLoading && (
+            <p className="mb-[9px] px-[8px] py-[5px] rounded-6 bg-well2 text-ctl text-t2" role="status">
+              Loading model routing policy…
+            </p>
+          )}
+          {policyError && (
+            <p className="mb-[9px] px-[8px] py-[5px] rounded-6 bg-errBg text-ctl text-err" role="alert">
+              Unable to load model routing policy: {policyError}
+            </p>
+          )}
           <div className="flex flex-col gap-[9px]">
-            {services.map((service) => (
-              <ServiceCard key={service.key} service={service} />
-            ))}
+            {services
+              .filter((s) => s.key === 'prompted' || s.key === 'instance')
+              .map((service) => (
+                <ServiceCard key={service.key} service={service} />
+              ))}
+            <CrossImageSuggestionCard />
           </div>
         </div>
       </div>

--- a/src/components/annotationPage/workspace/ToolOptionsDrawer.test.jsx
+++ b/src/components/annotationPage/workspace/ToolOptionsDrawer.test.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import ToolOptionsDrawer from './ToolOptionsDrawer';
+
+vi.mock('./useAnnotationServices', () => ({
+  default: () => ({
+    services: [],
+    policyLoading: false,
+    policyError: 'routing service unavailable',
+    showInstanceWarning: false,
+    closeInstanceWarning: vi.fn(),
+    confirmInstanceRun: vi.fn(),
+  }),
+}));
+
+vi.mock('./useRailTools', () => ({
+  default: () => ({
+    railTool: 'point',
+    promptAction: 'nothing',
+    changePromptAction: vi.fn(),
+  }),
+}));
+
+vi.mock('../../../stores/selectors/annotationSelectors', () => ({
+  useToggleLeftDrawer: () => vi.fn(),
+}));
+
+vi.mock('./CrossImageSuggestionCard', () => ({ default: () => <div>Cross image card</div> }));
+vi.mock('./ServiceCard', () => ({ default: () => <div>Service card</div> }));
+vi.mock('../modals/InstanceWarningModal', () => ({ default: () => null }));
+
+describe('ToolOptionsDrawer routing status', () => {
+  it('shows policy-loading failures instead of silently using stale routing', () => {
+    render(<ToolOptionsDrawer />);
+
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'Unable to load model routing policy: routing service unavailable'
+    );
+  });
+});

--- a/src/components/annotationPage/workspace/useAnnotationServices.js
+++ b/src/components/annotationPage/workspace/useAnnotationServices.js
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import {
   useAvailablePromptedModels,
   useAvailableSuggestionModels,
@@ -20,29 +20,54 @@ import {
   useInstanceRunRequested,
   useSetInstanceRunRequested,
   useSetInstanceWarningModalOpen,
+  useActiveLabelId,
+  useModelFavorites,
 } from '../../../stores/selectors/annotationSelectors';
+import { useDataset } from '../../../contexts/DatasetContext';
+import { getInferenceRoutingPolicy } from '../../../api/inference';
+import {
+  resolveRoutingBinding,
+  isModelCompatibleWithLabel,
+  matchesModelKey,
+} from '../../../utils/inferenceRouting';
 import annotationSession from '../../../services/annotationSession';
 import useModelSwitchPreloader from '../../../hooks/useModelSwitchPreloader';
 import { useInstanceSegmentation } from '../../../hooks/useInstanceSegmentation';
 
-const getFirstModelId = (models) => {
-  const first = (models || []).find((m) => m?.id || m?.registry_key || m?.identifier);
-  return first?.id || first?.registry_key || first?.identifier || null;
+const getModelKey = (model) => model?.id || model?.registry_key || model?.identifier || null;
+
+const getFallbackModelId = (models, task, favoriteKey, labelId = null) => {
+  const compatibleModels = (models || []).filter((model) =>
+    isModelCompatibleWithLabel(model, labelId)
+  );
+  const favorite = favoriteKey
+    ? compatibleModels.find((model) => matchesModelKey(model, task, favoriteKey))
+    : null;
+  return getModelKey(favorite || compatibleModels[0]);
 };
 
+const isUsableBinding = (resolved) =>
+  Boolean(resolved?.binding && resolved.model && resolved.isCompatible && !resolved.isStale);
+
+const getPolicyErrorMessage = (error) =>
+  error?.message || 'Failed to load model routing policy';
+
 /**
- * Model lists, selections, defaults, preloading and the instance-segmentation
+ * Model lists, selections, dataset policy defaults, preloading and the instance-segmentation
  * write-mode flow for the three annotation services.
- *
- * Lifted verbatim from the old Services component so the options drawer only
- * has to render. The behaviour it preserves:
- *  - fetch each model list once,
- *  - force a deterministic default selection as soon as a list arrives,
- *  - push every selection change to the backend so the model is warm,
- *  - open the instance write-mode modal both from its Run button and from the
- *    `3` shortcut, which sets `instanceRunRequested` in the store.
  */
 export default function useAnnotationServices() {
+  const { currentDataset } = useDataset();
+  const datasetId = currentDataset?.id;
+  const activeLabelId = useActiveLabelId();
+  const favorites = useModelFavorites();
+  const [policyState, setPolicyState] = useState(() => ({
+    datasetId,
+    status: datasetId != null ? 'loading' : 'idle',
+    policy: null,
+    error: null,
+  }));
+
   const fetchPromptedModels = useFetchAvailablePromptedModels();
   const fetchSuggestionModels = useFetchAvailableSuggestionModels();
   const fetchInstanceModels = useFetchAvailableInstanceModels();
@@ -71,12 +96,64 @@ export default function useAnnotationServices() {
 
   const [showInstanceWarning, setShowInstanceWarning] = useState(false);
 
+  const policyReady =
+    datasetId != null &&
+    policyState.datasetId === datasetId &&
+    policyState.status === 'loaded';
+  const policyLoading =
+    datasetId != null &&
+    (policyState.datasetId !== datasetId || policyState.status === 'loading');
+  const policyError =
+    policyState.datasetId === datasetId && policyState.status === 'error'
+      ? policyState.error
+      : null;
+  const policy = policyReady ? policyState.policy : null;
+
+  const promptedRouting = useMemo(
+    () =>
+      policyReady
+        ? resolveRoutingBinding(
+            policy,
+            'prompted-segmentation',
+            activeLabelId,
+            availablePromptedModels
+          )
+        : null,
+    [policy, policyReady, activeLabelId, availablePromptedModels]
+  );
+  const suggestionRouting = useMemo(
+    () =>
+      policyReady
+        ? resolveRoutingBinding(policy, 'instance-suggestion', null, availableSuggestionModels)
+        : null,
+    [policy, policyReady, availableSuggestionModels]
+  );
+  const instanceRouting = useMemo(
+    () =>
+      policyReady
+        ? resolveRoutingBinding(policy, 'instance-segmentation', null, availableInstanceModels)
+        : null,
+    [policy, policyReady, availableInstanceModels]
+  );
+  const instanceBindingInvalid =
+    policyReady && Boolean(instanceRouting?.binding) && !isUsableBinding(instanceRouting);
+  const canRunInstance =
+    policyReady &&
+    !instanceBindingInvalid &&
+    !isRunningInstance &&
+    Boolean(
+      instanceModel &&
+        availableInstanceModels.some((model) =>
+          matchesModelKey(model, 'instance-segmentation', instanceModel)
+        )
+    );
+
   useEffect(() => {
     if (instanceRunRequested) {
-      setShowInstanceWarning(true);
+      if (canRunInstance) setShowInstanceWarning(true);
       setInstanceRunRequested(false);
     }
-  }, [instanceRunRequested, setInstanceRunRequested]);
+  }, [instanceRunRequested, canRunInstance, setInstanceRunRequested]);
 
   // Mirrored to the store so keyboard shortcuts don't steal Enter while the
   // modal has focus.
@@ -84,32 +161,138 @@ export default function useAnnotationServices() {
     setInstanceWarningModalOpen(showInstanceWarning);
   }, [showInstanceWarning, setInstanceWarningModalOpen]);
 
+  // Fetch model lists on mount if empty
   useEffect(() => {
     if (availablePromptedModels.length === 0) fetchPromptedModels();
     if (availableSuggestionModels.length === 0) fetchSuggestionModels();
     if (availableInstanceModels.length === 0) fetchInstanceModels();
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
+  // Load dataset routing policy
   useEffect(() => {
-    if (!promptedModel) {
-      const id = getFirstModelId(availablePromptedModels);
-      if (id) setPromptedModel(id);
-    }
-  }, [promptedModel, availablePromptedModels, setPromptedModel]);
+    let cancelled = false;
+    // A model selected for the previous dataset must not remain executable
+    // while the next dataset's policy is loading (or if that load fails).
+    setPromptedModel(null);
+    setSuggestionModel(null);
+    setInstanceModel(null);
+    setPolicyState({
+      datasetId,
+      status: datasetId != null ? 'loading' : 'idle',
+      policy: null,
+      error: null,
+    });
 
-  useEffect(() => {
-    if (!suggestionModel) {
-      const id = getFirstModelId(availableSuggestionModels);
-      if (id) setSuggestionModel(id);
+    if (datasetId == null) {
+      return () => {
+        cancelled = true;
+      };
     }
-  }, [suggestionModel, availableSuggestionModels, setSuggestionModel]);
 
+    getInferenceRoutingPolicy(datasetId)
+      .then((res) => {
+        if (!cancelled) {
+          setPolicyState({ datasetId, status: 'loaded', policy: res || null, error: null });
+        }
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          setPolicyState({
+            datasetId,
+            status: 'error',
+            policy: null,
+            error: getPolicyErrorMessage(err),
+          });
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [datasetId, setPromptedModel, setSuggestionModel, setInstanceModel]);
+
+  // Prompted Segmentation model resolution (active label override -> task default -> favorite/first compatible)
   useEffect(() => {
-    if (!instanceModel) {
-      const id = getFirstModelId(availableInstanceModels);
-      if (id) setInstanceModel(id);
+    if (!policyReady || availablePromptedModels.length === 0) return;
+    if (promptedRouting?.binding) {
+      if (isUsableBinding(promptedRouting)) {
+        const modelId = getModelKey(promptedRouting.model);
+        if (modelId) setPromptedModel(modelId);
+      } else {
+        setPromptedModel(null);
+      }
+      return;
     }
-  }, [instanceModel, availableInstanceModels, setInstanceModel]);
+
+    const modelId = getFallbackModelId(
+      availablePromptedModels,
+      'prompted-segmentation',
+      favorites?.['prompted-segmentation'],
+      activeLabelId
+    );
+    if (modelId) setPromptedModel(modelId);
+  }, [
+    policyReady,
+    promptedRouting,
+    activeLabelId,
+    availablePromptedModels,
+    favorites,
+    setPromptedModel,
+  ]);
+
+  // Instance Suggestion model resolution (task default -> favorite/first; label overrides resolve dynamically on exemplar selection)
+  useEffect(() => {
+    if (!policyReady || availableSuggestionModels.length === 0) return;
+    if (suggestionRouting?.binding) {
+      if (isUsableBinding(suggestionRouting)) {
+        const modelId = getModelKey(suggestionRouting.model);
+        if (modelId) setSuggestionModel(modelId);
+      } else {
+        setSuggestionModel(null);
+      }
+      return;
+    }
+
+    const modelId = getFallbackModelId(
+      availableSuggestionModels,
+      'instance-suggestion',
+      favorites?.['instance-suggestion']
+    );
+    if (modelId) setSuggestionModel(modelId);
+  }, [
+    policyReady,
+    suggestionRouting,
+    availableSuggestionModels,
+    favorites,
+    setSuggestionModel,
+  ]);
+
+  // Whole-image Instance Segmentation model resolution (task default -> favorite/first)
+  useEffect(() => {
+    if (!policyReady || availableInstanceModels.length === 0) return;
+    if (instanceRouting?.binding) {
+      if (isUsableBinding(instanceRouting)) {
+        const modelId = getModelKey(instanceRouting.model);
+        if (modelId) setInstanceModel(modelId);
+      } else {
+        setInstanceModel(null);
+      }
+      return;
+    }
+
+    const modelId = getFallbackModelId(
+      availableInstanceModels,
+      'instance-segmentation',
+      favorites?.['instance-segmentation']
+    );
+    if (modelId) setInstanceModel(modelId);
+  }, [
+    policyReady,
+    instanceRouting,
+    availableInstanceModels,
+    favorites,
+    setInstanceModel,
+  ]);
 
   useModelSwitchPreloader(
     promptedModel,
@@ -133,6 +316,7 @@ export default function useAnnotationServices() {
   };
 
   const confirmInstanceRun = (writeMode = 'patch') => {
+    if (!canRunInstance) return;
     setShowInstanceWarning(false);
     setInstanceRunRequested(false);
     setInstanceWarningModalOpen(false);
@@ -151,18 +335,6 @@ export default function useAnnotationServices() {
       isRunning: false,
     },
     {
-      key: 'suggestion',
-      task: 'instance-suggestion',
-      name: 'Instance Suggestion',
-      models: availableSuggestionModels,
-      isLoading: isLoadingSuggestion,
-      selectedModel: suggestionModel,
-      setSelectedModel: setSuggestionModel,
-      isRunning: isRunningSuggestion,
-      usageHint:
-        'Shift-click objects to select exemplars, then right-click any exemplar and choose “Suggest Similar Instances”.',
-    },
-    {
       key: 'instance',
       task: 'instance-segmentation',
       name: 'Instance Segmentation',
@@ -171,12 +343,27 @@ export default function useAnnotationServices() {
       selectedModel: instanceModel,
       setSelectedModel: setInstanceModel,
       isRunning: isRunningInstance,
-      onRun: () => setShowInstanceWarning(true),
+      onRun: canRunInstance ? () => setShowInstanceWarning(true) : undefined,
+    },
+    {
+      key: 'suggestion',
+      task: 'instance-suggestion',
+      name: 'Within-Image Suggestion',
+      models: availableSuggestionModels,
+      isLoading: isLoadingSuggestion,
+      selectedModel: suggestionModel,
+      setSelectedModel: setSuggestionModel,
+      isRunning: isRunningSuggestion,
+      usageHint:
+        'Shift-click objects on canvas to select exemplars, then right-click any exemplar and choose “Suggest Similar Instances”.',
     },
   ];
 
   return {
     services,
+    policy,
+    policyLoading,
+    policyError,
     showInstanceWarning,
     closeInstanceWarning,
     confirmInstanceRun,

--- a/src/components/annotationPage/workspace/useAnnotationServices.test.js
+++ b/src/components/annotationPage/workspace/useAnnotationServices.test.js
@@ -1,0 +1,224 @@
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import useAnnotationServices from "./useAnnotationServices";
+import { getInferenceRoutingPolicy } from "../../../api/inference";
+
+const { mockState } = vi.hoisted(() => ({
+    mockState: {
+        currentDataset: { id: "101" },
+        activeLabelId: 1,
+        favorites: {},
+        // Production slice models: only id, name, description, tags, etc.
+        availablePromptedModels: [
+            { id: "sam2-generic", name: "SAM 2 Generic", description: "Base", label_ids: [], tags: {} },
+            { id: "sam2-cell", name: "SAM 2 Cell Specialist", description: "Cell", label_ids: [1], tags: {} },
+        ],
+        availableSuggestionModels: [
+            { id: "sam3-suggestion-generic", name: "SAM 3 Intra", description: "Intra", label_ids: [], tags: {} },
+        ],
+        availableInstanceModels: [
+            { id: "m2f-generic", name: "Mask2Former Generic", description: "M2F Base", label_ids: [], tags: {} },
+            { id: "m2f-routed-default", name: "M2F Routed Default", description: "M2F Routed", label_ids: [], tags: {} },
+        ],
+        promptedModel: null,
+        suggestionModel: null,
+        instanceModel: null,
+    },
+}));
+
+vi.mock("../../../contexts/DatasetContext", () => ({
+    useDataset: () => ({ currentDataset: mockState.currentDataset }),
+}));
+
+vi.mock("../../../api/inference", () => ({
+    getInferenceRoutingPolicy: vi.fn(),
+}));
+
+const mockSetPromptedModel = vi.fn((m) => { mockState.promptedModel = m; });
+const mockSetSuggestionModel = vi.fn((m) => { mockState.suggestionModel = m; });
+const mockSetInstanceModel = vi.fn((m) => { mockState.instanceModel = m; });
+
+vi.mock("../../../stores/selectors/annotationSelectors", () => ({
+    useAvailablePromptedModels: () => mockState.availablePromptedModels,
+    useAvailableSuggestionModels: () => mockState.availableSuggestionModels,
+    useAvailableInstanceModels: () => mockState.availableInstanceModels,
+    useFetchAvailablePromptedModels: () => vi.fn(),
+    useFetchAvailableSuggestionModels: () => vi.fn(),
+    useFetchAvailableInstanceModels: () => vi.fn(),
+    useIsLoadingPromptedModels: () => false,
+    useIsLoadingSuggestionModels: () => false,
+    useIsLoadingInstanceModels: () => false,
+    useIsRunningSuggestion: () => false,
+    useIsRunningInstance: () => false,
+    usePromptedModel: () => mockState.promptedModel,
+    useSuggestionModel: () => mockState.suggestionModel,
+    useInstanceModel: () => mockState.instanceModel,
+    useSetPromptedModel: () => mockSetPromptedModel,
+    useSetSuggestionModel: () => mockSetSuggestionModel,
+    useSetInstanceModel: () => mockSetInstanceModel,
+    useInstanceRunRequested: () => false,
+    useSetInstanceRunRequested: () => vi.fn(),
+    useSetInstanceWarningModalOpen: () => vi.fn(),
+    useActiveLabelId: () => mockState.activeLabelId,
+    useModelFavorites: () => mockState.favorites,
+}));
+
+vi.mock("../../../services/annotationSession", () => ({
+    default: {
+        selectPromptedModel: vi.fn(),
+        selectSuggestionModel: vi.fn(),
+        selectInstanceModel: vi.fn(),
+    },
+}));
+
+vi.mock("../../../hooks/useModelSwitchPreloader", () => ({
+    default: vi.fn(),
+}));
+
+vi.mock("../../../hooks/useInstanceSegmentation", () => ({
+    useInstanceSegmentation: () => ({ runInstance: vi.fn() }),
+}));
+
+describe("useAnnotationServices with dataset routing policy", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockState.currentDataset = { id: "101" };
+        mockState.promptedModel = null;
+        mockState.suggestionModel = null;
+        mockState.instanceModel = null;
+        mockState.activeLabelId = 1;
+        mockState.favorites = {};
+    });
+
+    it("applies label override for prompted segmentation and task default for instance segmentation on production model shapes", async () => {
+        getInferenceRoutingPolicy.mockResolvedValueOnce({
+            dataset_id: 101,
+            bindings: [
+                {
+                    task: "prompted-segmentation",
+                    label_id: 1,
+                    model_registry_key: "sam2-cell",
+                },
+                {
+                    task: "instance-segmentation",
+                    label_id: null,
+                    model_registry_key: "m2f-routed-default",
+                },
+            ],
+        });
+
+        renderHook(() => useAnnotationServices());
+
+        await waitFor(() => {
+            expect(mockSetPromptedModel).toHaveBeenCalledWith("sam2-cell");
+            expect(mockSetInstanceModel).toHaveBeenCalledWith("m2f-routed-default");
+        });
+    });
+
+    it("falls back to first available model when no dataset route is configured", async () => {
+        getInferenceRoutingPolicy.mockResolvedValueOnce(null);
+
+        renderHook(() => useAnnotationServices());
+
+        await waitFor(() => {
+            expect(mockSetPromptedModel).toHaveBeenCalledWith("sam2-generic");
+            expect(mockSetInstanceModel).toHaveBeenCalledWith("m2f-generic");
+        });
+    });
+
+    it("does not apply class-aware task default to incompatible active labels", async () => {
+        // activeLabelId is 2 (unsupported by sam2-cell which only predicts 1)
+        mockState.activeLabelId = 2;
+        mockState.availablePromptedModels = [
+            { id: "sam2-generic", name: "SAM 2 Generic", label_ids: [] },
+            { id: "sam2-cell", name: "SAM 2 Cell Specialist", label_ids: [1] },
+        ];
+
+        getInferenceRoutingPolicy.mockResolvedValueOnce({
+            dataset_id: 101,
+            bindings: [
+                {
+                    task: "prompted-segmentation",
+                    label_id: null,
+                    model_registry_key: "sam2-cell", // class-aware default for label 1 only
+                },
+            ],
+        });
+
+        renderHook(() => useAnnotationServices());
+
+        await waitFor(() => {
+            // A configured route is authoritative. An invalid class-aware
+            // default is disabled instead of silently choosing another model.
+            expect(mockSetPromptedModel).toHaveBeenCalledWith(null);
+        });
+    });
+
+    it("restores personal favorite or first compatible model when switching to an unrouted label without leaking previous specialist", async () => {
+        mockState.activeLabelId = 1;
+        mockState.promptedModel = "sam2-cell"; // previously armed label 1 had specialist
+        mockState.favorites = { "prompted-segmentation": "sam2-generic" };
+
+        getInferenceRoutingPolicy.mockResolvedValueOnce({
+            dataset_id: 101,
+            bindings: [
+                {
+                    task: "prompted-segmentation",
+                    label_id: 1,
+                    model_registry_key: "sam2-cell",
+                },
+            ],
+        });
+
+        const { rerender } = renderHook(() => useAnnotationServices());
+
+        await waitFor(() => {
+            expect(mockSetPromptedModel).toHaveBeenCalledWith("sam2-cell");
+        });
+
+        // Switch to label 2 (has no override)
+        mockState.activeLabelId = 2;
+        rerender();
+
+        await waitFor(() => {
+            // Restores favorite (sam2-generic) instead of leaking sam2-cell
+            expect(mockSetPromptedModel).toHaveBeenCalledWith("sam2-generic");
+        });
+    });
+
+    it("tracks policyError when policy loading fails with a network or server error", async () => {
+        const error = new Error("500 Internal Server Error");
+        getInferenceRoutingPolicy.mockRejectedValueOnce(error);
+
+        const { result } = renderHook(() => useAnnotationServices());
+
+        await waitFor(() => {
+            expect(result.current.policy).toBeNull();
+            expect(result.current.policyError).toBe("500 Internal Server Error");
+        });
+    });
+
+    it("does not overwrite a manual model selection after policy prefill", async () => {
+        getInferenceRoutingPolicy.mockResolvedValueOnce({
+            dataset_id: 101,
+            bindings: [
+                {
+                    task: "prompted-segmentation",
+                    label_id: 1,
+                    model_registry_key: "sam2-cell",
+                },
+            ],
+        });
+
+        const { rerender } = renderHook(() => useAnnotationServices());
+        await waitFor(() => {
+            expect(mockSetPromptedModel).toHaveBeenCalledWith("sam2-cell");
+        });
+        const callsAfterPrefill = mockSetPromptedModel.mock.calls.length;
+
+        mockState.promptedModel = "sam2-generic";
+        rerender();
+
+        expect(mockSetPromptedModel).toHaveBeenCalledTimes(callsAfterPrefill);
+    });
+});

--- a/src/components/annotationPage/workspace/useInferenceConfigSuggestion.js
+++ b/src/components/annotationPage/workspace/useInferenceConfigSuggestion.js
@@ -1,0 +1,305 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+    getInferenceConfig,
+    getInferenceModelCatalog,
+    suggestInferenceConfigStep,
+} from "../../../api/inference";
+import { getContourHierarchy } from "../../../api/contours";
+import { useDataset } from "../../../contexts/DatasetContext";
+import { useToast } from "../../../contexts/ToastContext";
+import { usePermissions } from "../../../hooks/usePermissions";
+import { Permission } from "../../../utils/permissions";
+import { resolveRoutingBinding } from "../../../utils/inferenceRouting";
+import {
+    useCurrentImageId,
+    useCurrentMaskId,
+    useDatasetLabelsMap,
+    useSetObjectsFromHierarchy,
+} from "../../../stores/selectors/annotationSelectors";
+
+/**
+ * Hook for executing single-image per-label AI suggestions based on the dataset's
+ * active model orchestration configuration.
+ */
+export function useInferenceConfigSuggestion() {
+    const { currentDataset } = useDataset();
+    const datasetId = currentDataset?.id;
+    const imageId = useCurrentImageId();
+    const currentMaskId = useCurrentMaskId();
+    const datasetLabelsMap = useDatasetLabelsMap();
+    const setObjectsFromHierarchy = useSetObjectsFromHierarchy();
+    const { addToast } = useToast();
+    const { can } = usePermissions(datasetId);
+
+    const imageIdRef = useRef(imageId);
+    imageIdRef.current = imageId;
+    const currentMaskIdRef = useRef(currentMaskId);
+    currentMaskIdRef.current = currentMaskId;
+    const suggestionRequestTokenRef = useRef(0);
+
+    const [config, setConfig] = useState(null);
+    const [catalogModels, setCatalogModels] = useState([]);
+    const [isLoadingConfig, setIsLoadingConfig] = useState(false);
+    const [configError, setConfigError] = useState(null);
+    const [activeRunningLabelId, setActiveRunningLabelId] = useState(null);
+
+    const canSuggest = Boolean(
+        can(Permission.AI_INTERACTIVE) && can(Permission.ANNOTATION_CREATE)
+    );
+
+    // Fetch the dataset config and catalog on dataset change
+    useEffect(() => {
+        // Immediately invalidate in-flight suggestions, clear config, and reset running state
+        suggestionRequestTokenRef.current += 1;
+        setConfig(null);
+        setCatalogModels([]);
+        setConfigError(null);
+        setActiveRunningLabelId(null);
+
+        if (!datasetId) {
+            setIsLoadingConfig(false);
+            return undefined;
+        }
+
+        let isCancelled = false;
+        setIsLoadingConfig(true);
+
+        Promise.all([
+            getInferenceConfig(datasetId),
+            typeof getInferenceModelCatalog === "function"
+                ? Promise.resolve(getInferenceModelCatalog(datasetId))
+                : Promise.resolve({ models: [] }),
+        ])
+            .then(([res, catRes]) => {
+                if (!isCancelled) {
+                    setConfig(res);
+                    setCatalogModels(catRes?.models || []);
+                    setConfigError(null);
+                }
+            })
+            .catch((err) => {
+                if (!isCancelled) {
+                    setConfig(null);
+                    setCatalogModels([]);
+                    setConfigError(err?.message || "Failed to load orchestration configuration or model catalog.");
+                }
+            })
+            .finally(() => {
+                if (!isCancelled) {
+                    setIsLoadingConfig(false);
+                }
+            });
+
+        return () => {
+            isCancelled = true;
+            suggestionRequestTokenRef.current += 1;
+        };
+    }, [datasetId]);
+
+    // Invalidate any in-flight suggestion requests on unmount
+    useEffect(() => {
+        return () => {
+            suggestionRequestTokenRef.current += 1;
+        };
+    }, []);
+
+    const configuredStepsByLabelId = useMemo(() => {
+        const map = new Map();
+        if (!config) return map;
+
+        // Support new canonical policy bindings
+        if (Array.isArray(config.bindings)) {
+            const labelIdsSet = new Set();
+            if (datasetLabelsMap) {
+                const mapKeys =
+                    datasetLabelsMap instanceof Map
+                        ? Array.from(datasetLabelsMap.keys())
+                        : Object.keys(datasetLabelsMap);
+                mapKeys.forEach((k) => labelIdsSet.add(Number(k)));
+            }
+            config.bindings.forEach((b) => {
+                if (b.label_id != null) labelIdsSet.add(Number(b.label_id));
+            });
+
+            labelIdsSet.forEach((lid) => {
+                const resolved = resolveRoutingBinding(
+                    config,
+                    "cross-image-suggestion",
+                    Number(lid),
+                    catalogModels
+                );
+                if (resolved && resolved.binding && resolved.isCompatible && !resolved.isStale) {
+                    map.set(String(lid), {
+                        ...resolved.binding,
+                        model: resolved.model || null,
+                    });
+                }
+            });
+            return map;
+        }
+
+        // Support legacy steps array if present
+        if (Array.isArray(config.steps)) {
+            for (const step of config.steps) {
+                if (step && step.label_id != null) {
+                    map.set(String(step.label_id), step);
+                }
+            }
+        }
+        return map;
+    }, [config, datasetLabelsMap, catalogModels]);
+
+    const isConfigured = useCallback(
+        (labelId) => {
+            if (!canSuggest || labelId == null) return false;
+            return configuredStepsByLabelId.has(String(labelId));
+        },
+        [canSuggest, configuredStepsByLabelId]
+    );
+
+    const getResolvedBinding = useCallback(
+        (labelId) => {
+            if (labelId == null) return null;
+            const step = configuredStepsByLabelId.get(String(labelId));
+            if (!step) return null;
+            return {
+                binding: step,
+                model: step.model || null,
+            };
+        },
+        [configuredStepsByLabelId]
+    );
+
+    const isRunning = useCallback(
+        (labelId) => {
+            return String(activeRunningLabelId) === String(labelId);
+        },
+        [activeRunningLabelId]
+    );
+
+    const isAnyRunning = activeRunningLabelId !== null;
+
+    const suggestLabel = useCallback(
+        async (labelId) => {
+            if (!datasetId || !imageId || !currentMaskId || labelId == null) return;
+            if (isAnyRunning) return;
+
+            const step = configuredStepsByLabelId.get(String(labelId));
+            if (!step) return;
+
+            const targetImageId = imageId;
+            const targetMaskId = currentMaskId;
+            const requestToken = ++suggestionRequestTokenRef.current;
+
+            setActiveRunningLabelId(labelId);
+
+            let result;
+            try {
+                result = await suggestInferenceConfigStep({
+                    datasetId,
+                    imageId: targetImageId,
+                    maskId: targetMaskId,
+                    labelId: Number(labelId),
+                    task: "cross-image-suggestion",
+                });
+            } catch (err) {
+                // Only toast mutation errors if this request is still the active token and user is on target image and mask
+                if (
+                    requestToken === suggestionRequestTokenRef.current &&
+                    imageIdRef.current === targetImageId &&
+                    currentMaskIdRef.current === targetMaskId
+                ) {
+                    addToast({
+                        type: "error",
+                        message: `Suggestion failed: ${err.message || "Unknown error"}`,
+                    });
+                }
+                return;
+            } finally {
+                // Only clear the active running state if this request is still the active token
+                if (suggestionRequestTokenRef.current === requestToken) {
+                    setActiveRunningLabelId(null);
+                }
+            }
+
+            // Mutation succeeded! Guard against stale image/mask changes
+            if (
+                requestToken !== suggestionRequestTokenRef.current ||
+                imageIdRef.current !== targetImageId ||
+                currentMaskIdRef.current !== targetMaskId
+            ) {
+                return;
+            }
+
+            const created = result.contours_created ?? 0;
+            const suppressed = result.contours_suppressed ?? 0;
+
+            if (created > 0) {
+                const suppressionText =
+                    suppressed > 0
+                        ? ` (${suppressed} duplicate${suppressed === 1 ? "" : "s"} suppressed)`
+                        : "";
+                addToast({
+                    type: "success",
+                    message: `Suggested ${created} object${created === 1 ? "" : "s"}${suppressionText}.`,
+                });
+            } else {
+                addToast({
+                    type: "info",
+                    message: "Model finished with 0 candidate objects on this image.",
+                });
+            }
+
+            // Reload contour hierarchy to update canvas objects (separate try/catch so refresh errors don't report mutation failure)
+            try {
+                const rawHierarchy = await getContourHierarchy(targetMaskId);
+                const hierarchy = rawHierarchy?.contours || rawHierarchy;
+
+                if (
+                    requestToken !== suggestionRequestTokenRef.current ||
+                    imageIdRef.current !== targetImageId ||
+                    currentMaskIdRef.current !== targetMaskId
+                ) {
+                    return;
+                }
+
+                setObjectsFromHierarchy(hierarchy, datasetLabelsMap);
+            } catch (refreshErr) {
+                console.warn("Could not refresh canvas hierarchy after suggestion:", refreshErr);
+                if (
+                    requestToken === suggestionRequestTokenRef.current &&
+                    imageIdRef.current === targetImageId &&
+                    currentMaskIdRef.current === targetMaskId
+                ) {
+                    addToast({
+                        type: "warning",
+                        message: "Suggested annotations were saved, but canvas refresh failed. Reload the image to view them.",
+                    });
+                }
+            }
+        },
+        [
+            datasetId,
+            imageId,
+            currentMaskId,
+            isAnyRunning,
+            configuredStepsByLabelId,
+            config,
+            setObjectsFromHierarchy,
+            datasetLabelsMap,
+            addToast,
+        ]
+    );
+
+    return {
+        config,
+        catalogModels,
+        isLoadingConfig,
+        configError,
+        isConfigured,
+        getResolvedBinding,
+        isRunning,
+        isAnyRunning,
+        suggestLabel,
+    };
+}

--- a/src/components/annotationPage/workspace/useInferenceConfigSuggestion.test.js
+++ b/src/components/annotationPage/workspace/useInferenceConfigSuggestion.test.js
@@ -1,0 +1,539 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { useInferenceConfigSuggestion } from "./useInferenceConfigSuggestion";
+import * as inferenceApi from "../../../api/inference";
+import * as contoursApi from "../../../api/contours";
+import * as DatasetContext from "../../../contexts/DatasetContext";
+import * as ToastContext from "../../../contexts/ToastContext";
+import * as usePermissionsModule from "../../../hooks/usePermissions";
+import * as annotationSelectors from "../../../stores/selectors/annotationSelectors";
+
+vi.mock("../../../api/inference");
+vi.mock("../../../api/contours");
+
+describe("useInferenceConfigSuggestion", () => {
+    const addToast = vi.fn();
+    const setObjectsFromHierarchy = vi.fn();
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+
+        vi.spyOn(DatasetContext, "useDataset").mockReturnValue({
+            currentDataset: { id: 10, name: "Test Dataset" },
+        });
+        vi.spyOn(ToastContext, "useToast").mockReturnValue({ addToast });
+        vi.spyOn(usePermissionsModule, "usePermissions").mockReturnValue({
+            can: vi.fn().mockReturnValue(true),
+        });
+        vi.spyOn(annotationSelectors, "useCurrentImageId").mockReturnValue(100);
+        vi.spyOn(annotationSelectors, "useCurrentMaskId").mockReturnValue(50);
+        vi.spyOn(annotationSelectors, "useDatasetLabelsMap").mockReturnValue(new Map([[1, "cell"]]));
+        vi.spyOn(annotationSelectors, "useSetObjectsFromHierarchy").mockReturnValue(setObjectsFromHierarchy);
+
+        inferenceApi.getInferenceModelCatalog.mockResolvedValue({
+            models: [
+                { registry_key: "m2f", task: "instance-segmentation", label_ids: [] },
+                { registry_key: "sam3-cross", task: "cross-image-suggestion", label_ids: [] },
+                { registry_key: "sam3-cross-default", task: "cross-image-suggestion", label_ids: [] },
+            ],
+        });
+        inferenceApi.getInferenceConfig.mockResolvedValue({
+            dataset_id: 10,
+            steps: [{ label_id: 1, model_registry_key: "m2f" }],
+            options: {},
+        });
+    });
+
+    it("indexes configured steps and identifies configured labels", async () => {
+        const { result } = renderHook(() => useInferenceConfigSuggestion());
+
+        await waitFor(() => {
+            expect(result.current.isConfigured(1)).toBe(true);
+        });
+
+        expect(result.current.isConfigured(2)).toBe(false);
+        expect(result.current.isRunning(1)).toBe(false);
+    });
+
+    it("executes suggestion, refreshes contour hierarchy, and displays toast", async () => {
+        inferenceApi.suggestInferenceConfigStep.mockResolvedValue({
+            dataset_id: 10,
+            image_id: 100,
+            label_id: 1,
+            contours_created: 3,
+            contours_suppressed: 1,
+            contour_ids: [101, 102, 103],
+        });
+
+        const mockResponse = {
+            success: true,
+            message: "Contours hierarchy retrieved.",
+            contours: { root_contours: [{ id: 101, label_id: 1 }] },
+        };
+        contoursApi.getContourHierarchy.mockResolvedValue(mockResponse);
+
+        const { result } = renderHook(() => useInferenceConfigSuggestion());
+
+        await waitFor(() => {
+            expect(result.current.isConfigured(1)).toBe(true);
+        });
+
+        await act(async () => {
+            await result.current.suggestLabel(1);
+        });
+
+        expect(inferenceApi.suggestInferenceConfigStep).toHaveBeenCalledWith(
+            expect.objectContaining({
+                datasetId: 10,
+                imageId: 100,
+                maskId: 50,
+                labelId: 1,
+            })
+        );
+        expect(contoursApi.getContourHierarchy).toHaveBeenCalledWith(50);
+        expect(setObjectsFromHierarchy).toHaveBeenCalledWith(
+            { root_contours: [{ id: 101, label_id: 1 }] },
+            expect.any(Map)
+        );
+        expect(addToast).toHaveBeenCalledWith({
+            type: "success",
+            message: "Suggested 3 objects (1 duplicate suppressed).",
+        });
+    });
+
+    it("discards hierarchy refresh if user navigates to another image while suggestion is in-flight", async () => {
+        let resolveInference;
+        inferenceApi.suggestInferenceConfigStep.mockImplementation(
+            () =>
+                new Promise((resolve) => {
+                    resolveInference = resolve;
+                })
+        );
+
+        let currentImageId = 100;
+        vi.spyOn(annotationSelectors, "useCurrentImageId").mockImplementation(() => currentImageId);
+
+        const { result, rerender } = renderHook(() => useInferenceConfigSuggestion());
+
+        await waitFor(() => {
+            expect(result.current.isConfigured(1)).toBe(true);
+        });
+
+        // Trigger suggestion on image 100
+        let suggestPromise;
+        act(() => {
+            suggestPromise = result.current.suggestLabel(1);
+        });
+
+        // User switches to image 200 while request is in-flight
+        currentImageId = 200;
+        rerender();
+
+        // Complete the in-flight inference request
+        await act(async () => {
+            resolveInference({
+                dataset_id: 10,
+                image_id: 100,
+                label_id: 1,
+                contours_created: 3,
+                contours_suppressed: 0,
+            });
+            await suggestPromise;
+        });
+
+        expect(contoursApi.getContourHierarchy).not.toHaveBeenCalled();
+        expect(setObjectsFromHierarchy).not.toHaveBeenCalled();
+    });
+
+    it("clears stale configuration and active running state immediately on dataset change", async () => {
+        let currentDataset = { id: 10, name: "Dataset 10" };
+        vi.spyOn(DatasetContext, "useDataset").mockImplementation(() => ({ currentDataset }));
+
+        let resolveDataset20;
+        inferenceApi.getInferenceConfig.mockImplementation((dsId) => {
+            if (dsId === 10) {
+                return Promise.resolve({
+                    id: 101,
+                    dataset_id: 10,
+                    name: "default",
+                    steps: [{ label_id: 1, model_registry_key: "m2f" }],
+                    options: {},
+                });
+            }
+            return new Promise((resolve) => {
+                resolveDataset20 = resolve;
+            });
+        });
+
+        const { result, rerender } = renderHook(() => useInferenceConfigSuggestion());
+
+        await waitFor(() => {
+            expect(result.current.isConfigured(1)).toBe(true);
+            expect(result.current.config?.id).toBe(101);
+        });
+
+        // Switch to Dataset 20 while API is in-flight
+        currentDataset = { id: 20, name: "Dataset 20" };
+        rerender();
+
+        // Stale config and running state must be cleared immediately
+        expect(result.current.config).toBeNull();
+        expect(result.current.isConfigured(1)).toBe(false);
+        expect(result.current.isAnyRunning).toBe(false);
+        expect(result.current.isLoadingConfig).toBe(true);
+
+        // Resolve new dataset config
+        await act(async () => {
+            resolveDataset20({
+                id: 202,
+                dataset_id: 20,
+                name: "default",
+                steps: [{ label_id: 2, model_registry_key: "sam2" }],
+                options: {},
+            });
+        });
+
+        await waitFor(() => {
+            expect(result.current.isLoadingConfig).toBe(false);
+            expect(result.current.config?.id).toBe(202);
+            expect(result.current.isConfigured(2)).toBe(true);
+            expect(result.current.isConfigured(1)).toBe(false);
+        });
+    });
+
+    it("suppresses error toast if user switches masks while suggestion is in-flight", async () => {
+        let rejectInference;
+        inferenceApi.suggestInferenceConfigStep.mockImplementation(
+            () =>
+                new Promise((_, reject) => {
+                    rejectInference = reject;
+                })
+        );
+
+        let currentMaskId = 50;
+        vi.spyOn(annotationSelectors, "useCurrentMaskId").mockImplementation(() => currentMaskId);
+
+        const { result, rerender } = renderHook(() => useInferenceConfigSuggestion());
+
+        await waitFor(() => {
+            expect(result.current.isConfigured(1)).toBe(true);
+        });
+
+        let suggestPromise;
+        act(() => {
+            suggestPromise = result.current.suggestLabel(1);
+        });
+
+        // User switches mask to 60 while inference is in-flight
+        currentMaskId = 60;
+        rerender();
+
+        // Inference fails
+        await act(async () => {
+            rejectInference(new Error("Model connection timeout on mask 50"));
+            await suggestPromise;
+        });
+
+        // Stale mask error toast is suppressed
+        expect(addToast).not.toHaveBeenCalled();
+    });
+
+    it("displays error toast if user remains on the same image and mask", async () => {
+        inferenceApi.suggestInferenceConfigStep.mockRejectedValue(
+            new Error("Inference engine error")
+        );
+
+        const { result } = renderHook(() => useInferenceConfigSuggestion());
+
+        await waitFor(() => {
+            expect(result.current.isConfigured(1)).toBe(true);
+        });
+
+        await act(async () => {
+            await result.current.suggestLabel(1);
+        });
+
+        expect(addToast).toHaveBeenCalledWith({
+            type: "error",
+            message: "Suggestion failed: Inference engine error",
+        });
+    });
+
+    it("fences stale suggestion finally cleanup against newer requests across dataset changes", async () => {
+        let currentDataset = { id: 10, name: "Dataset 10" };
+        vi.spyOn(DatasetContext, "useDataset").mockImplementation(() => ({ currentDataset }));
+
+        let resolveInferenceDs10;
+        let resolveInferenceDs20;
+        inferenceApi.suggestInferenceConfigStep.mockImplementation(({ datasetId }) => {
+            if (datasetId === 10) {
+                return new Promise((resolve) => {
+                    resolveInferenceDs10 = resolve;
+                });
+            }
+            return new Promise((resolve) => {
+                resolveInferenceDs20 = resolve;
+            });
+        });
+
+        inferenceApi.getInferenceConfig.mockImplementation((dsId) => {
+            if (dsId === 10) {
+                return Promise.resolve({
+                    id: 101,
+                    dataset_id: 10,
+                    name: "default",
+                    steps: [{ label_id: 1, model_registry_key: "m2f" }],
+                    options: {},
+                });
+            }
+            return Promise.resolve({
+                id: 202,
+                dataset_id: 20,
+                name: "default",
+                steps: [{ label_id: 2, model_registry_key: "sam2" }],
+                options: {},
+            });
+        });
+
+        const { result, rerender } = renderHook(() => useInferenceConfigSuggestion());
+
+        await waitFor(() => {
+            expect(result.current.isConfigured(1)).toBe(true);
+        });
+
+        // 1. Start suggestion on Dataset 10 (label 1)
+        let promise1;
+        act(() => {
+            promise1 = result.current.suggestLabel(1);
+        });
+        expect(result.current.isRunning(1)).toBe(true);
+
+        // 2. User switches to Dataset 20 while suggestion 1 is in-flight
+        currentDataset = { id: 20, name: "Dataset 20" };
+        rerender();
+
+        await waitFor(() => {
+            expect(result.current.isConfigured(2)).toBe(true);
+            expect(result.current.isAnyRunning).toBe(false);
+        });
+
+        // 3. Start suggestion on Dataset 20 (label 2)
+        let promise2;
+        act(() => {
+            promise2 = result.current.suggestLabel(2);
+        });
+        expect(result.current.isRunning(2)).toBe(true);
+
+        // 4. Stale request from Dataset 10 finishes
+        await act(async () => {
+            resolveInferenceDs10({
+                dataset_id: 10,
+                image_id: 100,
+                label_id: 1,
+                contours_created: 1,
+            });
+            await promise1;
+        });
+
+        // Stale completion must NOT have cleared the active running state of Dataset 20's suggestion
+        expect(result.current.isRunning(2)).toBe(true);
+        expect(result.current.isAnyRunning).toBe(true);
+
+        // 5. Complete Dataset 20 suggestion
+        await act(async () => {
+            resolveInferenceDs20({
+                dataset_id: 20,
+                image_id: 100,
+                label_id: 2,
+                contours_created: 2,
+            });
+            await promise2;
+        });
+
+        // Now Dataset 20's running state is cleanly reset
+        expect(result.current.isRunning(2)).toBe(false);
+        expect(result.current.isAnyRunning).toBe(false);
+    });
+
+    it("discards hierarchy refresh and toast if component unmounts while suggestion is in-flight", async () => {
+        let resolveInference;
+        inferenceApi.suggestInferenceConfigStep.mockImplementation(
+            () =>
+                new Promise((resolve) => {
+                    resolveInference = resolve;
+                })
+        );
+
+        const { result, unmount } = renderHook(() => useInferenceConfigSuggestion());
+
+        await waitFor(() => {
+            expect(result.current.isConfigured(1)).toBe(true);
+        });
+
+        let suggestPromise;
+        act(() => {
+            suggestPromise = result.current.suggestLabel(1);
+        });
+
+        // Component unmounts while inference is in-flight
+        unmount();
+
+        // In-flight inference resolves after unmount
+        await act(async () => {
+            resolveInference({
+                dataset_id: 10,
+                image_id: 100,
+                label_id: 1,
+                contours_created: 5,
+            });
+            await suggestPromise;
+        });
+
+        // Hierarchy refresh and toasts must NOT have been triggered after unmount
+        expect(contoursApi.getContourHierarchy).not.toHaveBeenCalled();
+        expect(setObjectsFromHierarchy).not.toHaveBeenCalled();
+        expect(addToast).not.toHaveBeenCalled();
+    });
+
+    it("separates suggestion creation success from hierarchy refresh failure", async () => {
+        inferenceApi.suggestInferenceConfigStep.mockResolvedValue({
+            dataset_id: 10,
+            image_id: 100,
+            label_id: 1,
+            contours_created: 4,
+            contours_suppressed: 0,
+        });
+        contoursApi.getContourHierarchy.mockRejectedValue(
+            new Error("Network timeout loading hierarchy")
+        );
+
+        const { result } = renderHook(() => useInferenceConfigSuggestion());
+
+        await waitFor(() => {
+            expect(result.current.isConfigured(1)).toBe(true);
+        });
+
+        await act(async () => {
+            await result.current.suggestLabel(1);
+        });
+
+        // 1. Success toast is displayed for the created annotations
+        expect(addToast).toHaveBeenCalledWith({
+            type: "success",
+            message: "Suggested 4 objects.",
+        });
+
+        // 2. Warning toast is displayed for the canvas refresh failure, NOT a generic "Suggestion failed" error
+        expect(addToast).toHaveBeenCalledWith({
+            type: "warning",
+            message: "Suggested annotations were saved, but canvas refresh failed. Reload the image to view them.",
+        });
+        expect(addToast).not.toHaveBeenCalledWith(
+            expect.objectContaining({
+                type: "error",
+                message: expect.stringMatching(/suggestion failed/i),
+            })
+        );
+    });
+
+    it("exposes configError when configuration fetch fails", async () => {
+        inferenceApi.getInferenceConfig.mockRejectedValue(
+            new Error("Internal Server Error (500)")
+        );
+
+        const { result } = renderHook(() => useInferenceConfigSuggestion());
+
+        await waitFor(() => {
+            expect(result.current.isLoadingConfig).toBe(false);
+        });
+
+        expect(result.current.config).toBeNull();
+        expect(result.current.configError).toBe("Internal Server Error (500)");
+        expect(result.current.isConfigured(1)).toBe(false);
+    });
+
+    it("resolves configured labels from canonical task-aware bindings", async () => {
+        inferenceApi.getInferenceConfig.mockResolvedValue({
+            dataset_id: 10,
+            bindings: [
+                {
+                    task: "cross-image-suggestion",
+                    label_id: 1,
+                    model_registry_key: "sam3-cross",
+                },
+                {
+                    task: "instance-segmentation",
+                    label_id: 2,
+                    model_registry_key: "m2f",
+                },
+            ],
+        });
+
+        const { result } = renderHook(() => useInferenceConfigSuggestion());
+
+        await waitFor(() => {
+            expect(result.current.isConfigured(1)).toBe(true);
+        });
+
+        // Label 2 is only bound to instance-segmentation (not interactive cross-image-suggestion)
+        expect(result.current.isConfigured(2)).toBe(false);
+    });
+
+    it("resolves task-default cross-image binding for unassigned dataset labels", async () => {
+        inferenceApi.getInferenceConfig.mockResolvedValue({
+            dataset_id: 10,
+            bindings: [
+                {
+                    task: "cross-image-suggestion",
+                    label_id: null,
+                    model_registry_key: "sam3-cross-default",
+                },
+            ],
+        });
+
+        const { result } = renderHook(() => useInferenceConfigSuggestion());
+
+        await waitFor(() => {
+            // Label 1 is in datasetLabelsMap, so it inherits the default cross-image binding
+            expect(result.current.isConfigured(1)).toBe(true);
+        });
+    });
+
+    it("does not apply class-aware cross-image task default to unsupported labels", async () => {
+        vi.spyOn(annotationSelectors, "useDatasetLabelsMap").mockReturnValue(
+            new Map([
+                [1, "cell"],
+                [2, "nucleus"],
+            ])
+        );
+        inferenceApi.getInferenceModelCatalog.mockResolvedValueOnce({
+            models: [
+                {
+                    registry_key: "sam3-cross-nucleus-only",
+                    task: "cross-image-suggestion",
+                    label_ids: [2], // predicts label 2 only
+                },
+            ],
+        });
+        inferenceApi.getInferenceConfig.mockResolvedValue({
+            dataset_id: 10,
+            bindings: [
+                {
+                    task: "cross-image-suggestion",
+                    label_id: null,
+                    model_registry_key: "sam3-cross-nucleus-only",
+                },
+            ],
+        });
+
+        const { result } = renderHook(() => useInferenceConfigSuggestion());
+
+        await waitFor(() => {
+            // Label 2 (predicted by model) is configured
+            expect(result.current.isConfigured(2)).toBe(true);
+        });
+
+        // Label 1 (NOT predicted by this class-aware model) is NOT configured
+        expect(result.current.isConfigured(1)).toBe(false);
+    });
+});

--- a/src/components/annotationPage/workspace/useSuggestSimilar.js
+++ b/src/components/annotationPage/workspace/useSuggestSimilar.js
@@ -1,14 +1,23 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   useObjectsList,
   useSelectedObjects,
   useSuggestionModel,
+  useAvailableSuggestionModels,
+  useModelFavorites,
   useWebSocketIsReady,
   useIsRunningSuggestion,
 } from '../../../stores/selectors/annotationSelectors';
 import { useSuggestionSegmentation } from '../../../hooks/useSuggestionSegmentation';
+import { useDataset } from '../../../contexts/DatasetContext';
 import { useToast } from '../../../contexts/ToastContext';
 import { hasValidLabel } from '../../../stores/utils/labelValidation';
+import { getInferenceRoutingPolicy } from '../../../api/inference';
+import {
+  isModelCompatibleWithLabel,
+  matchesModelKey,
+  resolveRoutingBinding,
+} from '../../../utils/inferenceRouting';
 
 /**
  * Stable identity for an object's class. Unlabelled objects collapse to one
@@ -19,6 +28,11 @@ const getClassKey = (object) => {
   if (object.labelId != null) return `id:${object.labelId}`;
   return `name:${String(object.label).trim()}`;
 };
+
+const getModelKey = (m) => m?.id || m?.registry_key || m?.identifier || null;
+
+const getPolicyErrorMessage = (error) =>
+  error?.message || 'Failed to load model routing policy';
 
 /**
  * "Suggest similar instances" — an action on the current selection rather than
@@ -32,9 +46,70 @@ export default function useSuggestSimilar() {
   const objectsList = useObjectsList();
   const selectedIds = useSelectedObjects();
   const suggestionModel = useSuggestionModel();
+  const availableModels = useAvailableSuggestionModels();
+  const favorites = useModelFavorites();
   const wsReady = useWebSocketIsReady();
   const isRunning = useIsRunningSuggestion();
+  const { currentDataset } = useDataset();
+  const datasetId = currentDataset?.id;
   const { addToast } = useToast();
+
+  const [policyState, setPolicyState] = useState(() => ({
+    datasetId,
+    status: datasetId != null ? 'loading' : 'idle',
+    policy: null,
+    error: null,
+  }));
+
+  useEffect(() => {
+    let cancelled = false;
+    setPolicyState({
+      datasetId,
+      status: datasetId != null ? 'loading' : 'idle',
+      policy: null,
+      error: null,
+    });
+
+    if (datasetId == null) {
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    getInferenceRoutingPolicy(datasetId)
+      .then((p) => {
+        if (!cancelled) {
+          setPolicyState({ datasetId, status: 'loaded', policy: p || null, error: null });
+        }
+      })
+      .catch((error) => {
+        if (!cancelled) {
+          setPolicyState({
+            datasetId,
+            status: 'error',
+            policy: null,
+            error: getPolicyErrorMessage(error),
+          });
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [datasetId]);
+
+  const policyReady =
+    datasetId != null &&
+    policyState.datasetId === datasetId &&
+    policyState.status === 'loaded';
+  const policyLoading =
+    datasetId != null &&
+    (policyState.datasetId !== datasetId || policyState.status === 'loading');
+  const policyError =
+    policyState.datasetId === datasetId && policyState.status === 'error'
+      ? policyState.error
+      : null;
+  const policy = policyReady ? policyState.policy : null;
 
   const { runSuggestion } = useSuggestionSegmentation(null, (error) =>
     addToast({
@@ -57,23 +132,110 @@ export default function useSuggestSimilar() {
 
   const isHomogeneous = targets.length > 0 && classKeys.size === 1;
   const hasSeeds = contourIds.length === targets.length && contourIds.length > 0;
-  const eligible = isHomogeneous && hasSeeds && !!suggestionModel && wsReady && !isRunning;
+
+  // Determine exemplar shared label if any
+  const sharedLabelId = useMemo(() => {
+    if (!isHomogeneous || targets.length === 0) return null;
+    const first = targets[0];
+    return hasValidLabel(first.label) && first.labelId != null ? Number(first.labelId) : null;
+  }, [isHomogeneous, targets]);
+
+  // Resolve the selected exemplar label. A configured binding is authoritative;
+  // only the absence of a binding permits the personal favorite/first fallback.
+  const routing = useMemo(() => {
+    if (!policyReady || availableModels.length === 0) {
+      return { modelId: null, error: null };
+    }
+
+    const resolved = resolveRoutingBinding(
+      policy,
+      'instance-suggestion',
+      sharedLabelId,
+      availableModels
+    );
+
+    if (resolved?.binding) {
+      if (resolved.isCompatible && !resolved.isStale && resolved.model) {
+        return { modelId: getModelKey(resolved.model), error: null };
+      }
+      return {
+        modelId: null,
+        error: resolved.isStale
+          ? 'The configured suggestion model is no longer available'
+          : 'The configured suggestion model does not support the selected label',
+      };
+    }
+
+    const favoriteKey = favorites?.['instance-suggestion'];
+    const manualSelection = suggestionModel
+      ? availableModels.find((model) =>
+          matchesModelKey(model, 'instance-suggestion', suggestionModel)
+        )
+      : null;
+    const favorite = favoriteKey
+      ? availableModels.find((model) => matchesModelKey(model, 'instance-suggestion', favoriteKey))
+      : null;
+    const compatibleModels = availableModels.filter((model) =>
+      isModelCompatibleWithLabel(model, sharedLabelId)
+    );
+    const fallback =
+      (manualSelection && isModelCompatibleWithLabel(manualSelection, sharedLabelId)
+        ? manualSelection
+        : null) ||
+      (favorite && isModelCompatibleWithLabel(favorite, sharedLabelId) ? favorite : null) ||
+      compatibleModels[0];
+
+    return { modelId: getModelKey(fallback), error: null };
+  }, [policy, policyReady, sharedLabelId, availableModels, favorites, suggestionModel]);
+
+  const resolvedModelId = routing.modelId;
+  const routingError = routing.error;
+
+  const eligible =
+    isHomogeneous &&
+    hasSeeds &&
+    policyReady &&
+    !policyLoading &&
+    !policyError &&
+    !routingError &&
+    !!resolvedModelId &&
+    wsReady &&
+    !isRunning;
 
   const reason = !isHomogeneous
     ? 'Select samples of the same class (or all unlabelled)'
     : !hasSeeds
       ? 'Selected objects are missing contour data'
-      : !suggestionModel
-        ? 'Select an Instance Suggestion model first'
-        : !wsReady
-          ? 'Connection not ready'
-          : null;
+      : !policyReady && policyLoading
+        ? 'Loading model routing policy'
+        : policyError
+          ? `Unable to load model routing policy: ${policyError}`
+          : routingError
+            ? routingError
+            : !resolvedModelId
+              ? 'Select an Instance Suggestion model first'
+              : !wsReady
+                ? 'Connection not ready'
+                : null;
 
   const run = useCallback(async () => {
-    if (!eligible) return;
-    const labelId = targets[0]?.labelId;
-    await runSuggestion(contourIds.length === 1 ? contourIds[0] : contourIds, labelId);
-  }, [eligible, targets, contourIds, runSuggestion]);
+    if (!eligible || !resolvedModelId) return;
+    await runSuggestion(
+      contourIds.length === 1 ? contourIds[0] : contourIds,
+      sharedLabelId,
+      resolvedModelId
+    );
+  }, [eligible, contourIds, sharedLabelId, resolvedModelId, runSuggestion]);
 
-  return { eligible, reason, isRunning, run, seedCount: contourIds.length };
+  return {
+    eligible,
+    reason,
+    isRunning,
+    run,
+    seedCount: contourIds.length,
+    resolvedModelId,
+    policy: policyReady ? policy : null,
+    policyLoading,
+    policyError,
+  };
 }

--- a/src/components/annotationPage/workspace/useSuggestSimilar.test.js
+++ b/src/components/annotationPage/workspace/useSuggestSimilar.test.js
@@ -1,0 +1,236 @@
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import useSuggestSimilar from "./useSuggestSimilar";
+
+const mockState = {
+  objectsList: [],
+  selectedIds: [],
+  suggestionModel: "sam3-default",
+  availableModels: [
+    { id: "sam3-default", name: "SAM 3 Default", task: "instance-suggestion", label_ids: [] },
+    { id: "polyp-specialist", name: "Polyp Specialist", task: "instance-suggestion", label_ids: [2] },
+  ],
+  wsReady: true,
+  isRunning: false,
+  currentDataset: { id: "101" },
+  favorites: {},
+};
+
+const mockRunSuggestion = vi.fn();
+
+vi.mock("../../../stores/selectors/annotationSelectors", () => ({
+  useObjectsList: () => mockState.objectsList,
+  useSelectedObjects: () => mockState.selectedIds,
+  useSuggestionModel: () => mockState.suggestionModel,
+  useAvailableSuggestionModels: () => mockState.availableModels,
+  useModelFavorites: () => mockState.favorites,
+  useWebSocketIsReady: () => mockState.wsReady,
+  useIsRunningSuggestion: () => mockState.isRunning,
+}));
+
+vi.mock("../../../hooks/useSuggestionSegmentation", () => ({
+  useSuggestionSegmentation: () => ({
+    runSuggestion: mockRunSuggestion,
+    isRunning: mockState.isRunning,
+  }),
+}));
+
+vi.mock("../../../contexts/DatasetContext", () => ({
+  useDataset: () => ({ currentDataset: mockState.currentDataset }),
+}));
+
+vi.mock("../../../contexts/ToastContext", () => ({
+  useToast: () => ({ addToast: vi.fn() }),
+}));
+
+vi.mock("../../../api/inference", () => ({
+  getInferenceRoutingPolicy: vi.fn(),
+}));
+
+import { getInferenceRoutingPolicy } from "../../../api/inference";
+
+describe("useSuggestSimilar dynamic exemplar routing", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockState.objectsList = [
+      { id: 1, label: "polyp", labelId: 2, contour_id: 101 },
+      { id: 2, label: "polyp", labelId: 2, contour_id: 102 },
+      { id: 3, label: "coral", labelId: 1, contour_id: 103 },
+      { id: 4, label: "", labelId: null, contour_id: 104 },
+    ];
+    mockState.selectedIds = [1, 2];
+    mockState.suggestionModel = "sam3-default";
+    mockState.wsReady = true;
+    mockState.isRunning = false;
+    mockState.favorites = {};
+  });
+
+  it("resolves label-specific model when selected exemplars share a label", async () => {
+    getInferenceRoutingPolicy.mockResolvedValueOnce({
+      dataset_id: 101,
+      bindings: [
+        {
+          task: "instance-suggestion",
+          label_id: 2,
+          model_registry_key: "polyp-specialist",
+        },
+      ],
+    });
+
+    const { result } = renderHook(() => useSuggestSimilar());
+
+    await waitFor(() => {
+      expect(result.current.eligible).toBe(true);
+      expect(result.current.resolvedModelId).toBe("polyp-specialist");
+    });
+
+    await act(async () => {
+      await result.current.run();
+    });
+
+    expect(mockRunSuggestion).toHaveBeenCalledWith([101, 102], 2, "polyp-specialist");
+  });
+
+  it("uses task default routing when selected exemplars are unlabelled", async () => {
+    mockState.selectedIds = [4];
+
+    getInferenceRoutingPolicy.mockResolvedValueOnce({
+      dataset_id: 101,
+      bindings: [
+        {
+          task: "instance-suggestion",
+          label_id: 2,
+          model_registry_key: "polyp-specialist",
+        },
+        {
+          task: "instance-suggestion",
+          label_id: null,
+          model_registry_key: "sam3-default",
+        },
+      ],
+    });
+
+    const { result } = renderHook(() => useSuggestSimilar());
+
+    await waitFor(() => {
+      expect(result.current.eligible).toBe(true);
+      expect(result.current.resolvedModelId).toBe("sam3-default");
+    });
+
+    await act(async () => {
+      await result.current.run();
+    });
+
+    expect(mockRunSuggestion).toHaveBeenCalledWith(104, null, "sam3-default");
+  });
+
+  it("stays disabled while the dataset policy is loading", async () => {
+    let resolvePolicy;
+    const pendingPolicy = new Promise((resolve) => {
+      resolvePolicy = resolve;
+    });
+    getInferenceRoutingPolicy.mockReturnValueOnce(pendingPolicy);
+
+    const { result } = renderHook(() => useSuggestSimilar());
+
+    expect(result.current.policyLoading).toBe(true);
+    expect(result.current.eligible).toBe(false);
+
+    resolvePolicy(null);
+    await waitFor(() => expect(result.current.policyLoading).toBe(false));
+    expect(result.current.eligible).toBe(true);
+  });
+
+  it("stays disabled and exposes policy failures", async () => {
+    getInferenceRoutingPolicy.mockRejectedValueOnce(new Error("policy unavailable"));
+
+    const { result } = renderHook(() => useSuggestSimilar());
+
+    await waitFor(() => expect(result.current.policyError).toBe("policy unavailable"));
+    expect(result.current.eligible).toBe(false);
+    expect(result.current.reason).toContain("policy unavailable");
+  });
+
+  it("clears the old policy while switching datasets", async () => {
+    getInferenceRoutingPolicy.mockResolvedValueOnce({
+      dataset_id: 101,
+      bindings: [
+        {
+          task: "instance-suggestion",
+          label_id: 2,
+          model_registry_key: "polyp-specialist",
+        },
+      ],
+    });
+
+    const { result, rerender } = renderHook(() => useSuggestSimilar());
+    await waitFor(() => expect(result.current.resolvedModelId).toBe("polyp-specialist"));
+
+    let resolveNewPolicy;
+    const pendingNewPolicy = new Promise((resolve) => {
+      resolveNewPolicy = resolve;
+    });
+    getInferenceRoutingPolicy.mockReturnValueOnce(pendingNewPolicy);
+    mockState.currentDataset = { id: "202" };
+    rerender();
+
+    expect(result.current.policy).toBeNull();
+    expect(result.current.policyLoading).toBe(true);
+    expect(result.current.eligible).toBe(false);
+
+    resolveNewPolicy(null);
+    await waitFor(() => expect(result.current.policyLoading).toBe(false));
+    expect(result.current.resolvedModelId).toBe("sam3-default");
+  });
+
+  it("uses the personal favorite after a routed label becomes unrouted", async () => {
+    mockState.favorites = { "instance-suggestion": "sam3-default" };
+    getInferenceRoutingPolicy.mockResolvedValueOnce({
+      dataset_id: 101,
+      bindings: [
+        {
+          task: "instance-suggestion",
+          label_id: 2,
+          model_registry_key: "polyp-specialist",
+        },
+      ],
+    });
+
+    const { result, rerender } = renderHook(() => useSuggestSimilar());
+    await waitFor(() => expect(result.current.resolvedModelId).toBe("polyp-specialist"));
+
+    mockState.selectedIds = [3];
+    rerender();
+
+    await waitFor(() => expect(result.current.resolvedModelId).toBe("sam3-default"));
+    expect(result.current.eligible).toBe(true);
+  });
+
+  it("preserves a compatible manual selection when no route exists", async () => {
+    mockState.suggestionModel = "polyp-specialist";
+    getInferenceRoutingPolicy.mockResolvedValueOnce(null);
+
+    const { result } = renderHook(() => useSuggestSimilar());
+
+    await waitFor(() => expect(result.current.resolvedModelId).toBe("polyp-specialist"));
+  });
+
+  it("does not fall back when an explicit route is stale", async () => {
+    getInferenceRoutingPolicy.mockResolvedValueOnce({
+      dataset_id: 101,
+      bindings: [
+        {
+          task: "instance-suggestion",
+          label_id: 2,
+          model_registry_key: "retired-specialist",
+        },
+      ],
+    });
+
+    const { result } = renderHook(() => useSuggestSimilar());
+
+    await waitFor(() => expect(result.current.reason).toContain("no longer available"));
+    expect(result.current.resolvedModelId).toBeNull();
+    expect(result.current.eligible).toBe(false);
+  });
+});

--- a/src/components/datasets/DatasetGallery.jsx
+++ b/src/components/datasets/DatasetGallery.jsx
@@ -140,6 +140,10 @@ const DatasetGallery = () => {
     navigate(`/dataset/${datasetId}/training`);
   };
 
+  const handleModelOrchestrationClick = () => {
+    navigate(`/dataset/${datasetId}/model-orchestration`);
+  };
+
   const handleBatchInferenceClick = () => {
     navigate(`/dataset/${datasetId}/inference`);
   };
@@ -173,6 +177,7 @@ const DatasetGallery = () => {
             onLabelManagementClick={handleLabelManagementClick}
             onExportCocoClick={() => setShowCocoModal(true)}
             onModelTrainingClick={handleModelTrainingClick}
+            onModelOrchestrationClick={handleModelOrchestrationClick}
             onBatchInferenceClick={handleBatchInferenceClick}
             onBrowseAnnotations={handleBrowseAnnotations}
             onManageAccessClick={handleManageAccessClick}

--- a/src/components/datasets/gallery/ManagementCardsView.jsx
+++ b/src/components/datasets/gallery/ManagementCardsView.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Database, Brain, BarChart3, Tag, SquarePen, Download, Eye, GraduationCap, Users2, ClipboardCheck, Ruler, Wrench, Settings, HelpCircle, Wand2 } from 'lucide-react';
+import { Database, Brain, BarChart3, Tag, SquarePen, Download, Eye, GraduationCap, Users2, ClipboardCheck, Ruler, Wrench, Settings, HelpCircle, Wand2, Cpu } from 'lucide-react';
 import ManagementCard from './ManagementCard';
 import PhaseProgressBar from '../PhaseProgressBar';
 import RoleBadge from '../RoleBadge';
@@ -37,6 +37,7 @@ const ManagementCardsView = ({
   onLabelManagementClick,
   onExportCocoClick,
   onModelTrainingClick,
+  onModelOrchestrationClick,
   onBatchInferenceClick,
   onBrowseAnnotations,
   onManageAccessClick,
@@ -245,6 +246,16 @@ const ManagementCardsView = ({
       onClick: onModelZooClick,
       permitted: canAny([Permission.AI_INTERACTIVE, Permission.AI_BATCH_INFER]),
       color: 'purple',
+    },
+    {
+      id: 'model-orchestration',
+      group: 'models',
+      icon: Cpu,
+      title: 'Model Orchestration',
+      description: 'Configure default models and per-label routing policies for interactive tools, cross-image suggestions, and batch runs',
+      onClick: onModelOrchestrationClick,
+      permitted: canAny([Permission.AI_INTERACTIVE, Permission.AI_BATCH_INFER]),
+      color: 'indigo',
     },
     {
       id: 'model-training',

--- a/src/components/datasets/gallery/ManagementCardsView.test.jsx
+++ b/src/components/datasets/gallery/ManagementCardsView.test.jsx
@@ -1,0 +1,83 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { vi, describe, it, expect } from "vitest";
+import ManagementCardsView from "./ManagementCardsView";
+import { Permission } from "../../../utils/permissions";
+
+const mockUsePermissions = vi.fn();
+vi.mock("../../../hooks/usePermissions", () => ({
+    usePermissions: (dataset) => mockUsePermissions(dataset),
+}));
+
+vi.mock("../../../stores/selectors", () => ({
+    useGalleryStats: () => ({
+        total: 10,
+        overall: { finished: 5, in_progress: 2, not_started: 3 },
+    }),
+}));
+
+vi.mock("../../../api/reviews", () => ({
+    fetchReviewSummary: vi.fn().mockResolvedValue({ success: true, summary: { pending_instances: 0, reviewed_instances: 0 } }),
+    fetchCorrectionSummary: vi.fn().mockResolvedValue({ success: true, summary: { open_rejections: 0 } }),
+}));
+
+describe("ManagementCardsView - Model Orchestration card", () => {
+    const dataset = { id: 101, name: "Test Dataset" };
+
+    it("renders Model Orchestration card when user has AI_BATCH_INFER permission and triggers click", () => {
+        mockUsePermissions.mockReturnValue({
+            can: (perm) => perm === Permission.AI_BATCH_INFER,
+            canAny: (perms) => perms.includes(Permission.AI_BATCH_INFER),
+            role: "owner",
+        });
+
+        const onModelOrchestrationClick = vi.fn();
+
+        render(
+            <ManagementCardsView
+                dataset={dataset}
+                onModelOrchestrationClick={onModelOrchestrationClick}
+            />
+        );
+
+        const cardTitle = screen.getByText("Model Orchestration");
+        expect(cardTitle).toBeInTheDocument();
+
+        fireEvent.click(cardTitle);
+        expect(onModelOrchestrationClick).toHaveBeenCalledTimes(1);
+    });
+
+    it("renders Model Orchestration card when user has AI_INTERACTIVE permission", () => {
+        mockUsePermissions.mockReturnValue({
+            can: (perm) => perm === Permission.AI_INTERACTIVE,
+            canAny: (perms) => perms.includes(Permission.AI_INTERACTIVE),
+            role: "annotator",
+        });
+
+        render(
+            <ManagementCardsView
+                dataset={dataset}
+                onModelOrchestrationClick={vi.fn()}
+            />
+        );
+
+        expect(screen.getByText("Model Orchestration")).toBeInTheDocument();
+    });
+
+    it("does not render Model Orchestration card when user lacks AI permissions", () => {
+        mockUsePermissions.mockReturnValue({
+            can: () => false,
+            canAny: () => false,
+            role: "viewer",
+        });
+
+        render(
+            <ManagementCardsView
+                dataset={dataset}
+                onModelOrchestrationClick={vi.fn()}
+            />
+        );
+
+        expect(screen.queryByText("Model Orchestration")).not.toBeInTheDocument();
+    });
+});

--- a/src/components/inference/InferenceProgressPanel.jsx
+++ b/src/components/inference/InferenceProgressPanel.jsx
@@ -7,6 +7,7 @@ import {
     Cpu,
     Layers,
     Loader2,
+    RotateCcw,
     Scissors,
     StopCircle,
     Trash2,
@@ -58,7 +59,13 @@ function Stat({ icon: Icon, value, label, tone = "text-t1" }) {
  * actually being respected — level 2 stays empty until level 1 is full.
  */
 export default function InferenceProgressPanel({
-    job, onCancel, isCancelling, onReview, onDelete, onOpenImage,
+    job,
+    onCancel,
+    isCancelling,
+    onReview,
+    onDelete,
+    onOpenImage,
+    onLoadIntoPlanner,
 }) {
     const [failedItems, setFailedItems] = useState([]);
 
@@ -239,7 +246,7 @@ export default function InferenceProgressPanel({
                 {isActive && (
                     <button
                         onClick={onCancel}
-                        disabled={isCancelling || job.status === "cancelling"}
+                        disabled={isCancelling}
                         className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-onAccent bg-err rounded-lg hover:brightness-110 disabled:opacity-60"
                     >
                         {isCancelling ? (
@@ -247,7 +254,7 @@ export default function InferenceProgressPanel({
                         ) : (
                             <StopCircle className="w-4 h-4" />
                         )}
-                        {job.status === "cancelling" ? "Stopping after this image…" : "Stop run"}
+                        {job.status === "cancelling" ? "Force stop" : "Stop run"}
                     </button>
                 )}
                 {!isActive && job.contours_created > 0 && (
@@ -257,6 +264,17 @@ export default function InferenceProgressPanel({
                     >
                         <ClipboardCheck className="w-4 h-4" />
                         Review the predictions
+                    </button>
+                )}
+                {!isActive && onLoadIntoPlanner && (
+                    <button
+                        type="button"
+                        onClick={() => onLoadIntoPlanner(job)}
+                        className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-t1 bg-p1 border border-ln rounded-lg hover:bg-hv transition-colors"
+                        title="Load this run's configuration steps and options into the plan editor"
+                    >
+                        <RotateCcw className="w-4 h-4" />
+                        Load into Planner
                     </button>
                 )}
                 {/* Always reachable except while a worker is mid-image: a run that failed to

--- a/src/components/inference/InferenceProgressPanel.test.jsx
+++ b/src/components/inference/InferenceProgressPanel.test.jsx
@@ -1,0 +1,113 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { vi, describe, it, expect } from "vitest";
+import InferenceProgressPanel from "./InferenceProgressPanel";
+
+vi.mock("../../api/inference", () => ({
+    getInferenceJobItems: vi.fn().mockResolvedValue([]),
+}));
+
+describe("InferenceProgressPanel Load into Planner action", () => {
+    const baseJob = {
+        id: 101,
+        dataset_id: 1,
+        name: "test_run",
+        total_units: 10,
+        done_units: 10,
+        failed_units: 0,
+        contours_created: 5,
+        status: "succeeded",
+        plan_steps: [{ label_id: 1, model_registry_key: "m2f" }],
+        options: {},
+    };
+
+    it("renders 'Load into Planner' button for terminal statuses and calls onLoadIntoPlanner", () => {
+        const terminalStatuses = ["succeeded", "partial", "failed", "cancelled"];
+
+        terminalStatuses.forEach((status) => {
+            const onLoadIntoPlanner = vi.fn();
+            const job = { ...baseJob, status };
+            const { unmount } = render(
+                <InferenceProgressPanel
+                    job={job}
+                    onLoadIntoPlanner={onLoadIntoPlanner}
+                />
+            );
+
+            const loadButton = screen.getByRole("button", { name: /load into planner/i });
+            expect(loadButton).toBeInTheDocument();
+
+            fireEvent.click(loadButton);
+            expect(onLoadIntoPlanner).toHaveBeenCalledWith(job);
+
+            unmount();
+        });
+    });
+
+    it("does NOT render 'Load into Planner' button for active in-flight statuses", () => {
+        const activeStatuses = ["pending", "running", "cancelling"];
+
+        activeStatuses.forEach((status) => {
+            const onLoadIntoPlanner = vi.fn();
+            const job = { ...baseJob, status };
+            const { unmount } = render(
+                <InferenceProgressPanel
+                    job={job}
+                    onLoadIntoPlanner={onLoadIntoPlanner}
+                />
+            );
+
+            expect(screen.queryByRole("button", { name: /load into planner/i })).not.toBeInTheDocument();
+
+            unmount();
+        });
+    });
+
+    it("allows force stop while a run is cancelling", () => {
+        const onCancel = vi.fn();
+        const job = { ...baseJob, status: "cancelling" };
+        render(
+            <InferenceProgressPanel
+                job={job}
+                onCancel={onCancel}
+                isCancelling={false}
+            />
+        );
+
+        const stopButton = screen.getByRole("button", { name: /force stop/i });
+        expect(stopButton).toBeInTheDocument();
+        expect(stopButton).not.toBeDisabled();
+        fireEvent.click(stopButton);
+        expect(onCancel).toHaveBeenCalledTimes(1);
+    });
+
+    it("renders 'Remove from history' for non-running statuses and hides it while running", () => {
+        const allowedStatuses = ["pending", "cancelling", "succeeded", "partial", "failed", "cancelled"];
+        allowedStatuses.forEach((status) => {
+            const onDelete = vi.fn();
+            const job = { ...baseJob, status };
+            const { unmount } = render(
+                <InferenceProgressPanel
+                    job={job}
+                    onDelete={onDelete}
+                />
+            );
+
+            const deleteButton = screen.getByRole("button", { name: /remove from history/i });
+            expect(deleteButton).toBeInTheDocument();
+            fireEvent.click(deleteButton);
+            expect(onDelete).toHaveBeenCalled();
+            unmount();
+        });
+
+        // Running status blocks deletion
+        const { unmount } = render(
+            <InferenceProgressPanel
+                job={{ ...baseJob, status: "running" }}
+                onDelete={vi.fn()}
+            />
+        );
+        expect(screen.queryByRole("button", { name: /remove from history/i })).not.toBeInTheDocument();
+        unmount();
+    });
+});

--- a/src/components/inference/LabelModelPlanner.jsx
+++ b/src/components/inference/LabelModelPlanner.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { ChevronRight, Cpu, Sparkles, Star, Layers } from "lucide-react";
 import DynamicHyperParameter from "../datasets/training/DynamicHyperParameter";
+import { BATCH_INFERENCE_TASKS } from "../../constants/tasks";
 import {
     getEffectiveContract,
     initStep,
@@ -56,10 +57,12 @@ export const groupLabelsByLevel = (labelsById) => {
         }));
 };
 
-/** Models that may be bound to a label: class-agnostic ones, plus those predicting it. */
-export const modelsForLabel = (models, labelId) =>
+/** Models that may be bound to a label: class-agnostic ones, plus those predicting it, filtered to allowed tasks. */
+export const modelsForLabel = (models, labelId, allowedTasks = BATCH_INFERENCE_TASKS) =>
     (models || []).filter(
-        (model) => !model.label_ids || model.label_ids.length === 0 || model.label_ids.includes(labelId)
+        (model) =>
+            (!allowedTasks || allowedTasks.includes(model.task)) &&
+            (!model.label_ids || model.label_ids.length === 0 || model.label_ids.includes(labelId))
     );
 
 function ModelRow({ label, step, models, strategies, onChange }) {
@@ -297,9 +300,19 @@ function ModelRow({ label, step, models, strategies, onChange }) {
     );
 }
 
-export default function LabelModelPlanner({ labelsById, models, strategies, steps, onChange }) {
+export default function LabelModelPlanner({
+    labelsById,
+    models,
+    strategies,
+    steps,
+    onChange,
+    allowedTasks = BATCH_INFERENCE_TASKS,
+}) {
     const levels = groupLabelsByLevel(labelsById);
     const stepByLabel = new Map(steps.map((step) => [step.label_id, step]));
+    const batchModels = React.useMemo(() => {
+        return (models || []).filter((m) => !allowedTasks || allowedTasks.includes(m.task));
+    }, [models, allowedTasks]);
 
     if (levels.length === 0) {
         return (
@@ -329,7 +342,7 @@ export default function LabelModelPlanner({ labelsById, models, strategies, step
                                 key={label.id}
                                 label={label}
                                 step={stepByLabel.get(label.id) || null}
-                                models={models}
+                                models={batchModels}
                                 strategies={strategies}
                                 onChange={onChange}
                             />
@@ -345,7 +358,7 @@ export default function LabelModelPlanner({ labelsById, models, strategies, step
                 whichever label it is bound to, so mixing specialists and multiclass models in
                 one run is fine.
             </p>
-            {models.some(
+            {batchModels.some(
                 (model) =>
                     model.input_contract?.conditioning?.kind === "reference_images" ||
                     model.input_contract?.conditioning?.kind === "instances" ||

--- a/src/components/inference/LabelModelPlanner.test.jsx
+++ b/src/components/inference/LabelModelPlanner.test.jsx
@@ -340,6 +340,7 @@ describe("LabelModelPlanner", () => {
         strategies={strategies}
         steps={[step]}
         onChange={jest.fn()}
+        allowedTasks={["instance-suggestion"]}
       />
     );
 
@@ -538,5 +539,52 @@ describe("LabelModelPlanner", () => {
         }),
       })
     );
+  });
+
+  it("excludes interactive models from the batch planner dropdown", () => {
+    const mixedModels = [
+      {
+        registry_key: "sam2-prompted",
+        name: "SAM 2 Prompted",
+        task: "prompted-segmentation",
+        label_ids: [],
+      },
+      {
+        registry_key: "sam3-intra",
+        name: "SAM 3 Intra",
+        task: "instance-suggestion",
+        label_ids: [],
+      },
+      {
+        registry_key: "m2f-batch",
+        name: "Mask2Former Batch",
+        task: "instance-segmentation",
+        label_ids: [],
+      },
+      {
+        registry_key: "sam3-cross",
+        name: "SAM 3 Cross Exemplar",
+        task: "cross-image-suggestion",
+        label_ids: [],
+      },
+    ];
+
+    render(
+      <LabelModelPlanner
+        labelsById={labelsById}
+        models={mixedModels}
+        strategies={strategies}
+        steps={[]}
+        onChange={jest.fn()}
+      />
+    );
+
+    const cellSelect = screen.getByLabelText("Model for cell");
+    const optionTexts = Array.from(cellSelect.options).map((opt) => opt.textContent);
+
+    expect(optionTexts).toContain("Mask2Former Batch");
+    expect(optionTexts.some((t) => t.includes("SAM 3 Cross Exemplar"))).toBe(true);
+    expect(optionTexts).not.toContain("SAM 2 Prompted");
+    expect(optionTexts).not.toContain("SAM 3 Intra");
   });
 });

--- a/src/components/inference/ModelOrchestrationPanel.jsx
+++ b/src/components/inference/ModelOrchestrationPanel.jsx
@@ -1,0 +1,638 @@
+import React, { useState, useEffect, useMemo } from "react";
+import {
+    Cpu,
+    Sparkles,
+    Star,
+    Layers,
+    Save,
+    RotateCcw,
+    Trash2,
+    AlertTriangle,
+    CheckCircle2,
+    ChevronDown,
+    ChevronRight,
+    ArrowRight,
+    Info,
+} from "lucide-react";
+import {
+    TASK_ORDER,
+    TASKS,
+    getTaskMeta,
+    BATCH_INFERENCE_TASKS,
+} from "../../constants/tasks";
+import DynamicHyperParameter from "../datasets/training/DynamicHyperParameter";
+import {
+    getEffectiveContract,
+    getDefaultConditioning,
+    getDefaultParameters,
+} from "./plannerContractUtils";
+import { groupLabelsByLevel } from "./LabelModelPlanner";
+
+const NONE_VALUE = "__NONE__";
+
+/**
+ * Finds models compatible with a specific task and optional label.
+ * For task default (labelId == null): all models for this task (class-agnostic or class-aware).
+ * For label override: class-agnostic models OR models predicting that specific label.
+ */
+export const modelsForTaskAndLabel = (models, task, labelId = null) => {
+    return (models || []).filter((m) => {
+        if (m.task !== task) return false;
+        if (labelId == null) {
+            // Task default allows any model for this task
+            return true;
+        }
+        return (
+            !m.label_ids ||
+            m.label_ids.length === 0 ||
+            m.label_ids.includes(Number(labelId))
+        );
+    });
+};
+
+/**
+ * Format model display name with badges.
+ */
+function ModelOptionLabel({ model }) {
+    return (
+        <span>
+            {model.name || model.registry_key}
+            {model.trained_on_dataset && " ★"}
+            {model.provenance === "declared" && " (Declared)"}
+        </span>
+    );
+}
+
+/**
+ * Single binding editor row (for either a task default or a label override).
+ */
+function BindingRow({
+    task,
+    label = null, // null for task default, or label object
+    binding,
+    models,
+    strategies,
+    onChange,
+    disabled = false,
+}) {
+    const taskModels = useMemo(
+        () => modelsForTaskAndLabel(models, task, label?.id ?? null),
+        [models, task, label]
+    );
+
+    const selectedModelKey = binding?.model_registry_key || NONE_VALUE;
+    const selectedModel = models.find(
+        (m) => m.task === task && m.registry_key === binding?.model_registry_key
+    );
+
+    const isStale = Boolean(
+        binding?.model_registry_key && !selectedModel
+    );
+
+    const contract = selectedModel ? getEffectiveContract(selectedModel) : null;
+    const condSpec = contract?.conditioning;
+    const parameters = contract?.parameters || [];
+
+    const handleModelChange = (e) => {
+        const value = e.target.value;
+        if (value === NONE_VALUE) {
+            onChange(null);
+            return;
+        }
+        const model = models.find((m) => m.task === task && m.registry_key === value);
+        if (!model) {
+            onChange(null);
+            return;
+        }
+
+        const effectiveContract = getEffectiveContract(model);
+        const defaultCond = getDefaultConditioning(effectiveContract, strategies, label);
+        const defaultParams = getDefaultParameters(effectiveContract);
+
+        onChange({
+            task,
+            label_id: label?.id ?? null,
+            model_registry_key: model.registry_key,
+            inputs: {
+                conditioning: defaultCond,
+                parameters: defaultParams,
+            },
+        });
+    };
+
+    const handleParamChange = (key, val) => {
+        if (!binding) return;
+        const currentInputs = binding.inputs || { conditioning: {}, parameters: {} };
+        const currentParams = currentInputs.parameters || {};
+        onChange({
+            ...binding,
+            inputs: {
+                ...currentInputs,
+                parameters: {
+                    ...currentParams,
+                    [key]: val,
+                },
+            },
+        });
+    };
+
+    const handleCondChange = (key, val) => {
+        if (!binding) return;
+        const currentInputs = binding.inputs || { conditioning: {}, parameters: {} };
+        const currentCond = currentInputs.conditioning || {};
+        onChange({
+            ...binding,
+            inputs: {
+                ...currentInputs,
+                conditioning: {
+                    ...currentCond,
+                    [key]: val,
+                },
+            },
+        });
+    };
+
+    const countUnitLabel =
+        condSpec?.unit === "image"
+            ? "Images"
+            : condSpec?.unit === "instance"
+            ? "Instances"
+            : condSpec?.unit === "vector"
+            ? "Vectors"
+            : "Count";
+
+    return (
+        <div
+            className={`border rounded-xl p-3 transition-colors ${
+                isStale
+                    ? "border-amber-400 bg-amber-50/50 dark:bg-amber-950/20"
+                    : binding
+                    ? "border-ln bg-p1"
+                    : "border-dashed border-ln bg-well"
+            }`}
+        >
+            <div className="flex flex-wrap items-center justify-between gap-3">
+                <div className="min-w-0 flex-1 flex items-center gap-2">
+                    {label ? (
+                        <div className="flex items-center gap-1.5 font-medium text-sm text-t1">
+                            <span className="w-2.5 h-2.5 rounded-full bg-ac" />
+                            <span>{label.name}</span>
+                            {label.parentName && (
+                                <span className="text-xs text-t3 font-normal">
+                                    (child of {label.parentName})
+                                </span>
+                            )}
+                        </div>
+                    ) : (
+                        <div className="flex items-center gap-1.5 font-medium text-sm text-t1">
+                            <Star size={14} className="text-amber-500 fill-amber-500" />
+                            <span>Task Default Model</span>
+                            <span className="text-xs text-t3 font-normal">
+                                (used when no label override is specified)
+                            </span>
+                        </div>
+                    )}
+                </div>
+
+                <div className="flex items-center gap-2">
+                    <select
+                        value={selectedModelKey}
+                        onChange={handleModelChange}
+                        disabled={disabled}
+                        className={`text-xs px-2.5 py-1.5 rounded-lg border bg-bg text-t1 font-medium focus:outline-none focus:ring-1 focus:ring-ac transition ${
+                            isStale ? "border-amber-400 text-amber-700 dark:text-amber-300" : "border-ln"
+                        }`}
+                        aria-label={label ? `Model for ${label.name} (${task})` : `Default model for ${task}`}
+                    >
+                        <option value={NONE_VALUE}>
+                            {label ? "(Inherit task default / None)" : "(No task default)"}
+                        </option>
+                        {isStale && (
+                            <option value={binding.model_registry_key} disabled>
+                                ⚠ {binding.model_registry_key} (Unavailable)
+                            </option>
+                        )}
+                        {taskModels.map((m) => (
+                            <option key={m.registry_key} value={m.registry_key}>
+                                {m.name || m.registry_key}
+                                {m.trained_on_dataset ? " ★" : ""}
+                                {!label && m.label_ids && m.label_ids.length > 0 ? " (Class-specific)" : ""}
+                            </option>
+                        ))}
+                    </select>
+                </div>
+            </div>
+
+            {!label && selectedModel?.label_ids && selectedModel.label_ids.length > 0 && (
+                <div className="mt-2 text-xs text-blue-700 dark:text-blue-300 flex items-center gap-1.5 bg-blue-50/60 dark:bg-blue-950/20 p-2 rounded-lg">
+                    <Info size={13} className="shrink-0" />
+                    <span>
+                        This default model predicts specific classes ({selectedModel.label_ids.length} class{selectedModel.label_ids.length > 1 ? "es" : ""}). It will only apply as a default to those classes.
+                    </span>
+                </div>
+            )}
+
+            {isStale && (
+                <div className="mt-2 text-xs text-amber-700 dark:text-amber-300 flex items-center gap-1.5">
+                    <AlertTriangle size={13} className="shrink-0" />
+                    <span>
+                        The previously saved model <code>{binding.model_registry_key}</code> is currently unavailable or unregistered. Select an active model or clear this binding to repair.
+                    </span>
+                </div>
+            )}
+
+            {/* Model contract inputs (parameters & conditioning) */}
+            {selectedModel && (parameters.length > 0 || condSpec?.kind === "concept_text" || condSpec?.user_selectable_count) && (
+                <div className="mt-3 pt-2.5 border-t border-ln grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-3">
+                    {/* Conditioning: concept text */}
+                    {condSpec?.kind === "concept_text" && (
+                        <div className="flex flex-col gap-1">
+                            <label className="text-[11px] font-medium text-t2">
+                                Prompt Concept
+                            </label>
+                            <input
+                                type="text"
+                                value={binding?.inputs?.conditioning?.concept_text || ""}
+                                onChange={(e) => handleCondChange("concept_text", e.target.value)}
+                                disabled={disabled}
+                                placeholder={label?.name || "e.g. object"}
+                                className="text-xs px-2 py-1 rounded border border-ln bg-bg text-t1 focus:ring-1 focus:ring-ac"
+                            />
+                        </div>
+                    )}
+
+                    {/* Conditioning: Exemplar count */}
+                    {condSpec?.user_selectable_count && (
+                        <div className="flex flex-col gap-1">
+                            <label className="text-[11px] font-medium text-t2">
+                                {countUnitLabel} count
+                            </label>
+                            <input
+                                type="number"
+                                min={condSpec.min_units || 1}
+                                max={condSpec.max_units || 32}
+                                value={binding?.inputs?.conditioning?.count ?? condSpec.default_count ?? 5}
+                                onChange={(e) => handleCondChange("count", Number(e.target.value))}
+                                disabled={disabled}
+                                className="text-xs px-2 py-1 rounded border border-ln bg-bg text-t1 w-24 focus:ring-1 focus:ring-ac"
+                            />
+                        </div>
+                    )}
+
+                    {/* Hyperparameters */}
+                    {parameters.map((param) => (
+                        <div key={param.key} className="flex flex-col gap-1">
+                            <label className="text-[11px] font-medium text-t2">
+                                {param.label || param.key}
+                            </label>
+                            <DynamicHyperParameter
+                                param={param}
+                                value={binding?.inputs?.parameters?.[param.key] ?? param.default_value}
+                                onChange={(val) => handleParamChange(param.key, val)}
+                                disabled={disabled}
+                            />
+                        </div>
+                    ))}
+                </div>
+            )}
+        </div>
+    );
+}
+
+/**
+ * Task section containing the task default and hierarchy label overrides.
+ */
+function TaskSection({
+    task,
+    policyBindings,
+    labelsById,
+    models,
+    strategies,
+    onUpdateBinding,
+    disabled = false,
+}) {
+    const meta = getTaskMeta(task);
+    const [isExpanded, setIsExpanded] = useState(false);
+
+    const levels = useMemo(() => groupLabelsByLevel(labelsById), [labelsById]);
+
+    const defaultBinding = useMemo(
+        () => policyBindings.find((b) => b.task === task && (b.label_id == null || b.label_id === undefined)),
+        [policyBindings, task]
+    );
+
+    const overridesByLabelId = useMemo(() => {
+        const map = new Map();
+        policyBindings.forEach((b) => {
+            if (b.task === task && b.label_id != null) {
+                map.set(Number(b.label_id), b);
+            }
+        });
+        return map;
+    }, [policyBindings, task]);
+
+    const activeCount = (defaultBinding ? 1 : 0) + overridesByLabelId.size;
+
+    return (
+        <div className="border border-ln rounded-2xl bg-p1 overflow-hidden shadow-xs">
+            <button
+                type="button"
+                onClick={() => setIsExpanded(!isExpanded)}
+                className="w-full flex items-center justify-between p-4 bg-p1 hover:bg-hv transition-colors text-left"
+                aria-expanded={isExpanded}
+            >
+                <div className="flex items-center gap-3">
+                    <span className={`px-2.5 py-1 rounded-full text-xs font-semibold ${meta.chip}`}>
+                        {meta.label}
+                    </span>
+                    <span className="text-xs text-t3 hidden sm:inline">
+                        {meta.description}
+                    </span>
+                </div>
+                <div className="flex items-center gap-3">
+                    <span className="text-xs text-t2 font-medium bg-well px-2 py-0.5 rounded-md">
+                        {activeCount === 0 ? "Not configured" : `${activeCount} route${activeCount > 1 ? "s" : ""}`}
+                    </span>
+                    {isExpanded ? <ChevronDown size={16} className="text-t3" /> : <ChevronRight size={16} className="text-t3" />}
+                </div>
+            </button>
+
+            {isExpanded && (
+                <div className="p-4 space-y-4 border-t border-ln">
+                    {/* 1. Task Default Row */}
+                    <div>
+                        <div className="text-xs font-semibold text-t2 uppercase tracking-wide mb-2">
+                            Default Routing
+                        </div>
+                        <BindingRow
+                            task={task}
+                            label={null}
+                            binding={defaultBinding}
+                            models={models}
+                            strategies={strategies}
+                            onChange={(newBinding) => onUpdateBinding(task, null, newBinding)}
+                            disabled={disabled}
+                        />
+                    </div>
+
+                    {/* 2. Hierarchy Label Overrides */}
+                    {levels.length > 0 && (
+                        <div className="space-y-3 pt-2">
+                            <div className="text-xs font-semibold text-t2 uppercase tracking-wide">
+                                Label Overrides
+                            </div>
+                            {levels.map(({ level, labels }) => (
+                                <div key={level} className="space-y-2">
+                                    <div className="text-[11px] font-medium text-t3 flex items-center gap-1.5">
+                                        <Layers size={12} />
+                                        <span>Level {level + 1}</span>
+                                    </div>
+                                    <div className="space-y-2 pl-2">
+                                        {labels.map((label) => (
+                                            <BindingRow
+                                                key={label.id}
+                                                task={task}
+                                                label={label}
+                                                binding={overridesByLabelId.get(label.id)}
+                                                models={models}
+                                                strategies={strategies}
+                                                onChange={(newBinding) => onUpdateBinding(task, label.id, newBinding)}
+                                                disabled={disabled}
+                                            />
+                                        ))}
+                                    </div>
+                                </div>
+                            ))}
+                        </div>
+                    )}
+                </div>
+            )}
+        </div>
+    );
+}
+
+/**
+ * Complete Dataset Model Orchestration Policy Editor.
+ */
+export default function ModelOrchestrationPanel({
+    datasetId,
+    policy,
+    labelsById,
+    catalog,
+    onSavePolicy,
+    onDeletePolicy,
+    isSaving = false,
+    isDeleting = false,
+    canEdit = true,
+    onApplyToBatch = null,
+}) {
+    const models = catalog?.models || [];
+    const strategies = catalog?.retrieval_strategies || [];
+
+    // Local draft bindings state initialized from loaded policy
+    const [draftBindings, setDraftBindings] = useState([]);
+    const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
+    const [statusMessage, setStatusMessage] = useState(null);
+
+    // Sync draft bindings when policy changes (e.g. initial load or dataset switch)
+    useEffect(() => {
+        const initial = policy?.bindings ? JSON.parse(JSON.stringify(policy.bindings)) : [];
+        setDraftBindings(initial);
+        setHasUnsavedChanges(false);
+    }, [policy, datasetId]);
+
+    const handleUpdateBinding = (task, labelId, newBinding) => {
+        setDraftBindings((prev) => {
+            // Remove existing binding for (task, labelId)
+            const filtered = prev.filter(
+                (b) => !(b.task === task && (labelId == null ? b.label_id == null : Number(b.label_id) === Number(labelId)))
+            );
+            if (newBinding) {
+                filtered.push(newBinding);
+            }
+            return filtered;
+        });
+        setHasUnsavedChanges(true);
+        setStatusMessage(null);
+    };
+
+    const handleSave = async () => {
+        if (!canEdit || isSaving) return;
+        setStatusMessage(null);
+        try {
+            await onSavePolicy(draftBindings);
+            setHasUnsavedChanges(false);
+            setStatusMessage({ type: "success", text: "Routing policy saved successfully." });
+        } catch (err) {
+            setStatusMessage({ type: "error", text: err.message || "Failed to save routing policy." });
+        }
+    };
+
+    const handleReset = () => {
+        const initial = policy?.bindings ? JSON.parse(JSON.stringify(policy.bindings)) : [];
+        setDraftBindings(initial);
+        setHasUnsavedChanges(false);
+        setStatusMessage(null);
+    };
+
+    const handleClearAll = async () => {
+        if (!canEdit || isDeleting) return;
+        if (!window.confirm("Are you sure you want to clear all model routing bindings for this dataset?")) {
+            return;
+        }
+        try {
+            await onDeletePolicy();
+            setDraftBindings([]);
+            setHasUnsavedChanges(false);
+            setStatusMessage({ type: "success", text: "Routing policy cleared." });
+        } catch (err) {
+            setStatusMessage({ type: "error", text: err.message || "Failed to clear routing policy." });
+        }
+    };
+
+    // Calculate batch-supported bindings available for pre-filling batch planner
+    const batchEligibleCount = useMemo(() => {
+        return draftBindings.filter((b) => BATCH_INFERENCE_TASKS.includes(b.task)).length;
+    }, [draftBindings]);
+
+    const hasInstanceRoutes = useMemo(() => {
+        return draftBindings.some((b) => b.task === "instance-segmentation");
+    }, [draftBindings]);
+
+    const hasCrossImageRoutes = useMemo(() => {
+        return draftBindings.some((b) => b.task === "cross-image-suggestion");
+    }, [draftBindings]);
+
+    return (
+        <div className="space-y-6">
+            {/* Header & Description */}
+            <div className="flex flex-wrap items-start justify-between gap-4">
+                <div>
+                    <h2 className="text-lg font-semibold text-t1 flex items-center gap-2">
+                        <Cpu size={20} className="text-ac" />
+                        Dataset Model Routing
+                    </h2>
+                    <p className="text-xs text-t3 mt-1 max-w-2xl">
+                        Define which AI model annotates each task and label in this dataset. Settings configured here serve as the canonical defaults for interactive canvas tools and full-dataset batch runs.
+                    </p>
+                </div>
+
+                {policy?.updated_at && (
+                    <div className="text-[11px] text-t3 text-right">
+                        <span>Last updated by <strong className="text-t2">{policy.updated_by || "system"}</strong></span>
+                        <br />
+                        <span>{new Date(policy.updated_at).toLocaleString()}</span>
+                    </div>
+                )}
+            </div>
+
+            {/* Status alert */}
+            {statusMessage && (
+                <div
+                    className={`p-3 rounded-xl text-xs flex items-center gap-2 ${
+                        statusMessage.type === "success"
+                            ? "bg-emerald-50 text-emerald-800 border border-emerald-200 dark:bg-emerald-950/30 dark:text-emerald-300 dark:border-emerald-800"
+                            : "bg-red-50 text-red-800 border border-red-200 dark:bg-red-950/30 dark:text-red-300 dark:border-red-800"
+                    }`}
+                >
+                    {statusMessage.type === "success" ? <CheckCircle2 size={15} /> : <AlertTriangle size={15} />}
+                    <span>{statusMessage.text}</span>
+                </div>
+            )}
+
+            {/* Canonical Task Sections */}
+            <div className="space-y-4">
+                {TASK_ORDER.map((task) => (
+                    <TaskSection
+                        key={task}
+                        task={task}
+                        policyBindings={draftBindings}
+                        labelsById={labelsById}
+                        models={models}
+                        strategies={strategies}
+                        onUpdateBinding={handleUpdateBinding}
+                        disabled={!canEdit || isSaving || isDeleting}
+                    />
+                ))}
+            </div>
+
+            {/* Action Bar */}
+            <div className="flex flex-wrap items-center justify-between gap-3 pt-4 border-t border-ln">
+                <div className="flex items-center gap-2">
+                    {onApplyToBatch && batchEligibleCount > 0 && (
+                        <div className="flex flex-wrap items-center gap-1.5">
+                            <button
+                                type="button"
+                                onClick={() => onApplyToBatch(draftBindings, null)}
+                                className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-ac bg-acS hover:bg-acS/80 rounded-xl transition"
+                            >
+                                <ArrowRight size={13} />
+                                <span>Apply All Routes ({batchEligibleCount})</span>
+                            </button>
+                            {hasInstanceRoutes && hasCrossImageRoutes && (
+                                <>
+                                    <button
+                                        type="button"
+                                        onClick={() => onApplyToBatch(draftBindings, "instance-segmentation")}
+                                        className="inline-flex items-center gap-1 px-2.5 py-1.5 text-xs font-medium text-t2 bg-well hover:bg-hv rounded-xl transition"
+                                        title="Apply only Instance Segmentation routes"
+                                    >
+                                        <span>Instance Seg Only</span>
+                                    </button>
+                                    <button
+                                        type="button"
+                                        onClick={() => onApplyToBatch(draftBindings, "cross-image-suggestion")}
+                                        className="inline-flex items-center gap-1 px-2.5 py-1.5 text-xs font-medium text-t2 bg-well hover:bg-hv rounded-xl transition"
+                                        title="Apply only Cross-Image Suggestion routes"
+                                    >
+                                        <span>Cross-Image Only</span>
+                                    </button>
+                                </>
+                            )}
+                        </div>
+                    )}
+                </div>
+
+                <div className="flex items-center gap-2">
+                    {policy && (
+                        <button
+                            type="button"
+                            onClick={handleClearAll}
+                            disabled={!canEdit || isDeleting || isSaving}
+                            className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-950/30 rounded-xl transition disabled:opacity-50"
+                        >
+                            <Trash2 size={13} />
+                            <span>{isDeleting ? "Clearing..." : "Clear Policy"}</span>
+                        </button>
+                    )}
+
+                    {hasUnsavedChanges && (
+                        <button
+                            type="button"
+                            onClick={handleReset}
+                            disabled={!canEdit || isSaving}
+                            className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-t2 hover:bg-well rounded-xl transition disabled:opacity-50"
+                        >
+                            <RotateCcw size={13} />
+                            <span>Reset Changes</span>
+                        </button>
+                    )}
+
+                    <button
+                        type="button"
+                        onClick={handleSave}
+                        disabled={!canEdit || isSaving || (!hasUnsavedChanges && policy !== null)}
+                        className={`inline-flex items-center gap-1.5 px-4 py-1.5 text-xs font-medium rounded-xl transition shadow-xs ${
+                            hasUnsavedChanges
+                                ? "bg-accent hover:bg-accent/90 text-white"
+                                : "bg-p2 text-t3 cursor-default"
+                        } disabled:opacity-50`}
+                    >
+                        <Save size={13} />
+                        <span>{isSaving ? "Saving..." : hasUnsavedChanges ? "Save Routing Policy" : "Saved"}</span>
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/components/inference/ModelOrchestrationPanel.test.jsx
+++ b/src/components/inference/ModelOrchestrationPanel.test.jsx
@@ -1,0 +1,266 @@
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import ModelOrchestrationPanel, { modelsForTaskAndLabel } from "./ModelOrchestrationPanel";
+import { TASK_ORDER } from "../../constants/tasks";
+
+describe("ModelOrchestrationPanel", () => {
+    const labelsById = {
+        1: { id: 1, name: "cell", parent_id: null },
+        2: { id: 2, name: "nucleus", parent_id: 1 },
+    };
+
+    const models = [
+        {
+            registry_key: "sam2-prompted",
+            name: "SAM 2 Prompted",
+            task: "prompted-segmentation",
+            label_ids: [],
+            provenance: "declared",
+            trained_on_dataset: false,
+        },
+        {
+            registry_key: "sam3-intra",
+            name: "SAM 3 Intra",
+            task: "instance-suggestion",
+            label_ids: [],
+            provenance: "declared",
+            trained_on_dataset: false,
+        },
+        {
+            registry_key: "m2f-generic",
+            name: "Mask2Former Generic",
+            task: "instance-segmentation",
+            label_ids: [],
+            provenance: "legacy_default",
+            trained_on_dataset: false,
+        },
+        {
+            registry_key: "m2f-cell-specialist",
+            name: "Mask2Former Cell Specialist",
+            task: "instance-segmentation",
+            label_ids: [1],
+            provenance: "declared",
+            trained_on_dataset: true,
+        },
+        {
+            registry_key: "sam3-cross",
+            name: "SAM 3 Cross Exemplar",
+            task: "cross-image-suggestion",
+            label_ids: [],
+            provenance: "declared",
+            trained_on_dataset: false,
+            input_contract: {
+                schema_version: 1,
+                task: "cross-image-suggestion",
+                conditioning: {
+                    kind: "concept_text",
+                    user_selectable_count: false,
+                },
+                parameters: [
+                    {
+                        key: "threshold",
+                        label: "Detection sensitivity",
+                        type: "float",
+                        default_value: 0.5,
+                        min_value: 0.0,
+                        max_value: 1.0,
+                        step: 0.05,
+                    },
+                ],
+            },
+        },
+    ];
+
+    const strategies = [
+        { key: "global_scene", label: "Global Scene", available: true },
+    ];
+
+    it("correctly filters models for task and label", () => {
+        // Task default for instance-segmentation: lists all models for the task (both class-agnostic and class-aware)
+        const defaultModels = modelsForTaskAndLabel(models, "instance-segmentation", null);
+        expect(defaultModels.map((m) => m.registry_key)).toEqual([
+            "m2f-generic",
+            "m2f-cell-specialist",
+        ]);
+
+        // Override for label 1 (cell): both class-agnostic and specialist predicting 1
+        const cellModels = modelsForTaskAndLabel(models, "instance-segmentation", 1);
+        expect(cellModels.map((m) => m.registry_key)).toEqual([
+            "m2f-generic",
+            "m2f-cell-specialist",
+        ]);
+
+        // Override for label 2 (nucleus): only class-agnostic m2f-generic
+        const nucleusModels = modelsForTaskAndLabel(models, "instance-segmentation", 2);
+        expect(nucleusModels.map((m) => m.registry_key)).toEqual(["m2f-generic"]);
+    });
+
+    it("renders all four task sections in canonical order and collapsed by default", () => {
+        render(
+            <ModelOrchestrationPanel
+                datasetId={10}
+                policy={null}
+                labelsById={labelsById}
+                catalog={{ models, retrieval_strategies: strategies }}
+                onSavePolicy={jest.fn()}
+                onDeletePolicy={jest.fn()}
+            />
+        );
+
+        const buttons = screen.getAllByRole("button", { expanded: false });
+        expect(buttons.length).toBeGreaterThanOrEqual(4);
+
+        expect(screen.getByText("Prompted seg")).toBeInTheDocument();
+        expect(screen.getByText("Within-image suggestion")).toBeInTheDocument();
+        expect(screen.getByText("Instance segmentation")).toBeInTheDocument();
+        expect(screen.getByText("Cross-image suggestion")).toBeInTheDocument();
+    });
+
+    it("initializes from an existing policy and displays saved bindings when expanded", () => {
+        const policy = {
+            dataset_id: 10,
+            bindings: [
+                {
+                    task: "instance-segmentation",
+                    label_id: null,
+                    model_registry_key: "m2f-generic",
+                    inputs: null,
+                },
+                {
+                    task: "cross-image-suggestion",
+                    label_id: 1,
+                    model_registry_key: "sam3-cross",
+                    inputs: { conditioning: { concept_text: "cell" }, parameters: { threshold: 0.7 } },
+                },
+            ],
+            updated_by: "curator",
+            created_at: "2026-08-24T10:00:00Z",
+            updated_at: "2026-08-24T12:00:00Z",
+        };
+
+        render(
+            <ModelOrchestrationPanel
+                datasetId={10}
+                policy={policy}
+                labelsById={labelsById}
+                catalog={{ models, retrieval_strategies: strategies }}
+                onSavePolicy={jest.fn()}
+                onDeletePolicy={jest.fn()}
+            />
+        );
+
+        expect(screen.getByText("Last updated by")).toBeInTheDocument();
+        expect(screen.getByText("curator")).toBeInTheDocument();
+
+        // Expand Instance segmentation and Cross-image suggestion cards
+        fireEvent.click(screen.getByRole("button", { name: /instance segmentation/i }));
+        fireEvent.click(screen.getByRole("button", { name: /cross-image suggestion/i }));
+
+        // Check selected models in dropdowns
+        const defaultInstSelect = screen.getByLabelText("Default model for instance-segmentation");
+        expect(defaultInstSelect.value).toBe("m2f-generic");
+
+        const crossCellSelect = screen.getByLabelText("Model for cell (cross-image-suggestion)");
+        expect(crossCellSelect.value).toBe("sam3-cross");
+    });
+
+    it("allows updating bindings and calls onSavePolicy with complete bindings list", async () => {
+        const handleSave = jest.fn().mockResolvedValue({});
+
+        render(
+            <ModelOrchestrationPanel
+                datasetId={10}
+                policy={null}
+                labelsById={labelsById}
+                catalog={{ models, retrieval_strategies: strategies }}
+                onSavePolicy={handleSave}
+                onDeletePolicy={jest.fn()}
+            />
+        );
+
+        // Expand Prompted segmentation card
+        fireEvent.click(screen.getByRole("button", { name: /prompted seg/i }));
+
+        // Select task default for prompted segmentation
+        const promptedDefaultSelect = screen.getByLabelText("Default model for prompted-segmentation");
+        fireEvent.change(promptedDefaultSelect, { target: { value: "sam2-prompted" } });
+
+        // Save button should now be enabled
+        const saveButton = screen.getByRole("button", { name: /save routing policy/i });
+        expect(saveButton).not.toBeDisabled();
+
+        fireEvent.click(saveButton);
+
+        await waitFor(() => {
+            expect(handleSave).toHaveBeenCalledTimes(1);
+        });
+
+        const savedBindings = handleSave.mock.calls[0][0];
+        expect(savedBindings).toHaveLength(1);
+        expect(savedBindings[0].task).toBe("prompted-segmentation");
+        expect(savedBindings[0].label_id).toBeNull();
+        expect(savedBindings[0].model_registry_key).toBe("sam2-prompted");
+    });
+
+    it("renders warning for stale unavailable models when expanded", () => {
+        const policyWithStale = {
+            dataset_id: 10,
+            bindings: [
+                {
+                    task: "instance-segmentation",
+                    label_id: 1,
+                    model_registry_key: "retired-legacy-model",
+                    inputs: null,
+                },
+            ],
+            updated_by: "curator",
+            created_at: "2026-08-24T10:00:00Z",
+            updated_at: "2026-08-24T12:00:00Z",
+        };
+
+        render(
+            <ModelOrchestrationPanel
+                datasetId={10}
+                policy={policyWithStale}
+                labelsById={labelsById}
+                catalog={{ models, retrieval_strategies: strategies }}
+                onSavePolicy={jest.fn()}
+                onDeletePolicy={jest.fn()}
+            />
+        );
+
+        // Expand Instance segmentation card
+        fireEvent.click(screen.getByRole("button", { name: /instance segmentation/i }));
+
+        expect(screen.getByText(/The previously saved model/)).toBeInTheDocument();
+        expect(screen.getByText("retired-legacy-model")).toBeInTheDocument();
+    });
+
+    it("disables editing controls when canEdit is false", () => {
+        render(
+            <ModelOrchestrationPanel
+                datasetId={10}
+                policy={null}
+                labelsById={labelsById}
+                catalog={{ models, retrieval_strategies: strategies }}
+                onSavePolicy={jest.fn()}
+                onDeletePolicy={jest.fn()}
+                canEdit={false}
+            />
+        );
+
+        // Expand all task cards to inspect controls
+        fireEvent.click(screen.getByRole("button", { name: /prompted seg/i }));
+        fireEvent.click(screen.getByRole("button", { name: /within-image suggestion/i }));
+        fireEvent.click(screen.getByRole("button", { name: /instance segmentation/i }));
+        fireEvent.click(screen.getByRole("button", { name: /cross-image suggestion/i }));
+
+        const selects = screen.getAllByRole("combobox");
+        selects.forEach((select) => {
+            expect(select).toBeDisabled();
+        });
+
+        const saveButton = screen.getByRole("button", { name: /saved|save routing policy/i });
+        expect(saveButton).toBeDisabled();
+    });
+});

--- a/src/components/models/ModelCard.jsx
+++ b/src/components/models/ModelCard.jsx
@@ -18,6 +18,8 @@ import {
 import { getTaskMeta, TASK_ORDER } from "../../constants/tasks";
 import { filterDisplayableModelTags } from "./modelTags";
 
+import TaskFavoriteChooser from "./TaskFavoriteChooser";
+
 // A model is model-centric now: it can serve several tasks. The header tile is
 // keyed by the model's first (primary) task; the capability chips below list
 // every task it can do.
@@ -32,7 +34,15 @@ const DEFAULT_VISUAL = { Icon: Scan, tile: "bg-acS text-ac" };
 const orderTasks = (tasks) =>
   [...(tasks || [])].sort((a, b) => TASK_ORDER.indexOf(a) - TASK_ORDER.indexOf(b));
 
-const ModelCard = ({ model, isFavorite = false, onToggleFavorite, onAction }) => {
+const ModelCard = ({
+  model,
+  isFavorite = false,
+  selectedTask = "all",
+  favorites = {},
+  onToggleFavorite,
+  onAction,
+}) => {
+  const [showChooser, setShowChooser] = React.useState(false);
   const handleAction = (actionType) => onAction?.(model, actionType);
 
   const tasks = orderTasks(model.tasks);
@@ -65,6 +75,15 @@ const ModelCard = ({ model, isFavorite = false, onToggleFavorite, onAction }) =>
     },
   ].filter(Boolean);
 
+  const handleStarClick = (e) => {
+    e.stopPropagation();
+    if (selectedTask !== "all" || tasks.length <= 1) {
+      onToggleFavorite?.(model, selectedTask !== "all" ? selectedTask : tasks[0]);
+    } else {
+      setShowChooser((prev) => !prev);
+    }
+  };
+
   return (
     <div className="group flex flex-col bg-p1 rounded-2xl border border-ln shadow-sm hover:shadow-lg hover:border-ln2 hover:-translate-y-0.5 transition-all duration-200">
       {/* Header: icon + name + status + favorite */}
@@ -80,7 +99,7 @@ const ModelCard = ({ model, isFavorite = false, onToggleFavorite, onAction }) =>
             <h3 className="text-base font-semibold text-t1 leading-snug truncate">
               {model.name}
             </h3>
-            <div className="flex items-center gap-1.5 shrink-0">
+            <div className="flex items-center gap-1.5 shrink-0 relative">
               {model.status && (
                 <span
                   className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-semibold ${
@@ -98,13 +117,13 @@ const ModelCard = ({ model, isFavorite = false, onToggleFavorite, onAction }) =>
               )}
               <button
                 type="button"
-                onClick={() => onToggleFavorite?.(model)}
+                onClick={handleStarClick}
                 aria-label={isFavorite ? "Remove from favorites" : "Add to favorites"}
                 aria-pressed={isFavorite}
                 title={
                   isFavorite
                     ? "Favorite — preselected in the annotation page"
-                    : "Set as your default model for its tasks"
+                    : "Set as your personal default model"
                 }
                 className="p-0.5 rounded-md hover:bg-hv transition-colors"
               >
@@ -117,6 +136,18 @@ const ModelCard = ({ model, isFavorite = false, onToggleFavorite, onAction }) =>
                   style={{ width: 18, height: 18 }}
                 />
               </button>
+
+              {showChooser && (
+                <TaskFavoriteChooser
+                  model={model}
+                  favorites={favorites}
+                  onToggleTaskFavorite={(m, t) => {
+                    onToggleFavorite?.(m, t);
+                  }}
+                  onClose={() => setShowChooser(false)}
+                  anchorAlign="right"
+                />
+              )}
             </div>
           </div>
           {model.identifier && (
@@ -131,18 +162,35 @@ const ModelCard = ({ model, isFavorite = false, onToggleFavorite, onAction }) =>
       </div>
 
       <div className="flex flex-col flex-1 px-5 pb-5">
-        {/* Capability chips: every task this model can serve */}
+        {/* Capability chips: every task this model can serve with per-task star */}
         {tasks.length > 0 && (
           <div className="flex flex-wrap gap-1.5 mb-3">
             {tasks.map((taskKey) => {
               const meta = getTaskMeta(taskKey);
+              const isTaskFav = favorites[taskKey] === model.identifier;
               return (
                 <span
                   key={taskKey}
-                  className={`inline-flex items-center gap-1.5 px-2.5 py-0.5 rounded-full text-[11px] font-medium ${meta.chip}`}
+                  className={`inline-flex items-center gap-1.5 pl-2.5 pr-1.5 py-0.5 rounded-full text-[11px] font-medium ${meta.chip}`}
                 >
                   <span className={`w-1.5 h-1.5 rounded-full ${meta.dot}`} />
-                  {meta.label}
+                  <span>{meta.label}</span>
+                  <button
+                    type="button"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onToggleFavorite?.(model, taskKey);
+                    }}
+                    aria-label={`Toggle favorite for ${meta.label}`}
+                    className="p-0.5 rounded hover:bg-black/10 transition-colors"
+                    title={isTaskFav ? `Favorite for ${meta.label}` : `Set as default for ${meta.label}`}
+                  >
+                    <Star
+                      className={`w-3 h-3 ${
+                        isTaskFav ? "fill-amber-400 text-warn" : "text-t3 hover:text-warn"
+                      }`}
+                    />
+                  </button>
                 </span>
               );
             })}

--- a/src/components/models/ModelChip.jsx
+++ b/src/components/models/ModelChip.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import {
   CheckCircle2,
   AlertCircle,
@@ -12,6 +12,7 @@ import {
 } from "lucide-react";
 import { TASK_ORDER } from "../../constants/tasks";
 import { formatParams, formatLatency } from "./modelStats";
+import TaskFavoriteChooser from "./TaskFavoriteChooser";
 
 // Keep in sync with ModelCard's visual map: the primary task drives the tile
 // gradient + icon so a model looks the same in the list and the detail panel.
@@ -30,88 +31,121 @@ const orderTasks = (tasks) =>
  * what you scan by — name, primary-task icon, status, favorite, and up to two
  * headline stats — and defers the full spec sheet to the detail panel.
  */
-const ModelChip = ({ model, isSelected = false, isFavorite = false, onSelect, onToggleFavorite }) => {
-  const primaryTask = orderTasks(model.tasks)[0];
+const ModelChip = ({
+  model,
+  isSelected = false,
+  isFavorite = false,
+  selectedTask = "all",
+  favorites = {},
+  onSelect,
+  onToggleFavorite,
+}) => {
+  const [showChooser, setShowChooser] = useState(false);
+  const tasks = orderTasks(model.tasks);
+  const primaryTask = tasks[0];
   const { Icon, tile } = TASK_VISUAL[primaryTask] || DEFAULT_VISUAL;
   const isReady = model.status !== "not_ready";
 
   const params = formatParams(model.performance?.num_parameters);
   const latency = formatLatency(model.performance?.latency_ms);
 
+  const handleStarClick = (e) => {
+    e.stopPropagation();
+    if (selectedTask !== "all" || tasks.length <= 1) {
+      onToggleFavorite?.(model, selectedTask !== "all" ? selectedTask : tasks[0]);
+    } else {
+      setShowChooser((prev) => !prev);
+    }
+  };
+
   return (
-    <button
-      type="button"
-      onClick={() => onSelect?.(model)}
-      aria-pressed={isSelected}
-      className={`w-full text-left flex items-start gap-3 p-3 rounded-xl border transition-all ${
-        isSelected
-          ? "bg-acS border-acLn ring-1 ring-ac"
-          : "bg-p1 border-ln hover:border-ln2 hover:bg-hv"
-      }`}
-    >
-      <div
-        className={`shrink-0 w-9 h-9 rounded-lg ${tile} flex items-center justify-center shadow-sm`}
+    <div className="relative">
+      <button
+        type="button"
+        onClick={() => onSelect?.(model)}
+        aria-pressed={isSelected}
+        className={`w-full text-left flex items-start gap-3 p-3 rounded-xl border transition-all ${
+          isSelected
+            ? "bg-acS border-acLn ring-1 ring-ac"
+            : "bg-p1 border-ln hover:border-ln2 hover:bg-hv"
+        }`}
       >
-        <Icon className="w-4.5 h-4.5" style={{ width: 18, height: 18 }} />
-      </div>
-
-      <div className="min-w-0 flex-1">
-        <div className="flex items-center gap-1.5">
-          <h3 className="text-sm font-semibold text-t1 truncate flex-1" title={model.name}>
-            {model.name}
-          </h3>
-          <span
-            className="shrink-0 p-0.5 rounded-md hover:bg-p2"
-            role="button"
-            tabIndex={0}
-            aria-label={isFavorite ? "Remove from favorites" : "Add to favorites"}
-            aria-pressed={isFavorite}
-            title={isFavorite ? "Favorite — preselected in the annotation page" : "Set as default"}
-            onClick={(e) => {
-              e.stopPropagation();
-              onToggleFavorite?.(model);
-            }}
-            onKeyDown={(e) => {
-              if (e.key === "Enter" || e.key === " ") {
-                e.preventDefault();
-                e.stopPropagation();
-                onToggleFavorite?.(model);
-              }
-            }}
-          >
-            <Star
-              className={
-                isFavorite ? "fill-amber-400 text-warn" : "text-t3 hover:text-warn"
-              }
-              style={{ width: 15, height: 15 }}
-            />
-          </span>
+        <div
+          className={`shrink-0 w-9 h-9 rounded-lg ${tile} flex items-center justify-center shadow-sm`}
+        >
+          <Icon className="w-4.5 h-4.5" style={{ width: 18, height: 18 }} />
         </div>
 
-        <div className="mt-1 flex items-center flex-wrap gap-x-3 gap-y-1 text-[11px] text-t3">
-          <span
-            className={`inline-flex items-center gap-1 font-medium ${
-              isReady ? "text-ok" : "text-warn"
-            }`}
-          >
-            {isReady ? <CheckCircle2 className="w-3 h-3" /> : <AlertCircle className="w-3 h-3" />}
-            {isReady ? "Ready" : "Needs training"}
-          </span>
-          {params && (
-            <span className="inline-flex items-center gap-1" title="Parameters">
-              <Cpu className="w-3 h-3 text-t3" />
-              {params}
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-1.5">
+            <h3 className="text-sm font-semibold text-t1 truncate flex-1" title={model.name}>
+              {model.name}
+            </h3>
+            <span
+              className="shrink-0 p-0.5 rounded-md hover:bg-p2 relative"
+              role="button"
+              tabIndex={0}
+              aria-label={isFavorite ? "Remove from favorites" : "Add to favorites"}
+              aria-pressed={isFavorite}
+              title={
+                isFavorite
+                  ? "Favorite — preselected in the annotation page"
+                  : "Set as your personal default model"
+              }
+              onClick={handleStarClick}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  handleStarClick(e);
+                }
+              }}
+            >
+              <Star
+                className={`w-4 h-4 ${
+                  isFavorite ? "fill-amber-400 text-warn" : "text-t3 hover:text-warn"
+                }`}
+                style={{ width: 15, height: 15 }}
+              />
             </span>
-          )}
-          {latency && (
-            <span className="inline-flex items-center gap-1" title="Approx. inference time">
-              <Timer className="w-3 h-3 text-t3" />
-              {latency}
+          </div>
+
+          <div className="mt-1 flex items-center flex-wrap gap-x-3 gap-y-1 text-[11px] text-t3">
+            <span
+              className={`inline-flex items-center gap-1 font-medium ${
+                isReady ? "text-ok" : "text-warn"
+              }`}
+            >
+              {isReady ? <CheckCircle2 className="w-3 h-3" /> : <AlertCircle className="w-3 h-3" />}
+              {isReady ? "Ready" : "Needs training"}
             </span>
-          )}
+            {params && (
+              <span className="inline-flex items-center gap-1" title="Parameters">
+                <Cpu className="w-3 h-3 text-t3" />
+                {params}
+              </span>
+            )}
+            {latency && (
+              <span className="inline-flex items-center gap-1" title="Approx. inference time">
+                <Timer className="w-3 h-3 text-t3" />
+                {latency}
+              </span>
+            )}
+          </div>
         </div>
-      </div>
-    </button>
+      </button>
+
+      {showChooser && (
+        <TaskFavoriteChooser
+          model={model}
+          favorites={favorites}
+          onToggleTaskFavorite={(m, t) => {
+            onToggleFavorite?.(m, t);
+          }}
+          onClose={() => setShowChooser(false)}
+          anchorAlign="right"
+        />
+      )}
+    </div>
   );
 };
 

--- a/src/components/models/ModelDetailPanel.jsx
+++ b/src/components/models/ModelDetailPanel.jsx
@@ -35,6 +35,8 @@ import {
 } from "./modelStats";
 import { filterDisplayableModelTags } from "./modelTags";
 
+import TaskFavoriteChooser from "./TaskFavoriteChooser";
+
 const TASK_VISUAL = {
   "prompted-segmentation": { Icon: MousePointerClick, tile: "bg-acS text-ac" },
   "instance-suggestion": { Icon: Wand2, tile: "bg-acS text-ac" },
@@ -81,7 +83,16 @@ const SectionTitle = ({ children }) => (
  * the compact chip omits lives here: full description, performance figures,
  * capabilities, a spec table, and the fine-tune action.
  */
-const ModelDetailPanel = ({ model, isFavorite = false, onToggleFavorite, onAction }) => {
+const ModelDetailPanel = ({
+  model,
+  isFavorite = false,
+  selectedTask = "all",
+  favorites = {},
+  onToggleFavorite,
+  onAction,
+}) => {
+  const [showChooser, setShowChooser] = React.useState(false);
+
   if (!model) {
     return (
       <div className="h-full flex flex-col items-center justify-center text-center p-10">
@@ -153,6 +164,15 @@ const ModelDetailPanel = ({ model, isFavorite = false, onToggleFavorite, onActio
     trainedOnDataset ||
     tags.length > 0;
 
+  const handleStarClick = (e) => {
+    e.stopPropagation();
+    if (selectedTask !== "all" || tasks.length <= 1) {
+      onToggleFavorite?.(model, selectedTask !== "all" ? selectedTask : tasks[0]);
+    } else {
+      setShowChooser((prev) => !prev);
+    }
+  };
+
   return (
     <div className="h-full overflow-y-auto">
       <div className="p-6 max-w-3xl">
@@ -173,7 +193,7 @@ const ModelDetailPanel = ({ model, isFavorite = false, onToggleFavorite, onActio
                   </p>
                 )}
               </div>
-              <div className="flex items-center gap-2 shrink-0">
+              <div className="flex items-center gap-2 shrink-0 relative">
                 {model.status && (
                   <span
                     className={`inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-semibold ${
@@ -190,13 +210,13 @@ const ModelDetailPanel = ({ model, isFavorite = false, onToggleFavorite, onActio
                 )}
                 <button
                   type="button"
-                  onClick={() => onToggleFavorite?.(model)}
+                  onClick={handleStarClick}
                   aria-label={isFavorite ? "Remove from favorites" : "Add to favorites"}
                   aria-pressed={isFavorite}
                   title={
                     isFavorite
                       ? "Favorite — preselected in the annotation page"
-                      : "Set as your default model for its tasks"
+                      : "Set as your personal default model"
                   }
                   className="p-1.5 rounded-lg hover:bg-hv transition-colors"
                 >
@@ -207,20 +227,49 @@ const ModelDetailPanel = ({ model, isFavorite = false, onToggleFavorite, onActio
                     style={{ width: 20, height: 20 }}
                   />
                 </button>
+
+                {showChooser && (
+                  <TaskFavoriteChooser
+                    model={model}
+                    favorites={favorites}
+                    onToggleTaskFavorite={(m, t) => {
+                      onToggleFavorite?.(m, t);
+                    }}
+                    onClose={() => setShowChooser(false)}
+                    anchorAlign="right"
+                  />
+                )}
               </div>
             </div>
 
-            {/* Capability + badge chips */}
+            {/* Capability + badge chips with per-task star controls */}
             <div className="mt-3 flex flex-wrap gap-1.5">
               {tasks.map((taskKey) => {
                 const meta = getTaskMeta(taskKey);
+                const isTaskFav = favorites[taskKey] === model.identifier;
                 return (
                   <span
                     key={taskKey}
-                    className={`inline-flex items-center gap-1.5 px-2.5 py-0.5 rounded-full text-[11px] font-medium ${meta.chip}`}
+                    className={`inline-flex items-center gap-1.5 pl-2.5 pr-1.5 py-0.5 rounded-full text-[11px] font-medium ${meta.chip}`}
                   >
                     <span className={`w-1.5 h-1.5 rounded-full ${meta.dot}`} />
-                    {meta.label}
+                    <span>{meta.label}</span>
+                    <button
+                      type="button"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onToggleFavorite?.(model, taskKey);
+                      }}
+                      aria-label={`Toggle favorite for ${meta.label}`}
+                      className="p-0.5 rounded hover:bg-black/10 transition-colors"
+                      title={isTaskFav ? `Favorite for ${meta.label}` : `Set as default for ${meta.label}`}
+                    >
+                      <Star
+                        className={`w-3 h-3 ${
+                          isTaskFav ? "fill-amber-400 text-warn" : "text-t3 hover:text-warn"
+                        }`}
+                      />
+                    </button>
                   </span>
                 );
               })}

--- a/src/components/models/TaskFavoriteChooser.jsx
+++ b/src/components/models/TaskFavoriteChooser.jsx
@@ -1,0 +1,75 @@
+import React, { useEffect, useRef } from "react";
+import { Star } from "lucide-react";
+import { getTaskMeta } from "../../constants/tasks";
+
+/**
+ * Small popover task chooser when starring a multi-task model from the 'All' view.
+ * Allows setting or removing personal task defaults per task independently.
+ */
+export default function TaskFavoriteChooser({
+  model,
+  favorites = {},
+  onToggleTaskFavorite,
+  onClose,
+  anchorAlign = "right",
+}) {
+  const ref = useRef(null);
+
+  useEffect(() => {
+    const handleClickOutside = (e) => {
+      if (ref.current && !ref.current.contains(e.target)) {
+        onClose?.();
+      }
+    };
+    const handleKeyDown = (e) => {
+      if (e.key === "Escape") onClose?.();
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [onClose]);
+
+  const tasks = model?.tasks || [];
+
+  return (
+    <div
+      ref={ref}
+      className={`absolute z-30 top-full mt-1.5 ${
+        anchorAlign === "right" ? "right-0" : "left-0"
+      } w-56 rounded-xl bg-p1 border border-ln shadow-lg p-2 text-left animate-in fade-in zoom-in-95 duration-100`}
+      onClick={(e) => e.stopPropagation()}
+    >
+      <div className="text-[11px] font-semibold text-t3 px-2 py-1 uppercase tracking-wider">
+        Star default for:
+      </div>
+      <div className="space-y-1 mt-1">
+        {tasks.map((taskKey) => {
+          const meta = getTaskMeta(taskKey);
+          const isFav = favorites[taskKey] === model.identifier;
+          return (
+            <button
+              key={taskKey}
+              type="button"
+              onClick={() => onToggleTaskFavorite?.(model, taskKey)}
+              aria-label={`Toggle favorite for ${meta.label}`}
+              className="w-full flex items-center justify-between px-2 py-1.5 rounded-lg text-xs text-t1 hover:bg-hv transition-colors"
+            >
+              <div className="flex items-center gap-2">
+                <span className={`w-2 h-2 rounded-full ${meta.dot}`} />
+                <span>{meta.short || meta.label}</span>
+              </div>
+              <Star
+                className={`w-3.5 h-3.5 ${
+                  isFav ? "fill-amber-400 text-warn" : "text-t3 hover:text-warn"
+                }`}
+              />
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/constants/tasks.js
+++ b/src/constants/tasks.js
@@ -13,38 +13,63 @@ export const TASKS = {
     endpoint: "prompted_segmentation",
     short: "Prompted",
     label: "Prompted seg",
+    description: "Interactive point-and-box segmentation for guided annotation.",
     chip: "bg-acS text-ac",
     dot: "bg-accent",
   },
   "instance-suggestion": {
     key: "instance-suggestion",
     endpoint: "suggestion_segmentation",
-    short: "Suggestion",
-    label: "Instance suggestion",
+    short: "Within-Image",
+    label: "Within-image suggestion",
+    description: "Auto-detect instances within the current image.",
     chip: "bg-acS text-ac",
     dot: "bg-accent",
   },
   "instance-segmentation": {
     key: "instance-segmentation",
     endpoint: "instance_segmentation",
-    short: "Instance",
-    label: "Instance seg",
+    short: "Full-Image",
+    label: "Instance segmentation",
+    description: "Batch instance segmentation across dataset images.",
     chip: "bg-warnBg text-warn",
     dot: "bg-warn",
   },
+  "cross-image-suggestion": {
+    key: "cross-image-suggestion",
+    endpoint: "cross_image_suggestion",
+    short: "Cross-Image",
+    label: "Cross-image suggestion",
+    description: "Suggest instances by retrieving exemplars across dataset images.",
+    chip: "bg-purple-100 text-purple-800 dark:bg-purple-900/40 dark:text-purple-300",
+    dot: "bg-purple-500",
+  },
 };
 
-// Stable display / iteration order.
+// Canonical display and policy order across the application
 export const TASK_ORDER = [
   "prompted-segmentation",
   "instance-suggestion",
   "instance-segmentation",
+  "cross-image-suggestion",
+];
+
+// Tasks supported for full-dataset batch execution
+export const BATCH_INFERENCE_TASKS = [
+  "instance-segmentation",
+  "cross-image-suggestion",
+];
+
+// Tasks supported for single-image interactive suggestion
+export const INTERACTIVE_SUGGESTION_TASKS = [
+  "cross-image-suggestion",
 ];
 
 export const getTaskMeta = (key) => TASKS[key] || {
   key,
   short: key,
   label: key,
+  description: "",
   chip: "bg-well text-t2",
   dot: "bg-t3",
 };

--- a/src/hooks/useAnnotationKeyboardShortcuts.js
+++ b/src/hooks/useAnnotationKeyboardShortcuts.js
@@ -15,9 +15,8 @@ import {
   useWorkspaceMode,
 } from '../stores/selectors/annotationSelectors';
 import useAISegmentation from './useAISegmentation';
-import { useSuggestionSegmentation } from './useSuggestionSegmentation';
+import useSuggestSimilar from '../components/annotationPage/workspace/useSuggestSimilar';
 import { deleteObject } from '../utils/objectOperations';
-import { getContourId } from '../utils/objectUtils';
 
 /**
  * Action keyboard shortcuts for the annotation page.
@@ -53,7 +52,7 @@ export default function useAnnotationKeyboardShortcuts() {
   const mode = useWorkspaceMode();
 
   const { runSegmentation } = useAISegmentation();
-  const { runSuggestion, isRunning: isRunningSuggestion } = useSuggestionSegmentation();
+  const suggestSimilar = useSuggestSimilar();
   const runInstanceRequest = setInstanceRunRequested;
 
   const canRunPrompted =
@@ -108,17 +107,9 @@ export default function useAnnotationKeyboardShortcuts() {
         }
         case '2': {
           if (isModifier) break;
-          if (selectedObjects.length === 0) break;
-          if (isRunningSuggestion) break;
+          if (!suggestSimilar.eligible) break;
           e.preventDefault();
-          const contourIds = selectedObjects.map((o) => getContourId(o)).filter(Boolean);
-          const labelId = selectedObjects[0]?.labelId ?? null;
-          if (contourIds.length > 0) {
-            runSuggestion(
-              contourIds.length === 1 ? contourIds[0] : contourIds,
-              labelId
-            );
-          }
+          suggestSimilar.run();
           break;
         }
         case '3': {
@@ -159,8 +150,7 @@ export default function useAnnotationKeyboardShortcuts() {
     mode,
     runSegmentation,
     selectedObjects,
-    runSuggestion,
-    isRunningSuggestion,
+    suggestSimilar,
     runInstanceRequest,
     handleRejectSelected,
     currentTool,

--- a/src/hooks/useSuggestionSegmentation.js
+++ b/src/hooks/useSuggestionSegmentation.js
@@ -24,7 +24,7 @@ export function useSuggestionSegmentation(onSuccess, onError) {
   const availableModels = useAvailableSuggestionModels();
   const { addToast } = useToast();
 
-  const runSuggestion = useCallback(async (contourIdOrIds, labelId) => {
+  const runSuggestion = useCallback(async (contourIdOrIds, labelId, modelIdOverride = null) => {
     // Note: Model status is handled by the backend, no need to update here
     
     // Normalize to array
@@ -38,7 +38,9 @@ export function useSuggestionSegmentation(onSuccess, onError) {
       return;
     }
 
-    if (!suggestionModelId) {
+    const effectiveModelId = modelIdOverride || suggestionModelId;
+
+    if (!effectiveModelId) {
       const error = new Error('Please select a suggestion model first');
       if (onError) {
         onError(error);
@@ -63,10 +65,10 @@ export function useSuggestionSegmentation(onSuccess, onError) {
 
     try {
       // Call WebSocket method - objects will be added automatically via OBJECT_ADDED messages
-      // suggestionModelId is already the string identifier we need
+      // effectiveModelId is already the string identifier we need
       const response = await annotationSession.runSuggestion(
         contourIds,         // Array of seed contour IDs (can be single or multiple)
-        suggestionModelId,  // Model identifier (string)
+        effectiveModelId,   // Model identifier (string)
         labelId             // Label ID
       );
       
@@ -80,9 +82,9 @@ export function useSuggestionSegmentation(onSuccess, onError) {
       // ack reports how many were found.
       if (response?.data?.added_count === 0) {
         const model = availableModels.find(
-          (m) => (m?.id || m?.registry_key || m?.identifier) === suggestionModelId
+          (m) => (m?.id || m?.registry_key || m?.identifier) === effectiveModelId
         );
-        const modelName = model?.name || 'The model';
+        const modelName = model?.name || effectiveModelId;
         addToast({
           type: 'info',
           message: `${modelName} did not find any new instances. Try another model or add more exemplars!`,
@@ -105,4 +107,3 @@ export function useSuggestionSegmentation(onSuccess, onError) {
 
   return { runSuggestion, isRunning };
 }
-

--- a/src/hooks/useSuggestionSegmentation.test.js
+++ b/src/hooks/useSuggestionSegmentation.test.js
@@ -1,0 +1,59 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useSuggestionSegmentation } from './useSuggestionSegmentation';
+import annotationSession from '../services/annotationSession';
+
+const addToast = vi.hoisted(() => vi.fn());
+const setIsRunning = vi.hoisted(() => vi.fn());
+
+vi.mock('../stores/selectors/annotationSelectors', () => ({
+  useAvailableSuggestionModels: () => [
+    { id: 'personal-default', name: 'Personal Default' },
+    { id: 'routed-specialist', name: 'Routed Specialist' },
+  ],
+  useSuggestionModel: () => 'personal-default',
+  useIsRunningSuggestion: () => false,
+  useSetIsRunningSuggestion: () => setIsRunning,
+}));
+
+vi.mock('../contexts/ToastContext', () => ({
+  useToast: () => ({ addToast }),
+}));
+
+vi.mock('../services/annotationSession', () => ({
+  default: {
+    isServiceAvailable: vi.fn(),
+    runSuggestion: vi.fn(),
+  },
+}));
+
+describe('useSuggestionSegmentation model override', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    annotationSession.isServiceAvailable.mockReturnValue(true);
+    annotationSession.runSuggestion.mockResolvedValue({
+      success: true,
+      data: { added_count: 0 },
+    });
+  });
+
+  it('executes and reports zero results using the routed override model', async () => {
+    const { result } = renderHook(() => useSuggestionSegmentation());
+
+    await act(async () => {
+      await result.current.runSuggestion([11, 12], 2, 'routed-specialist');
+    });
+
+    expect(annotationSession.runSuggestion).toHaveBeenCalledWith(
+      [11, 12],
+      'routed-specialist',
+      2
+    );
+    expect(addToast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'info',
+        message: expect.stringContaining('Routed Specialist'),
+      })
+    );
+  });
+});

--- a/src/index.css
+++ b/src/index.css
@@ -137,11 +137,9 @@ select option:disabled {
 @keyframes fade-in {
   0% {
     opacity: 0;
-    transform: translate(-50%, -50%) scale(0.98);
   }
   100% {
     opacity: 1;
-    transform: translate(-50%, -50%) scale(1);
   }
 }
 

--- a/src/pages/BatchInferenceIntegration.test.jsx
+++ b/src/pages/BatchInferenceIntegration.test.jsx
@@ -1,0 +1,249 @@
+import React from "react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { vi, describe, it, expect, beforeEach } from "vitest";
+import BatchInferencePage from "./BatchInferencePage";
+import { fetchLabels } from "../api/labels";
+import {
+    getInferenceModelCatalog,
+    getInferenceScopeCounts,
+    getInferenceJobs,
+    startInferenceJob,
+    getInferenceRoutingPolicy,
+    streamInferenceJob,
+} from "../api/inference";
+
+const { mockRoute } = vi.hoisted(() => ({
+    mockRoute: { datasetId: "101" },
+}));
+
+vi.mock("react-router-dom", () => ({
+    useParams: () => ({ datasetId: mockRoute.datasetId }),
+    useNavigate: () => vi.fn(),
+    Link: ({ to, children, ...props }) => (
+        <a href={to} {...props}>
+            {children}
+        </a>
+    ),
+}));
+
+vi.mock("../contexts/DatasetContext", () => ({
+    useDataset: () => ({ currentDataset: { id: mockRoute.datasetId, name: "Test Dataset" } }),
+}));
+
+vi.mock("../hooks/usePermissions", () => ({
+    usePermissions: () => ({ can: () => true }),
+}));
+
+vi.mock("../components/datasets/gallery/DatasetManagementLayout", () => ({
+    default: ({ children }) => <div data-testid="layout">{children}</div>,
+}));
+
+vi.mock("../api/labels", () => ({
+    fetchLabels: vi.fn(),
+}));
+
+vi.mock("../api/inference", () => ({
+    getInferenceModelCatalog: vi.fn(),
+    getInferenceScopeCounts: vi.fn(),
+    getInferenceJobs: vi.fn(),
+    startInferenceJob: vi.fn(),
+    cancelInferenceJob: vi.fn(),
+    deleteInferenceJob: vi.fn(),
+    streamInferenceJob: vi.fn(),
+    previewInferenceReplace: vi.fn(),
+    getInferenceRoutingPolicy: vi.fn(),
+}));
+
+describe("BatchInferencePage real integration with policy and planner", () => {
+    const catalogModels = [
+        {
+            registry_key: "m2f-generic",
+            name: "Mask2Former Generic",
+            task: "instance-segmentation",
+            label_ids: [],
+            provenance: "legacy_default",
+        },
+        {
+            registry_key: "m2f-cell-specialist",
+            name: "Mask2Former Cell Only",
+            task: "instance-segmentation",
+            label_ids: [1],
+            provenance: "declared",
+        },
+        {
+            registry_key: "sam3-cross",
+            name: "SAM 3 Cross Exemplar",
+            task: "cross-image-suggestion",
+            label_ids: [],
+            provenance: "declared",
+        },
+        {
+            registry_key: "sam3-cross-nucleus",
+            name: "SAM 3 Cross Nucleus Only",
+            task: "cross-image-suggestion",
+            label_ids: [2],
+            provenance: "declared",
+        },
+        {
+            registry_key: "sam2-prompted",
+            name: "SAM 2 Interactive Point",
+            task: "prompted-segmentation",
+            label_ids: [],
+            provenance: "declared",
+        },
+    ];
+
+    const labelsById = {
+        1: { id: 1, name: "cell", parent_id: null },
+        2: { id: 2, name: "nucleus", parent_id: 1 },
+    };
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockRoute.datasetId = "101";
+
+        fetchLabels.mockResolvedValue({
+            labels: { id_to_label_object: labelsById },
+        });
+        getInferenceModelCatalog.mockResolvedValue({
+            models: catalogModels,
+            retrieval_strategies: [{ key: "global_scene", label: "Global Scene", available: true }],
+        });
+        getInferenceScopeCounts.mockResolvedValue({
+            total: 20,
+            not_started: 15,
+            unreviewed: 5,
+        });
+        getInferenceJobs.mockResolvedValue([]);
+        streamInferenceJob.mockReturnValue({ abort: vi.fn() });
+    });
+
+    it("pre-fills batch plan from policy with class-aware task defaults when applying routes", async () => {
+        // Policy has a class-aware task default (sam3-cross-nucleus which only predicts label 2)
+        const policy = {
+            dataset_id: 101,
+            bindings: [
+                {
+                    task: "cross-image-suggestion",
+                    label_id: null,
+                    model_registry_key: "sam3-cross-nucleus", // predicts label 2 only
+                },
+                {
+                    task: "instance-segmentation",
+                    label_id: 1,
+                    model_registry_key: "m2f-cell-specialist", // explicit override for label 1
+                },
+            ],
+            updated_by: "tester",
+        };
+        getInferenceRoutingPolicy.mockResolvedValueOnce(policy);
+
+        render(<BatchInferencePage />);
+
+        await waitFor(() => {
+            expect(screen.getByRole("button", { name: /apply all routes/i })).toBeInTheDocument();
+        });
+
+        // Click "Apply All Routes"
+        const applyAllBtn = screen.getByRole("button", { name: /apply all routes/i });
+        fireEvent.click(applyAllBtn);
+
+        // Label 1 should have m2f-cell-specialist bound
+        const cellSelect = screen.getByLabelText("Model for cell");
+        expect(cellSelect.value).toBe("instance-segmentation::m2f-cell-specialist");
+
+        // Label 2 should inherit the compatible default sam3-cross-nucleus
+        const nucleusSelect = screen.getByLabelText("Model for nucleus");
+        expect(nucleusSelect.value).toBe("cross-image-suggestion::sam3-cross-nucleus");
+    });
+
+    it("automatically pre-fills batch plan on load when batch task is unambiguous", async () => {
+        const policy = {
+            dataset_id: 101,
+            bindings: [
+                {
+                    task: "instance-segmentation",
+                    label_id: 1,
+                    model_registry_key: "m2f-cell-specialist",
+                },
+            ],
+            updated_by: "tester",
+        };
+        getInferenceRoutingPolicy.mockResolvedValueOnce(policy);
+
+        render(<BatchInferencePage />);
+
+        await waitFor(() => {
+            expect(screen.getByText("Launch Batch Inference Run")).toBeInTheDocument();
+        });
+
+        // Automatically pre-filled on load without clicking Apply
+        const cellSelect = screen.getByLabelText("Model for cell");
+        expect(cellSelect.value).toBe("instance-segmentation::m2f-cell-specialist");
+    });
+
+    it("allows applying task-specific routes when both batch tasks are configured for one label", async () => {
+        // Label 1 has bindings for both instance-segmentation and cross-image-suggestion
+        const policy = {
+            dataset_id: 101,
+            bindings: [
+                {
+                    task: "instance-segmentation",
+                    label_id: 1,
+                    model_registry_key: "m2f-cell-specialist",
+                },
+                {
+                    task: "cross-image-suggestion",
+                    label_id: 1,
+                    model_registry_key: "sam3-cross",
+                },
+            ],
+            updated_by: "tester",
+        };
+        getInferenceRoutingPolicy.mockResolvedValueOnce(policy);
+
+        render(<BatchInferencePage />);
+
+        await waitFor(() => {
+            expect(screen.getByText("Launch Batch Inference Run")).toBeInTheDocument();
+        });
+
+        // Click "Cross-Image Only" apply button
+        const crossOnlyBtn = screen.getByRole("button", { name: /cross-image only/i });
+        fireEvent.click(crossOnlyBtn);
+
+        const cellSelect = screen.getByLabelText("Model for cell");
+        expect(cellSelect.value).toBe("cross-image-suggestion::sam3-cross");
+
+        // Click "Instance Seg Only" apply button
+        const instOnlyBtn = screen.getByRole("button", { name: /instance seg only/i });
+        fireEvent.click(instOnlyBtn);
+
+        expect(cellSelect.value).toBe("instance-segmentation::m2f-cell-specialist");
+    });
+
+    it("safely excludes stale models from prefilling the batch plan", async () => {
+        const policyWithStale = {
+            dataset_id: 101,
+            bindings: [
+                {
+                    task: "instance-segmentation",
+                    label_id: 1,
+                    model_registry_key: "non-existent-retired-model",
+                },
+            ],
+            updated_by: "tester",
+        };
+        getInferenceRoutingPolicy.mockResolvedValueOnce(policyWithStale);
+
+        render(<BatchInferencePage />);
+
+        await waitFor(() => {
+            expect(screen.getByText("Launch Batch Inference Run")).toBeInTheDocument();
+        });
+
+        // Stale binding is not applied as a valid executable step
+        const cellSelect = screen.getByLabelText("Model for cell");
+        expect(cellSelect.value).toBe(""); // Skipped / unconfigured in planner
+    });
+});

--- a/src/pages/BatchInferencePage.jsx
+++ b/src/pages/BatchInferencePage.jsx
@@ -1,8 +1,19 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useNavigate, useParams } from "react-router-dom";
-import { Clock, Loader2, Plus, Wand2 } from "lucide-react";
+import React, { useState, useEffect, useRef, useCallback, useMemo } from "react";
+import { useParams, useNavigate, Link } from "react-router-dom";
+import { Play, Loader2, Sparkles, Clock, Trash2, StopCircle, ArrowLeft, Wand2, ChevronDown, ChevronRight, Cpu, ArrowRight, Check } from "lucide-react";
 import DatasetManagementLayout from "../components/datasets/gallery/DatasetManagementLayout";
 import { useDataset } from "../contexts/DatasetContext";
+import {
+    deleteInferenceJob,
+    getInferenceJobs,
+    getInferenceModelCatalog,
+    getInferenceRoutingPolicy,
+    getInferenceScopeCounts,
+    previewInferenceReplace,
+    startInferenceJob,
+    streamInferenceJob,
+} from "../api/inference";
+import { fetchLabels } from "../api/labels";
 import LabelModelPlanner from "../components/inference/LabelModelPlanner";
 import WriteModeSelector from "../components/inference/WriteModeSelector";
 import ReplaceWarningModal from "../components/inference/ReplaceWarningModal";
@@ -10,24 +21,17 @@ import InferenceProgressPanel, {
     STATUS_STYLE,
     TERMINAL_JOB_STATUSES,
 } from "../components/inference/InferenceProgressPanel";
-import {
-    cancelInferenceJob,
-    deleteInferenceJob,
-    fetchLabels,
-    getInferenceJobs,
-    getInferenceModelCatalog,
-    getInferenceScopeCounts,
-    previewInferenceReplace,
-    startInferenceJob,
-    streamInferenceJob,
-} from "../api";
+import { BATCH_INFERENCE_TASKS } from "../constants/tasks";
+import { usePermissions } from "../hooks/usePermissions";
+import { Permission } from "../utils/permissions";
+import { getBatchStepsFromPolicy } from "../utils/inferenceRouting";
 
 /**
  * Batch inference: annotate a whole dataset without opening the canvas.
  *
- * The page is the plan editor plus the progress view for one run at a time, laid out like the
- * training page (history rail, config or progress on the right) so the two AI pages behave
- * the same way.
+ * Provides a focused batch run execution workflow with run history, scope selection,
+ * label model planning, and write-mode controls. Model routing policies are managed
+ * on the dedicated Model Orchestration page and prefilled here.
  */
 
 const DEFAULT_OPTIONS = {
@@ -48,9 +52,6 @@ const RUN_NAME_PATTERN = /^[\p{L}\p{N}_\-\s]{1,80}$/u;
 
 const LEGACY_STEP_KEYS = new Set(["retrieval_strategy", "top_k"]);
 
-// Retrieval fields remain local mirrors for old persisted plans, but canonical requests carry
-// conditioning through inputs. min_confidence is different: it is a gateway-owned post-filter
-// and remains valid alongside canonical model inputs.
 const stepsForRequest = (steps) =>
     steps.map((step) =>
         step.inputs
@@ -103,16 +104,25 @@ export default function BatchInferencePage() {
     const { datasetId } = useParams();
     const { currentDataset } = useDataset();
     const navigate = useNavigate();
+    const { can } = usePermissions(datasetId);
+
+    const canConfigure = Boolean(can(Permission.AI_BATCH_INFER));
 
     const [labelsById, setLabelsById] = useState({});
     const [catalog, setCatalog] = useState({ models: [], retrieval_strategies: [] });
     const [scope, setScope] = useState({ total: 0, not_started: 0, unreviewed: 0 });
 
+    // Dataset Model Routing Policy (read-only input for batch planner prefill)
+    const [policy, setPolicy] = useState(null);
+    const [appliedFilter, setAppliedFilter] = useState(null); // "all" | "instance-segmentation" | "cross-image-suggestion" | null
+
+    // Batch Execution Form State
     const [stepsByLabel, setStepsByLabel] = useState({});
     const [options, setOptions] = useState(DEFAULT_OPTIONS);
     const [imageSelection, setImageSelection] = useState("all");
     const [runName, setRunName] = useState("");
 
+    // Job Execution & History State
     const [jobs, setJobs] = useState([]);
     const [mode, setMode] = useState("config"); // "config" | "run"
     const [selectedJob, setSelectedJob] = useState(null);
@@ -126,56 +136,142 @@ export default function BatchInferencePage() {
     const [isLoading, setIsLoading] = useState(true);
 
     const streamRef = useRef(null);
+    const datasetIdRef = useRef(datasetId);
+    datasetIdRef.current = datasetId;
+    const isMountedRef = useRef(true);
+
+    useEffect(() => {
+        isMountedRef.current = true;
+        return () => {
+            isMountedRef.current = false;
+        };
+    }, []);
 
     const steps = useMemo(
         () => Object.values(stepsByLabel).filter(Boolean),
         [stepsByLabel]
     );
 
+    const canonicalCurrentSteps = useMemo(() => stepsForRequest(steps), [steps]);
+
     const requestBody = useCallback(
         (confirmReplace = false) => ({
             dataset_id: Number(datasetId),
             name: runName.trim() || undefined,
-            steps: stepsForRequest(steps),
+            steps: canonicalCurrentSteps,
             image_selection: imageSelection,
             options,
             confirm_replace: confirmReplace,
         }),
-        [datasetId, runName, steps, imageSelection, options]
+        [datasetId, runName, canonicalCurrentSteps, imageSelection, options]
     );
 
-    const loadJobs = useCallback(async () => {
-        try {
-            const list = await getInferenceJobs(datasetId);
-            setJobs(Array.isArray(list) ? list : []);
-            return list;
-        } catch (e) {
-            // Non-fatal: the history rail simply stays empty.
-            return [];
-        }
-    }, [datasetId]);
+    const loadJobs = useCallback(
+        async (isCancelled = () => false) => {
+            try {
+                const list = await getInferenceJobs(datasetId);
+                if (!isCancelled()) {
+                    setJobs(Array.isArray(list) ? list : []);
+                }
+                return list;
+            } catch (e) {
+                if (!isCancelled()) {
+                    setJobs([]);
+                }
+                return [];
+            }
+        },
+        [datasetId]
+    );
+
+    // Apply dataset policy bindings to the batch execution plan
+    const applyPolicyToBatchSteps = useCallback(
+        (bindings, availableLabels, availableCatalog, preferredTask = null) => {
+            if (!Array.isArray(bindings)) return;
+            const policyObj = { bindings };
+            const models = availableCatalog?.models || [];
+            const newSteps = getBatchStepsFromPolicy(
+                policyObj,
+                availableLabels,
+                models,
+                preferredTask
+            );
+            setStepsByLabel(newSteps);
+        },
+        []
+    );
+
+    const handleApplyFilter = useCallback(
+        (filterKey) => {
+            if (!policy?.bindings) return;
+            const task = filterKey === "all" ? null : filterKey;
+            applyPolicyToBatchSteps(policy.bindings, labelsById, catalog, task);
+            setAppliedFilter(filterKey);
+        },
+        [policy, labelsById, catalog, applyPolicyToBatchSteps]
+    );
 
     useEffect(() => {
-        if (!datasetId) return;
+        if (!datasetId) return undefined;
+        let cancelled = false;
         setIsLoading(true);
+        setError(null);
+        setIsStarting(false);
+        setIsCancelling(false);
+        setShowReplaceWarning(false);
+        setPolicy(null);
+        setAppliedFilter(null);
+        setStepsByLabel({});
+        setOptions(DEFAULT_OPTIONS);
+        setJobs([]);
+        setSelectedJob(null);
+        setActiveJobId(null);
+        setMode("config");
+
         (async () => {
             try {
-                const [labelResponse, catalogResponse, scopeResponse] = await Promise.all([
+                const [labelResponse, catalogResponse, scopeResponse, policyResponse] = await Promise.all([
                     fetchLabels(datasetId),
                     getInferenceModelCatalog(datasetId),
                     getInferenceScopeCounts(datasetId),
+                    getInferenceRoutingPolicy(datasetId),
                 ]);
-                setLabelsById(labelResponse?.labels?.id_to_label_object || {});
-                setCatalog(catalogResponse || { models: [], retrieval_strategies: [] });
+                if (cancelled) return;
+
+                const loadedLabels = labelResponse?.labels?.id_to_label_object || {};
+                const loadedCatalog = catalogResponse || { models: [], retrieval_strategies: [] };
+
+                setLabelsById(loadedLabels);
+                setCatalog(loadedCatalog);
                 setScope(scopeResponse || { total: 0, not_started: 0, unreviewed: 0 });
+                setPolicy(policyResponse);
+
+                // Initialize batch execution plan only if a single unambiguous batch task is configured;
+                // if both batch tasks are configured, require explicit user action via 'Apply Routes' buttons.
+                if (policyResponse?.bindings && Array.isArray(policyResponse.bindings)) {
+                    const hasInstance = policyResponse.bindings.some((b) => b.task === "instance-segmentation");
+                    const hasCross = policyResponse.bindings.some((b) => b.task === "cross-image-suggestion");
+                    if (hasInstance && !hasCross) {
+                        applyPolicyToBatchSteps(policyResponse.bindings, loadedLabels, loadedCatalog, "instance-segmentation");
+                        setAppliedFilter("instance-segmentation");
+                    } else if (hasCross && !hasInstance) {
+                        applyPolicyToBatchSteps(policyResponse.bindings, loadedLabels, loadedCatalog, "cross-image-suggestion");
+                        setAppliedFilter("cross-image-suggestion");
+                    }
+                }
             } catch (e) {
-                setError(e.message || "Could not load the models for this dataset.");
+                if (!cancelled) {
+                    setError(e.message || "Could not load the models or policy for this dataset.");
+                }
             } finally {
-                setIsLoading(false);
+                if (!cancelled) {
+                    setIsLoading(false);
+                }
             }
-            // Landing while a run is going should show that run, not an empty config form —
-            // this is the tab somebody comes back to in order to check on it.
-            const list = await loadJobs();
+
+            if (cancelled) return;
+            const list = await loadJobs(() => cancelled);
+            if (cancelled) return;
             const running = (list || []).find((job) => !TERMINAL_JOB_STATUSES.has(job.status));
             if (running) {
                 setSelectedJob(running);
@@ -183,88 +279,74 @@ export default function BatchInferencePage() {
                 setMode("run");
             }
         })();
-    }, [datasetId, loadJobs]);
 
-    // Stream the active run; tear the stream down on change/unmount.
-    useEffect(() => {
-        if (!activeJobId) return undefined;
-        const controller = streamInferenceJob(
-            activeJobId,
-            (snapshot) => {
-                setSelectedJob(snapshot);
-                setJobs((current) =>
-                    current.some((job) => job.id === snapshot.id)
-                        ? current.map((job) => (job.id === snapshot.id ? snapshot : job))
-                        : [snapshot, ...current]
-                );
-                if (TERMINAL_JOB_STATUSES.has(snapshot.status)) {
-                    setActiveJobId(null);
-                    loadJobs();
-                }
-            },
-            (streamError) => setError(streamError.message || "Lost the progress stream.")
-        );
-        streamRef.current = controller;
-        return () => controller.abort();
-    }, [activeJobId, loadJobs]);
-
-    // Keep the replace preview in step with the scope and the reviewed-work toggle: the
-    // warning is only useful if its numbers describe the run that is actually configured.
-    useEffect(() => {
-        if (options.write_mode !== "replace" || steps.length === 0) {
-            setReplacePreview(null);
-            return undefined;
-        }
-        let cancelled = false;
-        previewInferenceReplace(requestBody())
-            .then((preview) => {
-                if (!cancelled) setReplacePreview(preview);
-            })
-            .catch(() => {
-                if (!cancelled) setReplacePreview(null);
-            });
         return () => {
             cancelled = true;
         };
-    }, [options.write_mode, options.preserve_reviewed, imageSelection, steps.length, requestBody]);
+    }, [datasetId, loadJobs, applyPolicyToBatchSteps]);
 
-    const setStep = (labelId, step) =>
-        setStepsByLabel((current) => ({ ...current, [labelId]: step }));
+    // Stream the active run; tear down on change/unmount
+    useEffect(() => {
+        if (!activeJobId) return undefined;
+        let cancelled = false;
 
-    const start = async (confirmReplace) => {
-        setError(null);
-        setIsStarting(true);
-        try {
-            const snapshot = await startInferenceJob(requestBody(confirmReplace));
-            setShowReplaceWarning(false);
-            setJobs((current) => [snapshot, ...current]);
-            setSelectedJob(snapshot);
-            setActiveJobId(snapshot.id);
-            setMode("run");
-        } catch (e) {
-            setError(e.message || "Could not start the run.");
-        } finally {
-            setIsStarting(false);
-        }
+        const controller = streamInferenceJob(
+            activeJobId,
+            (update) => {
+                if (cancelled || !isMountedRef.current) return;
+                setSelectedJob(update);
+                setJobs((current) =>
+                    current.map((j) => (j.id === update.id ? update : j))
+                );
+                if (TERMINAL_JOB_STATUSES.has(update.status)) {
+                    setActiveJobId(null);
+                }
+            },
+            (err) => {
+                if (cancelled || !isMountedRef.current) return;
+                setError((prev) => prev || err?.message || "Lost connection to run updates.");
+            }
+        );
+        streamRef.current = controller;
+
+        return () => {
+            cancelled = true;
+            if (controller && typeof controller.abort === "function") {
+                controller.abort();
+            }
+        };
+    }, [activeJobId]);
+
+    const setStep = (labelId, stepOrNull) => {
+        setAppliedFilter(null);
+        setStepsByLabel((current) => {
+            const next = { ...current };
+            if (stepOrNull) {
+                next[labelId] = stepOrNull;
+            } else {
+                delete next[labelId];
+            }
+            return next;
+        });
     };
 
-    const handleStart = () => {
-        if (options.write_mode === "replace") {
-            setShowReplaceWarning(true);
-            return;
-        }
-        start(false);
+    const handleSelectJob = (job) => {
+        setSelectedJob(job);
+        setActiveJobId(TERMINAL_JOB_STATUSES.has(job.status) ? null : job.id);
+        setMode("run");
     };
 
     const handleCancel = async () => {
         if (!selectedJob) return;
         setIsCancelling(true);
         try {
-            setSelectedJob(await cancelInferenceJob(selectedJob.id));
+            await cancelInferenceJob(selectedJob.id);
         } catch (e) {
-            setError(e.message || "Could not stop the run.");
+            setError(e.message || "Failed to cancel run.");
         } finally {
-            setIsCancelling(false);
+            if (isMountedRef.current) {
+                setIsCancelling(false);
+            }
         }
     };
 
@@ -272,67 +354,147 @@ export default function BatchInferencePage() {
         if (!selectedJob) return;
         try {
             await deleteInferenceJob(selectedJob.id);
-            setJobs((current) => current.filter((job) => job.id !== selectedJob.id));
+            setJobs((cur) => cur.filter((j) => j.id !== selectedJob.id));
             setSelectedJob(null);
             setActiveJobId(null);
             setMode("config");
         } catch (e) {
-            setError(e.message || "Could not remove the run.");
+            setError(e.message || "Failed to delete run.");
         }
     };
 
-    const handleSelectJob = (job) => {
-        setMode("run");
-        setSelectedJob(job);
-        setActiveJobId(TERMINAL_JOB_STATUSES.has(job.status) ? null : job.id);
+    const start = async (confirmReplace = false) => {
+        setError(null);
+        setIsStarting(true);
+        try {
+            const body = requestBody(confirmReplace);
+            const job = await startInferenceJob(body);
+            setShowReplaceWarning(false);
+            setReplacePreview(null);
+            setJobs((current) => [job, ...current.filter((j) => j.id !== job.id)]);
+            setSelectedJob(job);
+            setActiveJobId(job.id);
+            setMode("run");
+        } catch (e) {
+            setError(e.message || "Failed to start batch inference.");
+        } finally {
+            if (isMountedRef.current) {
+                setIsStarting(false);
+            }
+        }
     };
 
+    const handleStart = async () => {
+        if (options.write_mode === "replace") {
+            try {
+                const body = requestBody(false);
+                const preview = await previewInferenceReplace(body);
+                setReplacePreview(preview);
+                setShowReplaceWarning(true);
+            } catch (e) {
+                setError(e.message || "Failed to preview replace run.");
+            }
+            return;
+        }
+        await start(false);
+    };
+
+    const handleLoadJobIntoPlanner = (job) => {
+        if (!job?.steps || !Array.isArray(job.steps)) return;
+        const restored = {};
+        for (const step of job.steps) {
+            if (step.label_id != null) {
+                restored[step.label_id] = step;
+            }
+        }
+        setStepsByLabel(restored);
+        if (job.image_selection) {
+            setImageSelection(job.image_selection);
+        }
+        if (job.options) {
+            setOptions({ ...DEFAULT_OPTIONS, ...job.options });
+        }
+        if (job.name) {
+            setRunName(`${job.name} (copy)`);
+        }
+        setMode("config");
+    };
+
+    const batchEligibleBindings = useMemo(() => {
+        if (!policy?.bindings || !Array.isArray(policy.bindings)) return [];
+        return policy.bindings.filter((b) => BATCH_INFERENCE_TASKS.includes(b.task));
+    }, [policy]);
+
+    const hasInstanceRoutes = useMemo(() => {
+        return batchEligibleBindings.some((b) => b.task === "instance-segmentation");
+    }, [batchEligibleBindings]);
+
+    const hasCrossRoutes = useMemo(() => {
+        return batchEligibleBindings.some((b) => b.task === "cross-image-suggestion");
+    }, [batchEligibleBindings]);
+
+    const scopeCount = scope[SCOPE_OPTIONS.find((s) => s.value === imageSelection)?.countKey ?? "total"] ?? 0;
+    const hasActiveRun = jobs.some((j) => !TERMINAL_JOB_STATUSES.has(j.status));
     const runNameError =
-        runName.length > 0 && !RUN_NAME_PATTERN.test(runName)
-            ? "Use letters, numbers, spaces, hyphens or underscores (max 80)."
+        runName.trim() && !RUN_NAME_PATTERN.test(runName.trim())
+            ? "Letters, numbers, spaces, underscores, and hyphens only (max 80)."
             : null;
-    const scopeCount = scope[SCOPE_OPTIONS.find((o) => o.value === imageSelection).countKey] ?? 0;
-    const hasActiveRun = jobs.some((job) => !TERMINAL_JOB_STATUSES.has(job.status));
-    const canStart =
-        steps.length > 0 && scopeCount > 0 && !hasActiveRun && !runNameError && !isStarting;
+
+    const canStart = steps.length > 0 && scopeCount > 0 && !hasActiveRun && !isStarting && !runNameError && canConfigure;
 
     return (
-        <DatasetManagementLayout>
-            <div className="h-full flex flex-col bg-p1 overflow-hidden">
-                <div className="bg-p1 border-b border-ln px-4 sm:px-6 lg:px-8 py-4 flex items-center gap-3">
-                    <Wand2 className="w-6 h-6 text-ac" />
+        <DatasetManagementLayout datasetId={datasetId}>
+            <div className="flex flex-col h-[calc(100vh-64px)] bg-app">
+                {/* Top Title Banner */}
+                <header className="p-6 border-b border-ln bg-p1 flex items-center justify-between">
                     <div>
-                        <h1 className="text-2xl font-bold text-t1">Batch Inference</h1>
-                        <p className="text-sm text-t2">
-                            Let your models annotate{" "}
-                            {currentDataset?.name ? `“${currentDataset.name}”` : "this dataset"} —
-                            one model per label, run in hierarchy order.
+                        <div className="flex items-center gap-3">
+                            <h1 className="text-xl font-bold text-t1">
+                                {currentDataset?.name ? `${currentDataset.name} — Batch Inference` : "Batch Inference"}
+                            </h1>
+                            <span className="inline-flex items-center gap-1 text-xs font-semibold px-2.5 py-0.5 rounded-full bg-acS text-ac">
+                                <Wand2 size={13} /> Batch Runner
+                            </span>
+                        </div>
+                        <p className="text-xs text-t3 mt-1">
+                            Launch autonomous batch inference runs across dataset images using configured model plans.
                         </p>
                     </div>
-                </div>
 
-                <div className="flex-1 flex overflow-hidden">
-                    <aside className="w-72 shrink-0 border-r border-ln flex flex-col">
-                        <div className="p-3 border-b border-ln">
+                    <div className="flex items-center gap-2">
+                        {mode === "run" ? (
                             <button
-                                onClick={() => {
-                                    setMode("config");
-                                    setSelectedJob(null);
-                                }}
-                                className={`w-full inline-flex items-center justify-center gap-2 px-3 py-2 text-sm font-medium rounded-lg transition-colors ${
-                                    mode === "config"
-                                        ? "bg-accent text-onAccent"
-                                        : "bg-acS text-ac hover:bg-acS"
-                                }`}
+                                type="button"
+                                onClick={() => setMode("config")}
+                                className="inline-flex items-center gap-1.5 px-3.5 py-1.5 text-xs font-medium border border-ln rounded-xl bg-p1 text-t1 hover:bg-hv transition"
                             >
-                                <Plus size={16} /> New Run
+                                <ArrowLeft size={13} />
+                                <span>Configure New Run</span>
                             </button>
+                        ) : (
+                            <Link
+                                to={`/dataset/${datasetId}/model-orchestration`}
+                                className="inline-flex items-center gap-1.5 px-3.5 py-1.5 text-xs font-medium border border-ln rounded-xl bg-p1 text-t1 hover:bg-hv transition"
+                            >
+                                <Cpu size={13} />
+                                <span>Model Orchestration</span>
+                            </Link>
+                        )}
+                    </div>
+                </header>
+
+                <div className="flex flex-1 min-h-0">
+                    {/* Left History Rail */}
+                    <aside className="w-80 border-r border-ln bg-p1 flex flex-col min-h-0">
+                        <div className="p-4 border-b border-ln flex items-center justify-between">
+                            <h2 className="text-xs font-semibold uppercase tracking-wide text-t2">
+                                Run History
+                            </h2>
+                            <span className="text-xs text-t3">{jobs.length} run{jobs.length === 1 ? "" : "s"}</span>
                         </div>
+
                         <div className="flex-1 overflow-y-auto p-3 space-y-2">
-                            <p className="text-[11px] font-semibold uppercase tracking-wide text-t3 px-1">
-                                Run history
-                            </p>
-                            {jobs.length === 0 && <p className="text-xs text-t3 px-1">No runs yet.</p>}
+                            {jobs.length === 0 && <p className="text-xs text-t3 px-1 py-4 text-center">No previous runs yet.</p>}
                             {jobs.map((job) => (
                                 <JobCard
                                     key={job.id}
@@ -344,179 +506,267 @@ export default function BatchInferencePage() {
                         </div>
                     </aside>
 
+                    {/* Main Content Area */}
                     <main className="flex-1 overflow-y-auto p-6">
                         {error && (
-                            <div className="mb-4 p-3 bg-errBg border border-errLn rounded-lg text-sm text-err">
+                            <div className="mb-6 p-4 bg-errBg border border-errLn rounded-2xl text-sm text-err">
                                 {error}
                             </div>
                         )}
 
                         {mode === "run" && selectedJob ? (
-                            <div className="max-w-3xl">
+                            <div className="max-w-4xl">
                                 <InferenceProgressPanel
                                     job={selectedJob}
                                     onCancel={handleCancel}
                                     isCancelling={isCancelling}
                                     onReview={() =>
                                         navigate(`/dataset/${datasetId}/review`, {
-                                            state: { onlySubmitted: false },
-                                        })
+                                             state: { onlySubmitted: false },
+                                         })
                                     }
                                     onDelete={handleDelete}
+                                    onLoadIntoPlanner={handleLoadJobIntoPlanner}
                                     onOpenImage={(imageId) =>
                                         navigate(`/dataset/${datasetId}/annotate/${imageId}`)
                                     }
                                 />
                             </div>
                         ) : isLoading ? (
-                            <p className="flex items-center gap-2 text-sm text-t3">
-                                <Loader2 className="w-4 h-4 animate-spin" /> Loading models and
-                                labels…
-                            </p>
+                            <div className="flex items-center justify-center p-12 text-sm text-t3 gap-2">
+                                <Loader2 className="w-5 h-5 animate-spin text-ac" />
+                                <span>Loading dataset models, policies, and labels…</span>
+                            </div>
                         ) : (
-                            <div className="max-w-3xl space-y-8">
-                                <section>
-                                    <h2 className="text-base font-semibold text-t1 mb-1">
-                                        1. Which images
-                                    </h2>
-                                    <div className="flex flex-wrap gap-2">
-                                        {SCOPE_OPTIONS.map((option) => (
-                                            <button
-                                                key={option.value}
-                                                type="button"
-                                                onClick={() => setImageSelection(option.value)}
-                                                aria-pressed={imageSelection === option.value}
-                                                className={`px-3 py-1.5 text-sm rounded-lg border transition-colors ${
-                                                    imageSelection === option.value
-                                                        ? "border-acLn bg-acS text-ac"
-                                                        : "border-ln bg-p1 text-t2 hover:bg-hv"
-                                                }`}
-                                            >
-                                                {option.label}
-                                                <span className="ml-1.5 text-[11px] text-t3">
-                                                    {(scope[option.countKey] ?? 0).toLocaleString()}
-                                                </span>
-                                            </button>
-                                        ))}
+                            <div className="max-w-4xl space-y-8">
+                                {/* Batch Inference Runner */}
+                                <section className="border border-ln rounded-3xl bg-p1 p-6 shadow-xs space-y-8">
+                                    <div>
+                                        <h2 className="text-lg font-semibold text-t1 flex items-center gap-2">
+                                            <Wand2 size={20} className="text-ac" />
+                                            Launch Batch Inference Run
+                                        </h2>
+                                        <p className="text-xs text-t3 mt-1">
+                                            Execute autonomous segmentation across your dataset images using the configured label plan.
+                                        </p>
+                                    </div>
+
+                                    {/* Step A: Scope */}
+                                    <div>
+                                        <h3 className="text-sm font-semibold text-t1 mb-2">
+                                            1. Scope (Which images to annotate)
+                                        </h3>
+                                        <div className="flex flex-wrap gap-2">
+                                            {SCOPE_OPTIONS.map((option) => (
+                                                <button
+                                                    key={option.value}
+                                                    type="button"
+                                                    onClick={() => setImageSelection(option.value)}
+                                                    aria-pressed={imageSelection === option.value}
+                                                    className={`px-3 py-1.5 text-xs font-medium rounded-xl border transition-colors ${
+                                                        imageSelection === option.value
+                                                            ? "border-acLn bg-acS text-ac shadow-xs"
+                                                            : "border-ln bg-p1 text-t2 hover:bg-hv"
+                                                    }`}
+                                                >
+                                                    {option.label}
+                                                    <span className="ml-1.5 text-[11px] text-t3 font-normal">
+                                                        ({(scope[option.countKey] ?? 0).toLocaleString()})
+                                                    </span>
+                                                </button>
+                                            ))}
+                                        </div>
+                                    </div>
+
+                                    {/* Step B: Label Model Planner */}
+                                    <div>
+                                        <div className="flex flex-wrap items-center justify-between gap-3 mb-3">
+                                            <div>
+                                                <h3 className="text-sm font-semibold text-t1">
+                                                    2. Batch Label Plan
+                                                </h3>
+                                                <p className="text-xs text-t3">
+                                                    Specify which model executes each label in this batch run.
+                                                </p>
+                                            </div>
+
+                                            <div className="flex items-center gap-3">
+                                                {batchEligibleBindings.length > 0 && (
+                                                    <div className="flex flex-wrap items-center gap-2">
+                                                        <button
+                                                            type="button"
+                                                            onClick={() => handleApplyFilter("all")}
+                                                            aria-pressed={appliedFilter === "all"}
+                                                            className={`inline-flex items-center gap-1.5 px-3 py-1 text-xs font-medium rounded-xl border transition-all ${
+                                                                appliedFilter === "all"
+                                                                    ? "border-acLn bg-acS text-ac font-semibold shadow-xs"
+                                                                    : "border-ln bg-p1 text-t2 hover:bg-hv hover:text-t1"
+                                                            }`}
+                                                            title="Apply all batch routes from dataset policy"
+                                                        >
+                                                            {appliedFilter === "all" ? (
+                                                                <Check size={13} className="text-ac" />
+                                                            ) : (
+                                                                <ArrowRight size={13} className="text-t3" />
+                                                            )}
+                                                            <span>Apply All Routes</span>
+                                                        </button>
+                                                        {hasInstanceRoutes && hasCrossRoutes && (
+                                                            <>
+                                                                <button
+                                                                    type="button"
+                                                                    onClick={() => handleApplyFilter("instance-segmentation")}
+                                                                    aria-pressed={appliedFilter === "instance-segmentation"}
+                                                                    className={`inline-flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium rounded-xl border transition-all ${
+                                                                        appliedFilter === "instance-segmentation"
+                                                                            ? "border-acLn bg-acS text-ac font-semibold shadow-xs"
+                                                                            : "border-ln bg-p1 text-t2 hover:bg-hv hover:text-t1"
+                                                                    }`}
+                                                                    title="Apply only Instance Segmentation routes"
+                                                                >
+                                                                    {appliedFilter === "instance-segmentation" && (
+                                                                        <Check size={13} className="text-ac" />
+                                                                    )}
+                                                                    <span>Instance Seg Only</span>
+                                                                </button>
+                                                                <button
+                                                                    type="button"
+                                                                    onClick={() => handleApplyFilter("cross-image-suggestion")}
+                                                                    aria-pressed={appliedFilter === "cross-image-suggestion"}
+                                                                    className={`inline-flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium rounded-xl border transition-all ${
+                                                                        appliedFilter === "cross-image-suggestion"
+                                                                            ? "border-acLn bg-acS text-ac font-semibold shadow-xs"
+                                                                            : "border-ln bg-p1 text-t2 hover:bg-hv hover:text-t1"
+                                                                    }`}
+                                                                    title="Apply only Cross-Image Suggestion routes"
+                                                                >
+                                                                    {appliedFilter === "cross-image-suggestion" && (
+                                                                        <Check size={13} className="text-ac" />
+                                                                    )}
+                                                                    <span>Cross-Image Only</span>
+                                                                </button>
+                                                            </>
+                                                        )}
+                                                    </div>
+                                                )}
+
+                                                <Link
+                                                    to={`/dataset/${datasetId}/model-orchestration`}
+                                                    className="inline-flex items-center gap-1 text-xs font-medium text-ac hover:underline"
+                                                >
+                                                    <Cpu size={13} />
+                                                    <span>Edit model routing</span>
+                                                </Link>
+                                            </div>
+                                        </div>
+                                        <LabelModelPlanner
+                                            labelsById={labelsById}
+                                            models={catalog.models}
+                                            strategies={catalog.retrieval_strategies}
+                                            steps={steps}
+                                            onChange={setStep}
+                                            allowedTasks={BATCH_INFERENCE_TASKS}
+                                        />
+                                    </div>
+
+                                    {/* Step C: Annotation Mode */}
+                                    <div>
+                                        <h3 className="text-sm font-semibold text-t1 mb-2">
+                                            3. Annotation Write Mode
+                                        </h3>
+                                        <WriteModeSelector
+                                            options={options}
+                                            onChange={setOptions}
+                                            replacePreview={replacePreview}
+                                        />
+                                    </div>
+
+                                    {/* Step D: Nested Objects */}
+                                    {steps.some((step) => (labelsById[step.label_id]?.parent_id ?? null) !== null) && (
+                                        <div>
+                                            <h3 className="text-sm font-semibold text-t1 mb-2">
+                                                4. Nested Objects Hierarchy
+                                            </h3>
+                                            <label className="flex items-center gap-2 text-xs text-t2 cursor-pointer">
+                                                <input
+                                                    type="checkbox"
+                                                    checked={options.unparented === "keep_at_root"}
+                                                    onChange={(event) =>
+                                                        setOptions({
+                                                            ...options,
+                                                            unparented: event.target.checked
+                                                                ? "keep_at_root"
+                                                                : "drop",
+                                                        })
+                                                    }
+                                                    className="h-4 w-4 rounded border-ln text-ac focus:ring-ac"
+                                                />
+                                                <span>Keep child predictions that fall outside parent bounding boundaries</span>
+                                            </label>
+                                        </div>
+                                    )}
+
+                                    {/* Run Name */}
+                                    <div>
+                                        <label
+                                            htmlFor="inference-run-name"
+                                            className="block text-xs font-semibold text-t1 uppercase tracking-wide mb-1"
+                                        >
+                                            Run Name <span className="text-t3 font-normal">(optional)</span>
+                                        </label>
+                                        <input
+                                            id="inference-run-name"
+                                            type="text"
+                                            value={runName}
+                                            onChange={(event) => setRunName(event.target.value)}
+                                            maxLength={80}
+                                            aria-invalid={Boolean(runNameError)}
+                                            placeholder="e.g. Pass 1 — Cells & Nuclei"
+                                            className={`w-full px-3 py-2 text-xs border rounded-xl bg-well text-t1 focus:ring-2 focus:ring-ac focus:border-transparent ${
+                                                runNameError ? "border-errLn" : "border-ln"
+                                            }`}
+                                        />
+                                        {runNameError && (
+                                            <p className="text-[11px] text-err mt-1">{runNameError}</p>
+                                        )}
+                                    </div>
+
+                                    {hasActiveRun && (
+                                        <div className="p-3.5 bg-amber-50 border border-amber-200 dark:bg-amber-950/30 dark:border-amber-800 rounded-2xl text-xs text-amber-800 dark:text-amber-300">
+                                            A batch inference job is currently active for this dataset. Please wait for it to finish or cancel it before starting a new run.
+                                        </div>
+                                    )}
+
+                                    {/* Action Buttons */}
+                                    <div className="flex items-center gap-4 pt-2">
+                                        <button
+                                            type="button"
+                                            onClick={handleStart}
+                                            disabled={!canStart}
+                                            className={`inline-flex items-center gap-2 px-6 py-2.5 text-xs font-semibold text-white rounded-xl shadow-xs transition disabled:opacity-50 ${
+                                                options.write_mode === "replace" ? "bg-red-600 hover:bg-red-700" : "bg-accent hover:bg-accent/90"
+                                            }`}
+                                        >
+                                            {isStarting ? (
+                                                <Loader2 className="w-4 h-4 animate-spin" />
+                                            ) : (
+                                                <Play size={14} className="fill-white" />
+                                            )}
+                                            <span>{isStarting ? "Starting Run…" : "Start Batch Inference"}</span>
+                                        </button>
+
+                                        {steps.length > 0 && scopeCount > 0 && (
+                                            <span className="text-xs text-t3">
+                                                {(steps.length * scopeCount).toLocaleString()} total tasks ({steps.length} label{steps.length === 1 ? "" : "s"} × {scopeCount.toLocaleString()} images)
+                                            </span>
+                                        )}
+                                        {steps.length === 0 && (
+                                            <span className="text-xs text-t3">
+                                                Configure at least one label in the batch plan.
+                                            </span>
+                                        )}
                                     </div>
                                 </section>
-
-                                <section>
-                                    <h2 className="text-base font-semibold text-t1 mb-1">
-                                        2. Which model annotates which label
-                                    </h2>
-                                    <p className="text-xs text-t3 mb-3">
-                                        Bind a model to each label you want annotated. Labels left on
-                                        “Skip” are untouched.
-                                    </p>
-                                    <LabelModelPlanner
-                                        labelsById={labelsById}
-                                        models={catalog.models}
-                                        strategies={catalog.retrieval_strategies}
-                                        steps={steps}
-                                        onChange={setStep}
-                                    />
-                                </section>
-
-                                <section>
-                                    <h2 className="text-base font-semibold text-t1 mb-1">
-                                        3. What happens to existing annotations
-                                    </h2>
-                                    <WriteModeSelector
-                                        options={options}
-                                        onChange={setOptions}
-                                        replacePreview={replacePreview}
-                                    />
-                                </section>
-
-                                {steps.some((step) => (labelsById[step.label_id]?.parent_id ?? null) !== null) && (
-                                    <section>
-                                        <h2 className="text-base font-semibold text-t1 mb-1">
-                                            4. Nested objects
-                                        </h2>
-                                        <label className="flex items-center gap-2 text-sm text-t2">
-                                            <input
-                                                type="checkbox"
-                                                checked={options.unparented === "keep_at_root"}
-                                                onChange={(event) =>
-                                                    setOptions({
-                                                        ...options,
-                                                        unparented: event.target.checked
-                                                            ? "keep_at_root"
-                                                            : "drop",
-                                                    })
-                                                }
-                                                className="h-4 w-4"
-                                            />
-                                            Keep predictions that fall outside every parent object
-                                        </label>
-                                        <p className="text-[11px] text-t3 mt-1">
-                                            Off by default: a nested object predicted outside any
-                                            parent is usually a false positive.
-                                        </p>
-                                    </section>
-                                )}
-
-                                <section>
-                                    <label
-                                        htmlFor="inference-run-name"
-                                        className="block text-sm font-medium text-t1 mb-1"
-                                    >
-                                        Run name <span className="text-t3 font-normal">(optional)</span>
-                                    </label>
-                                    <input
-                                        id="inference-run-name"
-                                        type="text"
-                                        value={runName}
-                                        onChange={(event) => setRunName(event.target.value)}
-                                        maxLength={80}
-                                        aria-invalid={Boolean(runNameError)}
-                                        placeholder="e.g. Cells + nuclei, first pass"
-                                        className={`w-full px-3 py-2 text-sm border rounded-lg bg-well text-t1 focus:ring-2 focus:ring-ac focus:border-transparent ${
-                                            runNameError ? "border-errLn" : "border-ln"
-                                        }`}
-                                    />
-                                    {runNameError && (
-                                        <p className="text-[11px] text-err mt-1">{runNameError}</p>
-                                    )}
-                                </section>
-
-                                {hasActiveRun && (
-                                    <p className="p-3 bg-warnBg border border-warnLn rounded-lg text-sm text-warn">
-                                        A run is already going on this dataset. Wait for it to finish
-                                        or stop it first — two runs writing the same images would
-                                        fight over duplicates.
-                                    </p>
-                                )}
-
-                                <div className="flex items-center gap-3">
-                                    <button
-                                        onClick={handleStart}
-                                        disabled={!canStart}
-                                        className={`inline-flex items-center gap-2 px-5 py-2.5 text-sm font-medium text-onAccent rounded-lg hover:brightness-110 transition-colors disabled:opacity-60 ${
-                                            options.write_mode === "replace" ? "bg-err" : "bg-accent"
-                                        }`}
-                                    >
-                                        {isStarting ? (
-                                            <Loader2 className="w-4 h-4 animate-spin" />
-                                        ) : (
-                                            <Wand2 className="w-4 h-4" />
-                                        )}
-                                        {isStarting ? "Starting…" : "Start Inference"}
-                                    </button>
-                                    {steps.length > 0 && scopeCount > 0 && (
-                                        <span className="text-xs text-t3">
-                                            {(steps.length * scopeCount).toLocaleString()} model runs
-                                            ({steps.length} label{steps.length === 1 ? "" : "s"} ×{" "}
-                                            {scopeCount.toLocaleString()} images)
-                                        </span>
-                                    )}
-                                    {steps.length === 0 && (
-                                        <span className="text-xs text-t3">
-                                            Bind at least one label to a model.
-                                        </span>
-                                    )}
-                                </div>
                             </div>
                         )}
                     </main>

--- a/src/pages/BatchInferencePage.test.jsx
+++ b/src/pages/BatchInferencePage.test.jsx
@@ -1,0 +1,311 @@
+import React from "react";
+import { render, screen, waitFor, act, fireEvent } from "@testing-library/react";
+import { vi, describe, it, expect, beforeEach } from "vitest";
+import BatchInferencePage from "./BatchInferencePage";
+import { fetchLabels } from "../api/labels";
+import {
+    getInferenceModelCatalog,
+    getInferenceScopeCounts,
+    getInferenceJobs,
+    startInferenceJob,
+    cancelInferenceJob,
+    streamInferenceJob,
+    previewInferenceReplace,
+    getInferenceRoutingPolicy,
+    deleteInferenceJob,
+} from "../api/inference";
+
+const { mockRoute } = vi.hoisted(() => ({
+    mockRoute: { datasetId: "101" },
+}));
+
+vi.mock("react-router-dom", () => ({
+    useParams: () => ({ datasetId: mockRoute.datasetId }),
+    useNavigate: () => vi.fn(),
+    Link: ({ to, children, ...props }) => (
+        <a href={to} {...props}>
+            {children}
+        </a>
+    ),
+}));
+
+vi.mock("../contexts/DatasetContext", () => ({
+    useDataset: () => ({ currentDataset: { id: mockRoute.datasetId, name: "Test Dataset" } }),
+}));
+
+vi.mock("../hooks/usePermissions", () => ({
+    usePermissions: () => ({ can: () => true }),
+}));
+
+vi.mock("../components/datasets/gallery/DatasetManagementLayout", () => ({
+    default: ({ children }) => <div data-testid="layout">{children}</div>,
+}));
+
+vi.mock("../components/inference/LabelModelPlanner", () => ({
+    default: ({ steps, onChange }) => (
+        <div data-testid="planner">
+            <span>Planner Component ({steps?.length || 0} steps)</span>
+            <button
+                onClick={() =>
+                    onChange?.(1, {
+                        label_id: 1,
+                        model_registry_key: "m2f",
+                        task: "instance-segmentation",
+                        inputs: null,
+                    })
+                }
+                data-testid="add-step-btn"
+            >
+                Add Step
+            </button>
+        </div>
+    ),
+}));
+
+vi.mock("../components/inference/InferenceProgressPanel", () => ({
+    STATUS_STYLE: {
+        pending: "bg-well text-t2",
+        running: "bg-acS text-ac",
+        cancelling: "bg-warnBg text-warn",
+        succeeded: "bg-okBg text-ok",
+        partial: "bg-warnBg text-warn",
+        failed: "bg-errBg text-err",
+        cancelled: "bg-well text-t3",
+    },
+    TERMINAL_JOB_STATUSES: new Set(["succeeded", "partial", "failed", "cancelled"]),
+    default: ({ job, onCancel, isCancelling, onDelete, onLoadIntoPlanner }) => (
+        <div data-testid="progress-panel">
+            <span data-testid="progress-job-id">{job?.id}</span>
+            <span data-testid="progress-is-cancelling">{isCancelling ? "Cancelling" : "Not Cancelling"}</span>
+            <button onClick={onCancel} disabled={isCancelling}>Cancel Run</button>
+            <button onClick={onDelete} data-testid="delete-job-btn">Delete Run</button>
+            <button onClick={() => onLoadIntoPlanner?.(job)} data-testid="load-into-planner">Load into Planner</button>
+        </div>
+    ),
+}));
+
+vi.mock("../api/labels", () => ({
+    fetchLabels: vi.fn(),
+}));
+
+vi.mock("../api/inference", () => ({
+    getInferenceModelCatalog: vi.fn(),
+    getInferenceScopeCounts: vi.fn(),
+    getInferenceJobs: vi.fn(),
+    startInferenceJob: vi.fn(),
+    cancelInferenceJob: vi.fn(),
+    deleteInferenceJob: vi.fn(),
+    streamInferenceJob: vi.fn(),
+    previewInferenceReplace: vi.fn(),
+    getInferenceRoutingPolicy: vi.fn(),
+}));
+
+describe("BatchInferencePage execution workflow and policy integration", () => {
+    const mockAbort = vi.fn();
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockRoute.datasetId = "101";
+
+        fetchLabels.mockResolvedValue({
+            labels: {
+                id_to_label_object: {
+                    1: { id: 1, name: "Cell", color: "#ff0000" },
+                    2: { id: 2, name: "Nucleus", color: "#00ff00" },
+                },
+            },
+        });
+        getInferenceModelCatalog.mockResolvedValue({
+            models: [
+                { registry_key: "m2f", name: "Mask2Former", task: "instance-segmentation", label_ids: [] },
+                { registry_key: "sam3-cross", name: "SAM 3 Cross", task: "cross-image-suggestion", label_ids: [] },
+            ],
+            retrieval_strategies: [],
+        });
+        getInferenceScopeCounts.mockResolvedValue({
+            total: 10,
+            not_started: 5,
+            unreviewed: 3,
+        });
+        getInferenceRoutingPolicy.mockResolvedValue(null);
+        getInferenceJobs.mockResolvedValue([]);
+        previewInferenceReplace.mockResolvedValue({
+            contours: 0,
+            images: 0,
+            reviewed_contours: 0,
+            root_contours: 0,
+            protected_contours: 0,
+        });
+        streamInferenceJob.mockReturnValue({ abort: mockAbort });
+    });
+
+    it("resets active run view, stream, and jobs when switching datasets", async () => {
+        const activeJobA = {
+            id: 999,
+            dataset_id: 101,
+            status: "running",
+            created_at: new Date().toISOString(),
+            steps: [{ label_id: 1, model_registry_key: "m2f", task: "instance-segmentation" }],
+            image_count: 10,
+            completed_images: 2,
+        };
+        getInferenceJobs.mockResolvedValueOnce([activeJobA]);
+
+        const { rerender } = render(<BatchInferencePage />);
+
+        await waitFor(() => {
+            expect(screen.getByTestId("progress-panel")).toBeInTheDocument();
+            expect(screen.getByTestId("progress-job-id")).toHaveTextContent("999");
+            expect(streamInferenceJob).toHaveBeenCalledWith(999, expect.any(Function), expect.any(Function));
+        });
+
+        // Switch to Dataset 202 which has no jobs and no active run
+        mockRoute.datasetId = "202";
+        getInferenceJobs.mockResolvedValueOnce([]);
+        getInferenceRoutingPolicy.mockResolvedValueOnce(null);
+
+        rerender(<BatchInferencePage />);
+
+        expect(mockAbort).toHaveBeenCalled();
+
+        await waitFor(() => {
+            expect(screen.queryByTestId("progress-panel")).not.toBeInTheDocument();
+            expect(screen.queryByTestId("orchestration-panel")).not.toBeInTheDocument();
+        });
+    });
+
+    it("does not render policy editor controls and provides link to Model Orchestration page", async () => {
+        render(<BatchInferencePage />);
+
+        await waitFor(() => {
+            expect(screen.getByTestId("planner")).toBeInTheDocument();
+        });
+
+        expect(screen.queryByTestId("orchestration-panel")).not.toBeInTheDocument();
+        expect(screen.queryByText(/Dataset Model Routing/i)).not.toBeInTheDocument();
+
+        const editLink = screen.getByRole("link", { name: /edit model routing/i });
+        expect(editLink).toBeInTheDocument();
+        expect(editLink).toHaveAttribute("href", "/dataset/101/model-orchestration");
+    });
+
+    it("loads saved routing policy and automatically pre-fills batch plan when single batch task exists", async () => {
+        const singleTaskPolicy = {
+            dataset_id: 101,
+            bindings: [
+                {
+                    task: "instance-segmentation",
+                    label_id: 1,
+                    model_registry_key: "m2f",
+                    inputs: null,
+                },
+            ],
+            updated_by: "tester",
+            created_at: "2026-08-24T10:00:00Z",
+            updated_at: "2026-08-24T12:00:00Z",
+        };
+        getInferenceRoutingPolicy.mockResolvedValueOnce(singleTaskPolicy);
+
+        render(<BatchInferencePage />);
+
+        await waitFor(() => {
+            expect(screen.getByTestId("planner")).toHaveTextContent("Planner Component (1 steps)");
+        });
+    });
+
+    it("renders compact chooser buttons when dual batch tasks exist and applies selected routes", async () => {
+        const dualTaskPolicy = {
+            dataset_id: 101,
+            bindings: [
+                {
+                    task: "instance-segmentation",
+                    label_id: 1,
+                    model_registry_key: "m2f",
+                    inputs: null,
+                },
+                {
+                    task: "cross-image-suggestion",
+                    label_id: 2,
+                    model_registry_key: "sam3-cross",
+                    inputs: null,
+                },
+            ],
+            updated_by: "tester",
+        };
+        getInferenceRoutingPolicy.mockResolvedValueOnce(dualTaskPolicy);
+
+        render(<BatchInferencePage />);
+
+        await waitFor(() => {
+            expect(screen.getByRole("button", { name: /apply all routes/i })).toBeInTheDocument();
+            expect(screen.getByRole("button", { name: /instance seg only/i })).toBeInTheDocument();
+            expect(screen.getByRole("button", { name: /cross-image only/i })).toBeInTheDocument();
+        });
+
+        // Click Apply All Routes
+        const applyAllBtn = screen.getByRole("button", { name: /apply all routes/i });
+        fireEvent.click(applyAllBtn);
+        expect(screen.getByTestId("planner")).toHaveTextContent("Planner Component (2 steps)");
+        expect(applyAllBtn).toHaveAttribute("aria-pressed", "true");
+
+        // Click Instance Seg Only
+        const instanceOnlyBtn = screen.getByRole("button", { name: /instance seg only/i });
+        fireEvent.click(instanceOnlyBtn);
+        expect(screen.getByTestId("planner")).toHaveTextContent("Planner Component (1 steps)");
+        expect(instanceOnlyBtn).toHaveAttribute("aria-pressed", "true");
+        expect(applyAllBtn).toHaveAttribute("aria-pressed", "false");
+
+        // Click Cross-Image Only
+        const crossOnlyBtn = screen.getByRole("button", { name: /cross-image only/i });
+        fireEvent.click(crossOnlyBtn);
+        expect(screen.getByTestId("planner")).toHaveTextContent("Planner Component (1 steps)");
+        expect(crossOnlyBtn).toHaveAttribute("aria-pressed", "true");
+        expect(instanceOnlyBtn).toHaveAttribute("aria-pressed", "false");
+    });
+
+    it("starts a batch inference run and transitions to run mode", async () => {
+        const createdJob = {
+            id: 888,
+            dataset_id: 101,
+            status: "running",
+            created_at: new Date().toISOString(),
+            steps: [{ label_id: 1, model_registry_key: "m2f", task: "instance-segmentation" }],
+            image_count: 10,
+            completed_images: 0,
+        };
+        startInferenceJob.mockResolvedValueOnce(createdJob);
+
+        render(<BatchInferencePage />);
+
+        await waitFor(() => {
+            expect(screen.getByTestId("planner")).toBeInTheDocument();
+        });
+
+        // Add step to planner
+        fireEvent.click(screen.getByTestId("add-step-btn"));
+
+        // Click start batch inference button
+        const startBtn = screen.getByRole("button", { name: /start batch inference/i });
+        expect(startBtn).not.toBeDisabled();
+
+        fireEvent.click(startBtn);
+
+        await waitFor(() => {
+            expect(startInferenceJob).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    dataset_id: 101,
+                    steps: [
+                        {
+                            label_id: 1,
+                            model_registry_key: "m2f",
+                            task: "instance-segmentation",
+                            inputs: null,
+                        },
+                    ],
+                })
+            );
+            expect(screen.getByTestId("progress-panel")).toBeInTheDocument();
+            expect(screen.getByTestId("progress-job-id")).toHaveTextContent("888");
+        });
+    });
+});

--- a/src/pages/ModelOrchestrationPage.jsx
+++ b/src/pages/ModelOrchestrationPage.jsx
@@ -1,0 +1,235 @@
+import React, { useState, useEffect, useRef } from "react";
+import { useParams, useNavigate, Link } from "react-router-dom";
+import { Cpu, Loader2, ArrowLeft, AlertTriangle } from "lucide-react";
+import DatasetManagementLayout from "../components/datasets/gallery/DatasetManagementLayout";
+import { useDataset } from "../contexts/DatasetContext";
+import {
+    getInferenceModelCatalog,
+    getInferenceRoutingPolicy,
+    updateInferenceRoutingPolicy,
+    deleteInferenceRoutingPolicy,
+} from "../api/inference";
+import { fetchLabels } from "../api/labels";
+import ModelOrchestrationPanel from "../components/inference/ModelOrchestrationPanel";
+import { usePermissions } from "../hooks/usePermissions";
+import { Permission } from "../utils/permissions";
+
+/**
+ * Model Orchestration Page
+ *
+ * Dedicated dataset management page for configuring dataset-level task and label
+ * routing policies. These policies serve as canonical defaults for interactive
+ * annotation tools, cross-image suggestions, and batch inference runs.
+ */
+export default function ModelOrchestrationPage() {
+    const { datasetId } = useParams();
+    const { currentDataset, loading: datasetLoading } = useDataset();
+    const navigate = useNavigate();
+    const { can } = usePermissions(datasetId);
+
+    const canEdit = Boolean(can(Permission.AI_BATCH_INFER));
+    const canView = Boolean(can(Permission.AI_INTERACTIVE) || can(Permission.AI_BATCH_INFER));
+
+    const [labelsById, setLabelsById] = useState({});
+    const [catalog, setCatalog] = useState({ models: [], retrieval_strategies: [] });
+    const [policy, setPolicy] = useState(null);
+    const [isSaving, setIsSaving] = useState(false);
+    const [isDeleting, setIsDeleting] = useState(false);
+    const [isLoading, setIsLoading] = useState(true);
+    const [error, setError] = useState(null);
+
+    const datasetIdRef = useRef(datasetId);
+    datasetIdRef.current = datasetId;
+    const isMountedRef = useRef(true);
+
+    useEffect(() => {
+        isMountedRef.current = true;
+        return () => {
+            isMountedRef.current = false;
+        };
+    }, []);
+
+    useEffect(() => {
+        if (!datasetId || !canView) {
+            if (!datasetLoading) {
+                setIsLoading(false);
+            }
+            return undefined;
+        }
+        let cancelled = false;
+        setIsLoading(true);
+        setError(null);
+        setIsSaving(false);
+        setIsDeleting(false);
+        setPolicy(null);
+        setLabelsById({});
+        setCatalog({ models: [], retrieval_strategies: [] });
+
+        (async () => {
+            try {
+                const [labelResponse, catalogResponse, policyResponse] = await Promise.all([
+                    fetchLabels(datasetId),
+                    getInferenceModelCatalog(datasetId),
+                    getInferenceRoutingPolicy(datasetId),
+                ]);
+                if (cancelled || !isMountedRef.current || datasetIdRef.current !== datasetId) return;
+
+                const loadedLabels = labelResponse?.labels?.id_to_label_object || {};
+                const loadedCatalog = catalogResponse || { models: [], retrieval_strategies: [] };
+
+                setLabelsById(loadedLabels);
+                setCatalog(loadedCatalog);
+                setPolicy(policyResponse);
+            } catch (e) {
+                if (!cancelled && isMountedRef.current && datasetIdRef.current === datasetId) {
+                    setError(e.message || "Could not load the models or routing policy for this dataset.");
+                }
+            } finally {
+                if (!cancelled && isMountedRef.current && datasetIdRef.current === datasetId) {
+                    setIsLoading(false);
+                }
+            }
+        })();
+
+        return () => {
+            cancelled = true;
+        };
+    }, [datasetId, canView, datasetLoading]);
+
+    const handleSavePolicy = async (bindings) => {
+        const targetDatasetId = datasetId;
+        setError(null);
+        setIsSaving(true);
+        try {
+            const updated = await updateInferenceRoutingPolicy({
+                dataset_id: Number(targetDatasetId),
+                bindings,
+            });
+            if (!isMountedRef.current || datasetIdRef.current !== targetDatasetId) return;
+            setPolicy(updated);
+            return updated;
+        } catch (e) {
+            if (isMountedRef.current && datasetIdRef.current === targetDatasetId) {
+                setError(e.message || "Failed to save dataset routing policy.");
+            }
+            throw e;
+        } finally {
+            if (isMountedRef.current && datasetIdRef.current === targetDatasetId) {
+                setIsSaving(false);
+            }
+        }
+    };
+
+    const handleDeletePolicy = async () => {
+        const targetDatasetId = datasetId;
+        setError(null);
+        setIsDeleting(true);
+        try {
+            await deleteInferenceRoutingPolicy(targetDatasetId);
+            if (!isMountedRef.current || datasetIdRef.current !== targetDatasetId) return;
+            setPolicy(null);
+        } catch (e) {
+            if (isMountedRef.current && datasetIdRef.current === targetDatasetId) {
+                setError(e.message || "Failed to clear dataset routing policy.");
+            }
+            throw e;
+        } finally {
+            if (isMountedRef.current && datasetIdRef.current === targetDatasetId) {
+                setIsDeleting(false);
+            }
+        }
+    };
+
+    return (
+        <DatasetManagementLayout>
+            <div className="flex flex-col h-full bg-well min-h-0 overflow-hidden">
+                {/* Header */}
+                <header className="p-4 px-6 border-b border-ln bg-p1 flex items-center justify-between flex-shrink-0">
+                    <div className="flex items-center gap-3">
+                        <Link
+                            to={`/dataset/${datasetId}/datamanagement`}
+                            className="p-1.5 rounded-xl border border-ln bg-p1 text-t2 hover:bg-hv hover:text-t1 transition"
+                            title="Back to Dataset Management"
+                            aria-label="Back to Dataset Management"
+                        >
+                            <ArrowLeft size={16} />
+                        </Link>
+                        <div>
+                            <h1 className="text-base font-semibold text-t1 flex items-center gap-2">
+                                <Cpu size={18} className="text-ac" />
+                                <span>Model Orchestration</span>
+                                {currentDataset?.name && (
+                                    <span className="text-xs font-normal text-t3">
+                                        — {currentDataset.name}
+                                    </span>
+                                )}
+                            </h1>
+                            <p className="text-xs text-t3">
+                                Configure default models and per-label routing policies for interactive tools, cross-image suggestions, and batch runs.
+                            </p>
+                        </div>
+                    </div>
+
+                    <div className="flex items-center gap-2">
+                        <button
+                            type="button"
+                            onClick={() => navigate(`/dataset/${datasetId}/datamanagement`)}
+                            className="inline-flex items-center gap-1.5 px-3.5 py-1.5 text-xs font-medium border border-ln rounded-xl bg-p1 text-t1 hover:bg-hv transition"
+                        >
+                            <ArrowLeft size={13} />
+                            <span>Dataset Management</span>
+                        </button>
+                    </div>
+                </header>
+
+                {/* Main Content Area */}
+                <main className="flex-1 overflow-y-auto p-6">
+                    {error && (
+                        <div className="mb-6 p-4 bg-errBg border border-errLn rounded-2xl text-sm text-err flex items-center gap-2 max-w-4xl">
+                            <AlertTriangle size={16} />
+                            <span>{error}</span>
+                        </div>
+                    )}
+
+                    {datasetLoading || (isLoading && canView) ? (
+                        <div className="flex items-center justify-center p-12 text-sm text-t3 gap-2">
+                            <Loader2 className="w-5 h-5 animate-spin text-ac" />
+                            <span>Loading dataset models, routing policy, and labels…</span>
+                        </div>
+                    ) : !canView ? (
+                        <div className="max-w-4xl p-6 bg-p1 border border-ln rounded-3xl text-center space-y-3">
+                            <h2 className="text-sm font-semibold text-t1">Access Restricted</h2>
+                            <p className="text-xs text-t3">
+                                You do not have permission to view or configure model orchestration for this dataset.
+                            </p>
+                            <button
+                                type="button"
+                                onClick={() => navigate(`/dataset/${datasetId}/datamanagement`)}
+                                className="inline-flex items-center gap-1.5 px-4 py-2 text-xs font-medium bg-accent text-white rounded-xl hover:bg-accent/90 transition"
+                            >
+                                <ArrowLeft size={13} />
+                                <span>Return to Dataset Management</span>
+                            </button>
+                        </div>
+                    ) : (
+                        <div className="max-w-4xl">
+                            <section className="border border-ln rounded-3xl bg-p1 p-6 shadow-xs">
+                                <ModelOrchestrationPanel
+                                    datasetId={Number(datasetId)}
+                                    policy={policy}
+                                    labelsById={labelsById}
+                                    catalog={catalog}
+                                    onSavePolicy={handleSavePolicy}
+                                    onDeletePolicy={handleDeletePolicy}
+                                    isSaving={isSaving}
+                                    isDeleting={isDeleting}
+                                    canEdit={canEdit}
+                                />
+                            </section>
+                        </div>
+                    )}
+                </main>
+            </div>
+        </DatasetManagementLayout>
+    );
+}

--- a/src/pages/ModelOrchestrationPage.test.jsx
+++ b/src/pages/ModelOrchestrationPage.test.jsx
@@ -1,0 +1,275 @@
+import React from "react";
+import { render, screen, waitFor, fireEvent, act } from "@testing-library/react";
+import { vi, describe, it, expect, beforeEach } from "vitest";
+import ModelOrchestrationPage from "./ModelOrchestrationPage";
+import { fetchLabels } from "../api/labels";
+import {
+    getInferenceModelCatalog,
+    getInferenceRoutingPolicy,
+    updateInferenceRoutingPolicy,
+    deleteInferenceRoutingPolicy,
+} from "../api/inference";
+
+const { mockRoute, mockPermissions, mockDatasetContext } = vi.hoisted(() => ({
+    mockRoute: { datasetId: "101" },
+    mockPermissions: { can: vi.fn(() => true) },
+    mockDatasetContext: { loading: false },
+}));
+
+vi.mock("react-router-dom", () => ({
+    useParams: () => ({ datasetId: mockRoute.datasetId }),
+    useNavigate: () => vi.fn(),
+    Link: ({ to, children, ...props }) => (
+        <a href={to} {...props}>
+            {children}
+        </a>
+    ),
+}));
+
+vi.mock("../contexts/DatasetContext", () => ({
+    useDataset: () => ({
+        currentDataset: { id: mockRoute.datasetId, name: "Test Dataset" },
+        loading: mockDatasetContext.loading,
+    }),
+}));
+
+vi.mock("../hooks/usePermissions", () => ({
+    usePermissions: () => ({ can: mockPermissions.can }),
+}));
+
+vi.mock("../components/datasets/gallery/DatasetManagementLayout", () => ({
+    default: ({ children }) => <div data-testid="layout">{children}</div>,
+}));
+
+vi.mock("../components/inference/ModelOrchestrationPanel", () => ({
+    default: ({ datasetId, policy, labelsById, catalog, onSavePolicy, onDeletePolicy, isSaving, isDeleting, canEdit }) => (
+        <div data-testid="orchestration-panel">
+            <span data-testid="panel-dataset-id">{datasetId}</span>
+            <span data-testid="panel-can-edit">{canEdit ? "editable" : "read-only"}</span>
+            <span data-testid="panel-policy-state">{policy ? `Saved: ${policy.bindings?.length || 0} bindings` : "No Policy"}</span>
+            <button
+                onClick={() =>
+                    onSavePolicy?.([
+                        {
+                            task: "instance-segmentation",
+                            label_id: 1,
+                            model_registry_key: "m2f",
+                            inputs: null,
+                        },
+                    ])
+                }
+                data-testid="save-btn"
+                disabled={!canEdit || isSaving}
+            >
+                Save
+            </button>
+            <button
+                onClick={() => onDeletePolicy?.()}
+                data-testid="delete-btn"
+                disabled={!canEdit || isDeleting}
+            >
+                Delete
+            </button>
+        </div>
+    ),
+}));
+
+vi.mock("../api/labels", () => ({
+    fetchLabels: vi.fn(),
+}));
+
+vi.mock("../api/inference", () => ({
+    getInferenceModelCatalog: vi.fn(),
+    getInferenceRoutingPolicy: vi.fn(),
+    updateInferenceRoutingPolicy: vi.fn(),
+    deleteInferenceRoutingPolicy: vi.fn(),
+}));
+
+describe("ModelOrchestrationPage", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockRoute.datasetId = "101";
+        mockPermissions.can.mockImplementation(() => true);
+        mockDatasetContext.loading = false;
+
+        fetchLabels.mockResolvedValue({
+            success: true,
+            labels: {
+                id_to_label_object: {
+                    1: { id: 1, name: "cell", parent_id: null },
+                },
+            },
+        });
+
+        getInferenceModelCatalog.mockResolvedValue({
+            models: [
+                { registry_key: "m2f", name: "Mask2Former", task: "instance-segmentation" },
+            ],
+            retrieval_strategies: [],
+        });
+
+        getInferenceRoutingPolicy.mockResolvedValue({
+            dataset_id: 101,
+            bindings: [
+                { task: "instance-segmentation", label_id: 1, model_registry_key: "m2f", inputs: null },
+            ],
+            updated_by: "test-user",
+            created_at: "2026-08-24T12:00:00Z",
+            updated_at: "2026-08-24T12:00:00Z",
+        });
+    });
+
+    it("loads labels, catalog, and policy and renders ModelOrchestrationPanel", async () => {
+        render(<ModelOrchestrationPage />);
+
+        expect(screen.getByText(/Loading dataset models, routing policy, and labels…/i)).toBeInTheDocument();
+
+        await waitFor(() => {
+            expect(screen.getByTestId("orchestration-panel")).toBeInTheDocument();
+        });
+
+        expect(screen.getByText(/Model Orchestration/i)).toBeInTheDocument();
+        expect(screen.getByTestId("panel-dataset-id")).toHaveTextContent("101");
+        expect(screen.getByTestId("panel-can-edit")).toHaveTextContent("editable");
+        expect(screen.getByTestId("panel-policy-state")).toHaveTextContent("Saved: 1 bindings");
+    });
+
+    it("handles saving policy and updates state with canonical response", async () => {
+        const canonicalSavedPolicy = {
+            dataset_id: 101,
+            bindings: [
+                { task: "instance-segmentation", label_id: 1, model_registry_key: "m2f", inputs: null },
+            ],
+            updated_by: "current-user",
+            updated_at: "2026-08-24T14:00:00Z",
+        };
+        updateInferenceRoutingPolicy.mockResolvedValueOnce(canonicalSavedPolicy);
+
+        render(<ModelOrchestrationPage />);
+
+        await waitFor(() => {
+            expect(screen.getByTestId("save-btn")).toBeInTheDocument();
+        });
+
+        await act(async () => {
+            fireEvent.click(screen.getByTestId("save-btn"));
+        });
+
+        expect(updateInferenceRoutingPolicy).toHaveBeenCalledWith({
+            dataset_id: 101,
+            bindings: [
+                {
+                    task: "instance-segmentation",
+                    label_id: 1,
+                    model_registry_key: "m2f",
+                    inputs: null,
+                },
+            ],
+        });
+
+        expect(screen.getByTestId("panel-policy-state")).toHaveTextContent("Saved: 1 bindings");
+    });
+
+    it("handles clearing policy and calls deleteInferenceRoutingPolicy", async () => {
+        deleteInferenceRoutingPolicy.mockResolvedValueOnce({ success: true });
+
+        render(<ModelOrchestrationPage />);
+
+        await waitFor(() => {
+            expect(screen.getByTestId("delete-btn")).toBeInTheDocument();
+        });
+
+        await act(async () => {
+            fireEvent.click(screen.getByTestId("delete-btn"));
+        });
+
+        expect(deleteInferenceRoutingPolicy).toHaveBeenCalledWith("101");
+        expect(screen.getByTestId("panel-policy-state")).toHaveTextContent("No Policy");
+    });
+
+    it("passes read-only mode when user has AI_INTERACTIVE but not AI_BATCH_INFER", async () => {
+        mockPermissions.can.mockImplementation((perm) => perm === "ai.interactive");
+
+        render(<ModelOrchestrationPage />);
+
+        await waitFor(() => {
+            expect(screen.getByTestId("orchestration-panel")).toBeInTheDocument();
+        });
+
+        expect(screen.getByTestId("panel-can-edit")).toHaveTextContent("read-only");
+    });
+
+    it("reactively loads data when permissions resolve from unavailable to available without dataset ID change", async () => {
+        mockPermissions.can.mockReturnValue(false);
+
+        const { rerender } = render(<ModelOrchestrationPage />);
+
+        expect(screen.getByText(/Access Restricted/i)).toBeInTheDocument();
+        expect(screen.queryByTestId("orchestration-panel")).not.toBeInTheDocument();
+
+        // Permissions resolve as available for current dataset
+        mockPermissions.can.mockImplementation((perm) => perm === "ai.interactive");
+
+        rerender(<ModelOrchestrationPage />);
+
+        await waitFor(() => {
+            expect(screen.getByTestId("orchestration-panel")).toBeInTheDocument();
+        });
+
+        expect(screen.getByTestId("panel-can-edit")).toHaveTextContent("read-only");
+        expect(screen.getByTestId("panel-policy-state")).toHaveTextContent("Saved: 1 bindings");
+    });
+
+    it("displays access restricted banner when user has no AI permissions", async () => {
+        mockPermissions.can.mockReturnValue(false);
+
+        render(<ModelOrchestrationPage />);
+
+        expect(screen.getByText(/Access Restricted/i)).toBeInTheDocument();
+        expect(screen.queryByTestId("orchestration-panel")).not.toBeInTheDocument();
+    });
+
+    it("displays error banner when loading policy fails", async () => {
+        getInferenceRoutingPolicy.mockRejectedValueOnce(new Error("Network connection failed"));
+
+        render(<ModelOrchestrationPage />);
+
+        await waitFor(() => {
+            expect(screen.getByText(/Network connection failed/i)).toBeInTheDocument();
+        });
+    });
+
+    it("discards stale responses when datasetId changes", async () => {
+        let resolveFirstPolicy;
+        getInferenceRoutingPolicy.mockImplementationOnce(() => new Promise((resolve) => {
+            resolveFirstPolicy = resolve;
+        }));
+
+        const { rerender } = render(<ModelOrchestrationPage />);
+
+        // Switch route to dataset 102
+        mockRoute.datasetId = "102";
+        getInferenceRoutingPolicy.mockResolvedValueOnce({
+            dataset_id: 102,
+            bindings: [],
+        });
+
+        rerender(<ModelOrchestrationPage />);
+
+        await waitFor(() => {
+            expect(screen.getByTestId("panel-dataset-id")).toHaveTextContent("102");
+        });
+
+        // Resolve first promise after switch
+        if (resolveFirstPolicy) {
+            resolveFirstPolicy({
+                dataset_id: 101,
+                bindings: [{ task: "instance-segmentation", label_id: 1, model_registry_key: "m2f" }],
+            });
+        }
+
+        // Must still show dataset 102 state
+        expect(screen.getByTestId("panel-dataset-id")).toHaveTextContent("102");
+        expect(screen.getByTestId("panel-policy-state")).toHaveTextContent("Saved: 0 bindings");
+    });
+});

--- a/src/pages/ModelZooPage.jsx
+++ b/src/pages/ModelZooPage.jsx
@@ -101,6 +101,11 @@ const transformModel = (model) => ({
 
 const POLL_INTERVAL_MS = 4000;
 
+const normalizeFavorites = (result) =>
+  result?.success && result?.favorites && typeof result.favorites === "object"
+    ? result.favorites
+    : {};
+
 const ModelZooPage = () => {
   const navigate = useNavigate();
   const location = useLocation();
@@ -126,6 +131,17 @@ const ModelZooPage = () => {
   const datasetIdFromState = location.state?.datasetId || datasetId;
   const isFromDatasetManagement = !!datasetIdFromState;
 
+  const resyncFavorites = useCallback(async () => {
+    try {
+      const result = await getModelFavorites();
+      if (!result?.success) return false;
+      setFavorites(normalizeFavorites(result));
+      return true;
+    } catch (_) {
+      return false;
+    }
+  }, []);
+
   const refetchModels = useCallback(async () => {
     try {
       const result = await getAllModels();
@@ -143,20 +159,29 @@ const ModelZooPage = () => {
     const load = async () => {
       setIsLoading(true);
       setError(null);
-      try {
-        const [modelsResult, favResult] = await Promise.all([getAllModels(), getModelFavorites()]);
-        if (cancelled) return;
-        if (modelsResult.success && modelsResult.models) {
-          setModels(modelsResult.models.map(transformModel));
+      const [modelsResult, favoritesResult] = await Promise.allSettled([
+        getAllModels(),
+        getModelFavorites(),
+      ]);
+      if (cancelled) return;
+
+      if (modelsResult.status === "fulfilled") {
+        const result = modelsResult.value;
+        if (result?.success && result.models) {
+          setModels(result.models.map(transformModel));
         } else {
-          setError(modelsResult.error || "Failed to load models from backend");
+          setError(result?.error || "Failed to load models from backend");
         }
-        setFavorites(favResult.favorites || {});
-      } catch (err) {
-        if (!cancelled) setError(err.message || "Failed to load models");
-      } finally {
-        if (!cancelled) setIsLoading(false);
+      } else {
+        setError(modelsResult.reason?.message || "Failed to load models");
       }
+
+      if (favoritesResult.status === "fulfilled") {
+        setFavorites(normalizeFavorites(favoritesResult.value));
+      } else {
+        setFavorites({});
+      }
+      setIsLoading(false);
     };
     load();
     return () => { cancelled = true; };
@@ -200,45 +225,57 @@ const ModelZooPage = () => {
   }, [trainingJobs, refetchModels]);
 
   const isFavorite = useCallback(
-    (model) => (model.tasks || []).some((task) => favorites[task] === model.identifier),
-    [favorites]
+    (model) => {
+      if (selectedTask !== "all") {
+        return favorites[selectedTask] === model.identifier;
+      }
+      return (model.tasks || []).some((task) => favorites[task] === model.identifier);
+    },
+    [favorites, selectedTask]
   );
 
-  // Star toggles the model as favorite for *each* task it serves. Optimistic:
-  // update local state first, then persist per task.
+  // Star toggles the model as personal favorite for a specific task.
   const handleToggleFavorite = useCallback(
-    async (model) => {
+    async (model, specificTask = null) => {
       const id = model.identifier;
-      const tasks = model.tasks || [];
-      const wasFavorite = tasks.some((task) => favorites[task] === id);
+      const targetTask =
+        specificTask ||
+        (selectedTask !== "all"
+          ? selectedTask
+          : model.tasks?.length === 1
+          ? model.tasks[0]
+          : null);
+
+      if (!targetTask) return;
+
+      const wasFavorite = favorites[targetTask] === id;
 
       setFavorites((prev) => {
         const next = { ...prev };
-        for (const task of tasks) {
-          if (wasFavorite) {
-            if (next[task] === id) delete next[task];
-          } else {
-            next[task] = id;
-          }
+        if (wasFavorite) {
+          if (next[targetTask] === id) delete next[targetTask];
+        } else {
+          next[targetTask] = id;
         }
         return next;
       });
 
-      const ops = tasks
-        .map((task) => {
-          if (wasFavorite) return favorites[task] === id ? clearModelFavorite(task) : null;
-          return setModelFavorite(task, id);
-        })
-        .filter(Boolean);
-      const results = await Promise.allSettled(ops);
-      if (results.some((r) => r.status === "rejected" || r.value?.success === false)) {
-        // Re-sync from the server on any failure.
-        const fresh = await getModelFavorites();
-        setFavorites(fresh.favorites || {});
+      let result;
+      try {
+        result = wasFavorite
+          ? await clearModelFavorite(targetTask)
+          : await setModelFavorite(targetTask, id);
+      } catch (_) {
+        // Treat rejected API calls the same as an explicit failure response.
+      }
+
+      if (!result?.success) {
+        const resynced = await resyncFavorites();
+        if (!resynced) setFavorites(favorites);
         addToast({ message: "Couldn't update favorites. Try again.", type: "error" });
       }
     },
-    [favorites, addToast]
+    [favorites, selectedTask, addToast, resyncFavorites]
   );
 
   const handleModelAction = (model, actionType) => {
@@ -455,6 +492,8 @@ const ModelZooPage = () => {
                   <ModelDetailPanel
                     model={selectedModel}
                     isFavorite={selectedModel ? isFavorite(selectedModel) : false}
+                    selectedTask={selectedTask}
+                    favorites={favorites}
                     onToggleFavorite={handleToggleFavorite}
                     onAction={handleModelAction}
                   />
@@ -526,6 +565,8 @@ const ModelZooPage = () => {
                           model={model}
                           isSelected={model.identifier === selectedModelId}
                           isFavorite={isFavorite(model)}
+                          selectedTask={selectedTask}
+                          favorites={favorites}
                           onSelect={(m) => setSelectedModelId(m.identifier)}
                           onToggleFavorite={handleToggleFavorite}
                         />

--- a/src/pages/ModelZooPage.test.jsx
+++ b/src/pages/ModelZooPage.test.jsx
@@ -1,0 +1,203 @@
+import React from "react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { vi, describe, it, expect, beforeEach } from "vitest";
+import ModelZooPage from "./ModelZooPage";
+import {
+    getAllModels,
+    startSemanticTraining,
+    getSemanticTrainingStatus,
+    cancelSemanticTraining,
+} from "../api/training";
+import {
+    getModelFavorites,
+    setModelFavorite,
+    clearModelFavorite,
+} from "../api/models";
+
+const addToast = vi.hoisted(() => vi.fn());
+
+vi.mock("react-router-dom", () => ({
+    useNavigate: () => vi.fn(),
+    useLocation: () => ({ state: {} }),
+    useParams: () => ({}),
+}));
+
+vi.mock("../contexts/AuthContext", () => ({
+    useAuth: () => ({ isAuthenticated: true, user: { username: "tester" } }),
+}));
+
+vi.mock("../contexts/ToastContext", () => ({
+    useToast: () => ({ addToast }),
+}));
+
+vi.mock("../api/training", () => ({
+    getAllModels: vi.fn(),
+    startSemanticTraining: vi.fn(),
+    getSemanticTrainingStatus: vi.fn(),
+    cancelSemanticTraining: vi.fn(),
+}));
+
+vi.mock("../api/models", () => ({
+    getModelFavorites: vi.fn(),
+    setModelFavorite: vi.fn(),
+    clearModelFavorite: vi.fn(),
+}));
+
+describe("ModelZooPage task-specific favorites", () => {
+    const mockModels = [
+        {
+            identifier: "model-dual",
+            name: "Dual Task Model",
+            tasks: ["instance-segmentation", "prompted-segmentation"],
+            description: "Dual purpose model",
+            parameters: {},
+        },
+        {
+            identifier: "model-inst-only",
+            name: "Instance Specialist",
+            tasks: ["instance-segmentation"],
+            description: "Only instance",
+            parameters: {},
+        },
+    ];
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        getAllModels.mockResolvedValue({
+            success: true,
+            models: mockModels,
+        });
+        // Model is favorited ONLY for prompted-segmentation, NOT for instance-segmentation
+        getModelFavorites.mockResolvedValue({
+            success: true,
+            favorites: {
+                "prompted-segmentation": "model-dual",
+            },
+        });
+        setModelFavorite.mockResolvedValue({ success: true });
+        clearModelFavorite.mockResolvedValue({ success: true });
+    });
+
+    it("displays favorite when viewing all tasks, but NOT when viewing task where it is not favorited", async () => {
+        render(<ModelZooPage />);
+
+        await waitFor(() => {
+            expect(screen.getByText("Dual Task Model")).toBeInTheDocument();
+        });
+
+        // Under 'All tasks', favorites facet button exists because favoriteCount > 0
+        expect(screen.getByRole("button", { name: "Favorites" })).toBeInTheDocument();
+
+        // Switch facet to 'Full-Image' (where model-dual is NOT favorited)
+        const instFacetBtn = screen.getByRole("button", { name: "Full-Image" });
+        fireEvent.click(instFacetBtn);
+
+        // Under Full-Image, favorites facet button should NOT be rendered because favoriteCount is 0
+        await waitFor(() => {
+            expect(screen.queryByRole("button", { name: "Favorites" })).not.toBeInTheDocument();
+        });
+    });
+
+    it("sets favorite for the active task when starred in a task-filtered view", async () => {
+        render(<ModelZooPage />);
+
+        await waitFor(() => {
+            expect(screen.getByText("Dual Task Model")).toBeInTheDocument();
+        });
+
+        // Switch to 'Full-Image'
+        const instFacetBtn = screen.getByRole("button", { name: "Full-Image" });
+        fireEvent.click(instFacetBtn);
+
+        // Find star button for Dual Task Model (in chip)
+        const starBtn = screen.getAllByRole("button", { name: "Add to favorites" })[0];
+        fireEvent.click(starBtn);
+
+        expect(setModelFavorite).toHaveBeenCalledWith("instance-segmentation", "model-dual");
+    });
+
+    it("opens task chooser in All view for multi-task model and stars specific task", async () => {
+        render(<ModelZooPage />);
+
+        await waitFor(() => {
+            expect(screen.getByText("Dual Task Model")).toBeInTheDocument();
+        });
+
+        // In 'All' view, click star on Dual Task Model chip
+        const starBtn = screen.getAllByRole("button", { name: "Remove from favorites" })[0];
+        fireEvent.click(starBtn);
+
+        // Task chooser popover should appear with options
+        expect(screen.getByText("Star default for:")).toBeInTheDocument();
+        const instanceOpt = screen.getAllByRole("button", { name: /toggle favorite for instance segmentation/i })[0];
+        fireEvent.click(instanceOpt);
+
+        expect(setModelFavorite).toHaveBeenCalledWith("instance-segmentation", "model-dual");
+    });
+
+    it("loads models when favorites loading rejects", async () => {
+        getModelFavorites.mockRejectedValueOnce(new Error("favorites unavailable"));
+
+        render(<ModelZooPage />);
+
+        await waitFor(() => {
+            expect(screen.getByText("Dual Task Model")).toBeInTheDocument();
+        });
+        expect(screen.queryByText("Failed to load models")).not.toBeInTheDocument();
+    });
+
+    it("resyncs and toasts when setting a favorite resolves unsuccessfully", async () => {
+        getModelFavorites
+            .mockResolvedValueOnce({
+                success: true,
+                favorites: { "prompted-segmentation": "model-dual" },
+            })
+            .mockResolvedValueOnce({ success: true, favorites: {} });
+        setModelFavorite.mockResolvedValueOnce({ success: false });
+
+        render(<ModelZooPage />);
+
+        await waitFor(() => {
+            expect(screen.getByText("Dual Task Model")).toBeInTheDocument();
+        });
+        fireEvent.click(screen.getByRole("button", { name: "Full-Image" }));
+        fireEvent.click(screen.getAllByRole("button", { name: "Add to favorites" })[0]);
+
+        await waitFor(() => {
+            expect(addToast).toHaveBeenCalledWith({
+                message: "Couldn't update favorites. Try again.",
+                type: "error",
+            });
+        });
+        expect(setModelFavorite).toHaveBeenCalledWith("instance-segmentation", "model-dual");
+        expect(getModelFavorites).toHaveBeenCalledTimes(2);
+    });
+
+    it("toasts safely when clearing fails and the favorites resync rejects", async () => {
+        getModelFavorites
+            .mockResolvedValueOnce({
+                success: true,
+                favorites: { "prompted-segmentation": "model-dual" },
+            })
+            .mockRejectedValueOnce(new Error("favorites unavailable"));
+        clearModelFavorite.mockResolvedValueOnce({ success: false });
+
+        render(<ModelZooPage />);
+
+        await waitFor(() => {
+            expect(screen.getByText("Dual Task Model")).toBeInTheDocument();
+        });
+        fireEvent.click(screen.getByRole("button", { name: "Prompted" }));
+        fireEvent.click(screen.getAllByRole("button", { name: "Remove from favorites" })[0]);
+
+        await waitFor(() => {
+            expect(addToast).toHaveBeenCalledWith({
+                message: "Couldn't update favorites. Try again.",
+                type: "error",
+            });
+        });
+        expect(clearModelFavorite).toHaveBeenCalledWith("prompted-segmentation");
+        expect(getModelFavorites).toHaveBeenCalledTimes(2);
+        expect(screen.getAllByRole("button", { name: "Remove from favorites" }).length).toBeGreaterThan(0);
+    });
+});

--- a/src/services/annotationSession.js
+++ b/src/services/annotationSession.js
@@ -59,6 +59,10 @@ const getWsBaseUrl = () => {
     if (apiBase.startsWith('http://')) {
       return apiBase.replace(/^http:\/\//, 'ws://');
     }
+    if (apiBase.startsWith('/') && typeof window !== 'undefined' && window.location.host) {
+      const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+      return `${protocol}//${window.location.host}${apiBase}`;
+    }
   }
 
   return 'ws://localhost:8000';
@@ -712,5 +716,3 @@ class AnnotationSession {
 const annotationSession = new AnnotationSession();
 
 export default annotationSession;
-
-

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,4 +1,15 @@
+import React from 'react';
 import '@testing-library/jest-dom';
 import { vi } from 'vitest';
 
 globalThis.jest = vi;
+vi.mock('canvas', () => ({ default: {} }));
+vi.mock('react-konva', () => ({
+    Stage: ({ children, ...props }) => React.createElement('div', { 'data-testid': 'mock-stage', ...props }, children),
+    Layer: ({ children, ...props }) => React.createElement('div', { 'data-testid': 'mock-layer', ...props }, children),
+    Line: (props) => React.createElement('div', { 'data-testid': 'mock-line', ...props }),
+    Circle: (props) => React.createElement('div', { 'data-testid': 'mock-circle', ...props }),
+    Rect: (props) => React.createElement('div', { 'data-testid': 'mock-rect', ...props }),
+    Group: ({ children, ...props }) => React.createElement('div', { 'data-testid': 'mock-group', ...props }, children),
+    Image: (props) => React.createElement('div', { 'data-testid': 'mock-image', ...props }),
+}));

--- a/src/stores/slices/modelsSlice.js
+++ b/src/stores/slices/modelsSlice.js
@@ -22,6 +22,38 @@ const pickDefaultId = (models, favorite) => {
   return ids[0] ?? null;
 };
 
+const normalizeFavorites = (result) =>
+  result?.success && result?.favorites && typeof result.favorites === 'object'
+    ? result.favorites
+    : {};
+
+const extractLabelIds = (model) => {
+  if (Array.isArray(model?.label_ids)) return model.label_ids;
+  if (model?.label_id != null) return [model.label_id];
+  return [];
+};
+
+let favoritesInFlightPromise = null;
+
+const reconcileFavorites = async (set, fallback) => {
+  try {
+    const result = await getModelFavorites();
+    if (!result?.success) throw new Error('Favorites refresh failed');
+    const favorites = normalizeFavorites(result);
+    set((state) => {
+      state.models.favorites = favorites;
+      state.models.favoritesLoaded = true;
+    });
+    return favorites;
+  } catch (_) {
+    set((state) => {
+      state.models.favorites = fallback;
+      state.models.favoritesLoaded = true;
+    });
+    return fallback;
+  }
+};
+
 export const createModelsSlice = (set, get) => ({
   setPromptedModel: (model) => set((state) => {
     state.models.promptedModel = model;
@@ -47,39 +79,90 @@ export const createModelsSlice = (set, get) => ({
 
   // Load the user's favorite model per task ({ task: registry_key }).
   fetchModelFavorites: async () => {
-    const result = await getModelFavorites();
-    set((state) => {
-      state.models.favorites = result.favorites || {};
-      state.models.favoritesLoaded = true;
-    });
-    return get().models.favorites;
+    if (favoritesInFlightPromise) return favoritesInFlightPromise;
+    favoritesInFlightPromise = (async () => {
+      try {
+        const result = await getModelFavorites();
+        const favorites = result?.success
+          ? normalizeFavorites(result)
+          : get().models.favorites || {};
+        set((state) => {
+          state.models.favorites = favorites;
+          state.models.favoritesLoaded = true;
+        });
+        return favorites;
+      } catch (_) {
+        const favorites = get().models.favorites || {};
+        set((state) => {
+          state.models.favoritesLoaded = true;
+        });
+        return favorites;
+      } finally {
+        favoritesInFlightPromise = null;
+      }
+    })();
+    return favoritesInFlightPromise;
   },
 
   // Fetch favorites once, before defaults are computed.
   ensureFavoritesLoaded: async () => {
     if (get().models.favoritesLoaded) return;
-    await get().fetchModelFavorites();
+    try {
+      await get().fetchModelFavorites();
+    } catch (_) {
+      set((state) => {
+        state.models.favorites = {};
+        state.models.favoritesLoaded = true;
+      });
+    }
   },
 
   // Make `registryKey` the favorite (default) model for `task`. Optimistic;
   // reverts by refetching on failure.
   setFavoriteModel: async (task, registryKey) => {
+    const previousFavorites = { ...(get().models.favorites || {}) };
     set((state) => {
-      state.models.favorites = { ...state.models.favorites, [task]: registryKey };
+      if (!state.models.favorites) state.models.favorites = {};
+      state.models.favorites[task] = registryKey;
+      state.models.favoritesLoaded = true;
     });
-    const res = await setModelFavorite(task, registryKey);
-    if (!res.success) await get().fetchModelFavorites();
+    try {
+      const res = await setModelFavorite(task, registryKey);
+      if (!res?.success) {
+        await reconcileFavorites(set, previousFavorites);
+      }
+    } catch (_) {
+      await reconcileFavorites(set, previousFavorites);
+    }
   },
 
   // Clear the favorite model for `task`.
   clearFavoriteModel: async (task) => {
+    const previousFavorites = { ...(get().models.favorites || {}) };
     set((state) => {
-      const next = { ...state.models.favorites };
-      delete next[task];
-      state.models.favorites = next;
+      if (state.models.favorites) {
+        delete state.models.favorites[task];
+      }
+      state.models.favoritesLoaded = true;
     });
-    const res = await clearModelFavorite(task);
-    if (!res.success) await get().fetchModelFavorites();
+    try {
+      const res = await clearModelFavorite(task);
+      if (!res?.success) {
+        await reconcileFavorites(set, previousFavorites);
+      }
+    } catch (_) {
+      await reconcileFavorites(set, previousFavorites);
+    }
+  },
+
+  // Star / unstar a model for a specific task.
+  toggleFavorite: async (task, modelId) => {
+    const current = get().models.favorites?.[task];
+    if (current === modelId) {
+      await get().clearFavoriteModel(task);
+    } else {
+      await get().setFavoriteModel(task, modelId);
+    }
   },
 
   // --- Available models --------------------------------------------------
@@ -95,9 +178,12 @@ export const createModelsSlice = (set, get) => ({
       if (result.success && result.models && result.models.length > 0) {
         const transformedModels = result.models.map(model => ({
           id: getModelId(model),
+          registry_key: getModelId(model),
+          task: 'instance-suggestion',
           name: model.name,
           description: model.description,
           tags: model.tags,
+          label_ids: extractLabelIds(model),
           supports_refinement: model.refinement_supported,
           model_status: model.model_status || 'ready',
         }));
@@ -137,9 +223,12 @@ export const createModelsSlice = (set, get) => ({
       if (result.success && result.models && result.models.length > 0) {
         const transformedModels = result.models.map(model => ({
           id: getModelId(model),
+          registry_key: getModelId(model),
+          task: 'prompted-segmentation',
           name: model.name,
           description: model.description,
           tags: model.tags,
+          label_ids: extractLabelIds(model),
           supported_prompt_types: model.prompt_types_supported,
           supports_refinement: model.refinement_supported,
           model_status: model.model_status || 'ready',
@@ -181,9 +270,12 @@ export const createModelsSlice = (set, get) => ({
       if (result?.success && modelsList.length > 0) {
         const transformedModels = modelsList.map(model => ({
           id: getModelId(model),
+          registry_key: getModelId(model),
+          task: 'instance-segmentation',
           name: model.name,
           description: model.description,
           tags: model.tags,
+          label_ids: extractLabelIds(model),
           model_status: model.model_status || 'ready',
         }));
 

--- a/src/stores/slices/modelsSlice.test.js
+++ b/src/stores/slices/modelsSlice.test.js
@@ -1,0 +1,185 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import useAnnotationStore from "../useAnnotationStore";
+import * as modelsApi from "../../api/models";
+
+vi.mock("../../api/models", () => ({
+    getModelFavorites: vi.fn(),
+    setModelFavorite: vi.fn(),
+    clearModelFavorite: vi.fn(),
+    getPromptedModels: vi.fn(),
+    getSuggestionModels: vi.fn(),
+}));
+
+describe("modelsSlice favorites", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        modelsApi.getModelFavorites.mockResolvedValue({
+            success: true,
+            favorites: { "prompted-segmentation": "sam2-cell" },
+        });
+        modelsApi.setModelFavorite.mockResolvedValue({ success: true });
+        modelsApi.clearModelFavorite.mockResolvedValue({ success: true });
+
+        // Reset store models state
+        useAnnotationStore.setState((state) => {
+            state.models.favorites = {};
+            state.models.favoritesLoaded = false;
+            state.models.availablePromptedModels = [];
+            state.models.isLoadingModels = false;
+            state.models.promptedModel = null;
+        });
+    });
+
+    it("fetches favorites on ensureFavoritesLoaded when favoritesLoaded is false, and caches it", async () => {
+        const store = useAnnotationStore.getState();
+        expect(store.models.favoritesLoaded).toBe(false);
+
+        await store.ensureFavoritesLoaded();
+
+        expect(modelsApi.getModelFavorites).toHaveBeenCalledTimes(1);
+        expect(useAnnotationStore.getState().models.favorites).toEqual({
+            "prompted-segmentation": "sam2-cell",
+        });
+        expect(useAnnotationStore.getState().models.favoritesLoaded).toBe(true);
+
+        // Second call should not refetch
+        await useAnnotationStore.getState().ensureFavoritesLoaded();
+        expect(modelsApi.getModelFavorites).toHaveBeenCalledTimes(1);
+    });
+
+    it("degrades a success:false favorites response and still loads prompted models", async () => {
+        modelsApi.getModelFavorites.mockResolvedValue({ success: false });
+        modelsApi.getPromptedModels.mockResolvedValue({
+            success: true,
+            models: [{ id: "prompted-1", name: "Prompted model" }],
+        });
+
+        await useAnnotationStore.getState().fetchAvailablePromptedModels();
+
+        expect(useAnnotationStore.getState().models.favorites).toEqual({});
+        expect(useAnnotationStore.getState().models.favoritesLoaded).toBe(true);
+        expect(modelsApi.getPromptedModels).toHaveBeenCalledTimes(1);
+        expect(useAnnotationStore.getState().models.availablePromptedModels).toHaveLength(1);
+        expect(useAnnotationStore.getState().models.isLoadingModels).toBe(false);
+    });
+
+    it("degrades a rejected favorites request and still loads prompted models", async () => {
+        modelsApi.getModelFavorites.mockRejectedValue(new Error("favorites unavailable"));
+        modelsApi.getPromptedModels.mockResolvedValue({
+            success: true,
+            models: [{ id: "prompted-1", name: "Prompted model" }],
+        });
+
+        await useAnnotationStore.getState().fetchAvailablePromptedModels();
+
+        expect(useAnnotationStore.getState().models.favorites).toEqual({});
+        expect(useAnnotationStore.getState().models.favoritesLoaded).toBe(true);
+        expect(modelsApi.getPromptedModels).toHaveBeenCalledTimes(1);
+        expect(useAnnotationStore.getState().models.availablePromptedModels).toHaveLength(1);
+        expect(useAnnotationStore.getState().models.isLoadingModels).toBe(false);
+    });
+
+    it("sets favorite model optimistically and calls setModelFavorite", async () => {
+        const store = useAnnotationStore.getState();
+
+        await store.setFavoriteModel("instance-segmentation", "m2f-base");
+
+        expect(useAnnotationStore.getState().models.favorites["instance-segmentation"]).toBe("m2f-base");
+        expect(modelsApi.setModelFavorite).toHaveBeenCalledWith("instance-segmentation", "m2f-base");
+    });
+
+    it("clears favorite model optimistically and calls clearModelFavorite", async () => {
+        useAnnotationStore.setState((state) => {
+            state.models.favorites = { "prompted-segmentation": "sam2-cell" };
+        });
+
+        const store = useAnnotationStore.getState();
+        await store.clearFavoriteModel("prompted-segmentation");
+
+        expect(useAnnotationStore.getState().models.favorites["prompted-segmentation"]).toBeUndefined();
+        expect(modelsApi.clearModelFavorite).toHaveBeenCalledWith("prompted-segmentation");
+    });
+
+    it("resyncs favorites when an optimistic update rejects", async () => {
+        modelsApi.setModelFavorite.mockRejectedValueOnce(new Error("update failed"));
+        modelsApi.getModelFavorites.mockResolvedValueOnce({
+            success: true,
+            favorites: { "prompted-segmentation": "server-default" },
+        });
+
+        await useAnnotationStore
+            .getState()
+            .setFavoriteModel("prompted-segmentation", "local-choice");
+
+        expect(useAnnotationStore.getState().models.favorites).toEqual({
+            "prompted-segmentation": "server-default",
+        });
+    });
+
+    it("restores known favorites when mutation and resync both fail", async () => {
+        useAnnotationStore.setState((state) => {
+            state.models.favorites = { "prompted-segmentation": "sam2-cell" };
+            state.models.favoritesLoaded = true;
+        });
+        modelsApi.clearModelFavorite.mockRejectedValueOnce(new Error("update failed"));
+        modelsApi.getModelFavorites.mockRejectedValueOnce(new Error("refresh failed"));
+
+        await useAnnotationStore.getState().clearFavoriteModel("prompted-segmentation");
+
+        expect(useAnnotationStore.getState().models.favorites).toEqual({
+            "prompted-segmentation": "sam2-cell",
+        });
+    });
+
+    it("toggles favorite between set and clear", async () => {
+        const store = useAnnotationStore.getState();
+
+        // Initially empty -> sets favorite
+        await store.toggleFavorite("prompted-segmentation", "sam2-cell");
+        expect(useAnnotationStore.getState().models.favorites["prompted-segmentation"]).toBe("sam2-cell");
+        expect(modelsApi.setModelFavorite).toHaveBeenCalledWith("prompted-segmentation", "sam2-cell");
+
+        // Already favorited with same model -> clears favorite
+        await store.toggleFavorite("prompted-segmentation", "sam2-cell");
+        expect(useAnnotationStore.getState().models.favorites["prompted-segmentation"]).toBeUndefined();
+        expect(modelsApi.clearModelFavorite).toHaveBeenCalledWith("prompted-segmentation");
+    });
+
+    it("deduplicates concurrent in-flight fetchModelFavorites calls", async () => {
+        const store = useAnnotationStore.getState();
+
+        // Trigger multiple concurrent fetches before first finishes
+        const [res1, res2, res3] = await Promise.all([
+            store.fetchModelFavorites(),
+            store.fetchModelFavorites(),
+            store.fetchModelFavorites(),
+        ]);
+
+        expect(modelsApi.getModelFavorites).toHaveBeenCalledTimes(1);
+        expect(res1).toEqual({ "prompted-segmentation": "sam2-cell" });
+        expect(res2).toEqual({ "prompted-segmentation": "sam2-cell" });
+        expect(res3).toEqual({ "prompted-segmentation": "sam2-cell" });
+    });
+
+    it("deduplicates a failed fetch and permits a later retry", async () => {
+        modelsApi.getModelFavorites.mockRejectedValueOnce(new Error("favorites unavailable"));
+        const store = useAnnotationStore.getState();
+
+        const results = await Promise.all([
+            store.fetchModelFavorites(),
+            store.fetchModelFavorites(),
+            store.fetchModelFavorites(),
+        ]);
+
+        expect(modelsApi.getModelFavorites).toHaveBeenCalledTimes(1);
+        expect(results).toEqual([{}, {}, {}]);
+        expect(useAnnotationStore.getState().models.favoritesLoaded).toBe(true);
+
+        useAnnotationStore.setState((state) => {
+            state.models.favoritesLoaded = false;
+        });
+        await useAnnotationStore.getState().fetchModelFavorites();
+
+        expect(modelsApi.getModelFavorites).toHaveBeenCalledTimes(2);
+    });
+});

--- a/src/stores/slices/objectsSlice.js
+++ b/src/stores/slices/objectsSlice.js
@@ -9,11 +9,20 @@ export const createObjectsSlice = (set) => ({
   setDatasetLabels: (labelsArray, labelsMap) => set((state) => {
     state.objects.datasetLabels = labelsArray;
     state.objects.datasetLabelsMap = labelsMap;
+    if (state.workspace?.activeLabelId != null) {
+      const exists = Array.isArray(labelsArray) && labelsArray.some((l) => Number(l.id) === Number(state.workspace.activeLabelId));
+      if (!exists) {
+        state.workspace.activeLabelId = null;
+      }
+    }
   }),
 
   clearDatasetLabels: () => set((state) => {
     state.objects.datasetLabels = [];
     state.objects.datasetLabelsMap = null;
+    if (state.workspace?.activeLabelId != null) {
+      state.workspace.activeLabelId = null;
+    }
   }),
 
   addObject: (object) => set((state) => {
@@ -66,11 +75,12 @@ export const createObjectsSlice = (set) => ({
     
     // labelsMap is always a Map or null (constructed in AnnotationPageV2)
     const labelIdToNameMap = labelsMap;
+    const payload = hierarchy?.contours || hierarchy;
     
-    if (hierarchy && Array.isArray(hierarchy.root_contours)) {
+    if (payload && Array.isArray(payload.root_contours)) {
       // Queue entries are { contour, parentId } so we preserve hierarchy when backend
       // returns nested children without parent_id on each node (e.g. after page refresh)
-      const queue = hierarchy.root_contours.map(c => ({ contour: c, parentId: null }));
+      const queue = payload.root_contours.map(c => ({ contour: c, parentId: null }));
       let orderCounter = 0;
 
       while (queue.length > 0) {

--- a/src/stores/slices/objectsSlice.test.js
+++ b/src/stores/slices/objectsSlice.test.js
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import useAnnotationStore from "../useAnnotationStore";
+
+describe("objectsSlice setObjectsFromHierarchy", () => {
+    beforeEach(() => {
+        useAnnotationStore.setState((state) => {
+            state.objects = {
+                list: [],
+                colors: {},
+                selectedIds: [],
+                visible: {},
+                locked: {},
+            };
+        });
+    });
+
+    it("populates objects correctly from raw root_contours shape", () => {
+        const labelsMap = new Map([
+            [1, "Coral"],
+            ["1", "Coral"],
+        ]);
+
+        const rawHierarchy = {
+            root_contours: [
+                {
+                    id: 101,
+                    label_id: 1,
+                    points: [{ x: 0.1, y: 0.2 }],
+                    children: [],
+                },
+            ],
+        };
+
+        const store = useAnnotationStore.getState();
+        store.setObjectsFromHierarchy(rawHierarchy, labelsMap);
+
+        const updated = useAnnotationStore.getState().objects;
+        expect(updated.list.length).toBe(1);
+        expect(updated.list[0].id).toBe(101);
+        expect(updated.list[0].label).toBe("Coral");
+    });
+
+    it("populates objects correctly from backend API envelope { contours: { root_contours: [...] } }", () => {
+        const labelsMap = new Map([
+            [2, "Bleached"],
+            ["2", "Bleached"],
+        ]);
+
+        const backendEnvelope = {
+            success: true,
+            message: "Contours hierarchy retrieved.",
+            contours: {
+                root_contours: [
+                    {
+                        id: 202,
+                        label_id: 2,
+                        points: [{ x: 0.3, y: 0.4 }],
+                        children: [
+                            {
+                                id: 203,
+                                label_id: 2,
+                                points: [{ x: 0.35, y: 0.45 }],
+                                children: [],
+                            },
+                        ],
+                    },
+                ],
+            },
+        };
+
+        const store = useAnnotationStore.getState();
+        store.setObjectsFromHierarchy(backendEnvelope, labelsMap);
+
+        const updated = useAnnotationStore.getState().objects;
+        expect(updated.list.length).toBe(2);
+        expect(updated.list[0].id).toBe(202);
+        expect(updated.list[0].label).toBe("Bleached");
+        expect(updated.list[1].id).toBe(203);
+        expect(updated.list[1].parent_id).toBe(202);
+    });
+});

--- a/src/utils/inferenceRouting.js
+++ b/src/utils/inferenceRouting.js
@@ -1,0 +1,142 @@
+/**
+ * Reusable routing policy resolution utilities (Issue #31 Task-Aware Model Routing).
+ *
+ * Provides resolution of (task, label) bindings, inheritance cascades, class-aware
+ * model compatibility checks, and deterministic batch plan construction.
+ */
+
+import { BATCH_INFERENCE_TASKS } from "../constants/tasks";
+
+/**
+ * Checks whether a catalog model is compatible with a given label ID.
+ * Returns true if the model is class-agnostic or explicitly predicts labelId.
+ */
+export const isModelCompatibleWithLabel = (model, labelId) => {
+    if (!model || labelId == null) return true;
+    if (!model.label_ids || model.label_ids.length === 0) return true;
+    return model.label_ids.includes(Number(labelId));
+};
+
+/**
+ * Resolves the effective routing binding for a (task, label) pair against a policy.
+ *
+ * Checks exact label override first, then falls back to task default.
+ * If a task default model is class-aware and does not predict the target label,
+ * isCompatible is marked false.
+ *
+ * @param {object|null} policy - Stored DatasetModelRoutingRead object
+ * @param {string} task - Routing task key
+ * @param {number|null} labelId - Target label ID or null for task default
+ * @param {Array} catalogModels - Live models in the catalog for contract and compatibility lookup
+ * @returns {object|null} { binding, model, isOverride, isTaskDefault, isCompatible, isStale }
+ */
+export const matchesModelKey = (m, task, key) => {
+    if (!m || !key) return false;
+    const taskMatch = !m.task || m.task === task;
+    const keyMatch =
+        m.registry_key === key ||
+        m.id === key ||
+        m.identifier === key ||
+        String(m.id) === String(key);
+    return taskMatch && keyMatch;
+};
+
+export const resolveRoutingBinding = (policy, task, labelId = null, catalogModels = null) => {
+    if (!policy || !Array.isArray(policy.bindings)) return null;
+    const hasCatalog = catalogModels != null && Array.isArray(catalogModels);
+
+    // 1. Check exact label override
+    if (labelId != null) {
+        const override = policy.bindings.find(
+            (b) => b.task === task && Number(b.label_id) === Number(labelId)
+        );
+        if (override) {
+            const model = hasCatalog
+                ? catalogModels.find((m) => matchesModelKey(m, task, override.model_registry_key))
+                : null;
+            const isStale = Boolean(hasCatalog && !model);
+            const isCompatible = isStale
+                ? false
+                : !hasCatalog
+                ? true
+                : isModelCompatibleWithLabel(model, labelId);
+            return {
+                binding: override,
+                model: model || null,
+                isOverride: true,
+                isTaskDefault: false,
+                isCompatible,
+                isStale,
+            };
+        }
+    }
+
+    // 2. Check task default
+    const defaultBinding = policy.bindings.find(
+        (b) => b.task === task && (b.label_id == null || b.label_id === undefined)
+    );
+    if (defaultBinding) {
+        const model = hasCatalog
+            ? catalogModels.find((m) => matchesModelKey(m, task, defaultBinding.model_registry_key))
+            : null;
+        const isStale = Boolean(hasCatalog && !model);
+        const isCompatible = isStale
+            ? false
+            : !hasCatalog || labelId == null
+            ? true
+            : isModelCompatibleWithLabel(model, labelId);
+        return {
+            binding: defaultBinding,
+            model: model || null,
+            isOverride: false,
+            isTaskDefault: true,
+            isCompatible,
+            isStale,
+        };
+    }
+
+    return null;
+};
+
+/**
+ * Builds a deterministic batch step mapping from policy bindings.
+ *
+ * @param {object|null} policy - Stored routing policy
+ * @param {object} labelsById - Map of label ID -> label object
+ * @param {Array} catalogModels - Live models list
+ * @param {string|null} preferredTask - Optional explicit task filter ("instance-segmentation" | "cross-image-suggestion")
+ * @returns {object} Map of labelId -> step object
+ */
+export const getBatchStepsFromPolicy = (
+    policy,
+    labelsById = {},
+    catalogModels = [],
+    preferredTask = null
+) => {
+    if (!policy || !Array.isArray(policy.bindings)) return {};
+
+    const steps = {};
+    const labels = Object.values(labelsById || {});
+    const tasksToCheck = preferredTask
+        ? [preferredTask]
+        : ["instance-segmentation", "cross-image-suggestion"];
+
+    labels.forEach((label) => {
+        for (const task of tasksToCheck) {
+            if (!BATCH_INFERENCE_TASKS.includes(task)) continue;
+            const resolved = resolveRoutingBinding(policy, task, label.id, catalogModels);
+            if (resolved && resolved.binding && resolved.isCompatible && !resolved.isStale) {
+                steps[label.id] = {
+                    label_id: Number(label.id),
+                    model_registry_key: resolved.binding.model_registry_key,
+                    task: resolved.binding.task,
+                    inputs: resolved.binding.inputs || null,
+                    min_confidence: 0.0,
+                };
+                break; // Found highest-priority valid batch step for this label
+            }
+        }
+    });
+
+    return steps;
+};

--- a/src/utils/inferenceRouting.test.js
+++ b/src/utils/inferenceRouting.test.js
@@ -1,0 +1,213 @@
+import { describe, it, expect } from "vitest";
+import {
+    isModelCompatibleWithLabel,
+    resolveRoutingBinding,
+    getBatchStepsFromPolicy,
+} from "./inferenceRouting";
+
+describe("inferenceRouting utilities", () => {
+    const catalogModels = [
+        {
+            registry_key: "m2f-generic",
+            task: "instance-segmentation",
+            label_ids: [],
+        },
+        {
+            registry_key: "m2f-cell-specialist",
+            task: "instance-segmentation",
+            label_ids: [1],
+        },
+        {
+            registry_key: "sam3-cross",
+            task: "cross-image-suggestion",
+            label_ids: [],
+        },
+        {
+            registry_key: "sam3-cross-nucleus",
+            task: "cross-image-suggestion",
+            label_ids: [2],
+        },
+    ];
+
+    const labelsById = {
+        1: { id: 1, name: "cell" },
+        2: { id: 2, name: "nucleus" },
+        3: { id: 3, name: "background" },
+    };
+
+    it("evaluates model label compatibility accurately", () => {
+        const classAgnostic = { label_ids: [] };
+        const specialist = { label_ids: [1, 2] };
+
+        expect(isModelCompatibleWithLabel(classAgnostic, 1)).toBe(true);
+        expect(isModelCompatibleWithLabel(classAgnostic, 99)).toBe(true);
+        expect(isModelCompatibleWithLabel(specialist, 1)).toBe(true);
+        expect(isModelCompatibleWithLabel(specialist, 2)).toBe(true);
+        expect(isModelCompatibleWithLabel(specialist, 3)).toBe(false);
+    });
+
+    it("prefers exact label override over task default", () => {
+        const policy = {
+            dataset_id: 10,
+            bindings: [
+                {
+                    task: "instance-segmentation",
+                    label_id: null,
+                    model_registry_key: "m2f-generic",
+                },
+                {
+                    task: "instance-segmentation",
+                    label_id: 1,
+                    model_registry_key: "m2f-cell-specialist",
+                },
+            ],
+        };
+
+        const resolvedCell = resolveRoutingBinding(
+            policy,
+            "instance-segmentation",
+            1,
+            catalogModels
+        );
+        expect(resolvedCell.isOverride).toBe(true);
+        expect(resolvedCell.binding.model_registry_key).toBe("m2f-cell-specialist");
+        expect(resolvedCell.isCompatible).toBe(true);
+
+        const resolvedNucleus = resolveRoutingBinding(
+            policy,
+            "instance-segmentation",
+            2,
+            catalogModels
+        );
+        expect(resolvedNucleus.isOverride).toBe(false);
+        expect(resolvedNucleus.isTaskDefault).toBe(true);
+        expect(resolvedNucleus.binding.model_registry_key).toBe("m2f-generic");
+        expect(resolvedNucleus.isCompatible).toBe(true);
+    });
+
+    it("safely handles class-aware task defaults", () => {
+        const policy = {
+            dataset_id: 10,
+            bindings: [
+                {
+                    task: "cross-image-suggestion",
+                    label_id: null,
+                    model_registry_key: "sam3-cross-nucleus", // only predicts label 2
+                },
+            ],
+        };
+
+        // Label 2 (nucleus): compatible
+        const resolvedNucleus = resolveRoutingBinding(
+            policy,
+            "cross-image-suggestion",
+            2,
+            catalogModels
+        );
+        expect(resolvedNucleus.isTaskDefault).toBe(true);
+        expect(resolvedNucleus.isCompatible).toBe(true);
+
+        // Label 1 (cell): NOT compatible with the class-aware default
+        const resolvedCell = resolveRoutingBinding(
+            policy,
+            "cross-image-suggestion",
+            1,
+            catalogModels
+        );
+        expect(resolvedCell.isTaskDefault).toBe(true);
+        expect(resolvedCell.isCompatible).toBe(false);
+    });
+
+    it("flags stale bindings when the model is not in the live catalog", () => {
+        const policy = {
+            dataset_id: 10,
+            bindings: [
+                {
+                    task: "instance-segmentation",
+                    label_id: 1,
+                    model_registry_key: "retired-model",
+                },
+            ],
+        };
+
+        const resolved = resolveRoutingBinding(
+            policy,
+            "instance-segmentation",
+            1,
+            catalogModels
+        );
+        expect(resolved.isStale).toBe(true);
+        expect(resolved.isCompatible).toBe(false);
+        expect(resolved.model).toBeNull();
+
+        // Stale model is never included in executable batch steps
+        const steps = getBatchStepsFromPolicy(policy, labelsById, catalogModels);
+        expect(steps[1]).toBeUndefined();
+    });
+
+    it("marks models as stale when catalog is successfully loaded as empty array", () => {
+        const policy = {
+            dataset_id: 10,
+            bindings: [
+                {
+                    task: "cross-image-suggestion",
+                    label_id: 1,
+                    model_registry_key: "sam3-cross",
+                },
+            ],
+        };
+
+        // When catalog loaded with 0 models
+        const resolvedEmpty = resolveRoutingBinding(
+            policy,
+            "cross-image-suggestion",
+            1,
+            []
+        );
+        expect(resolvedEmpty.isStale).toBe(true);
+        expect(resolvedEmpty.isCompatible).toBe(false);
+
+        // When catalog was not provided (null)
+        const resolvedUnprovided = resolveRoutingBinding(
+            policy,
+            "cross-image-suggestion",
+            1,
+            null
+        );
+        expect(resolvedUnprovided.isStale).toBe(false);
+        expect(resolvedUnprovided.isCompatible).toBe(true);
+    });
+
+    it("constructs batch steps deterministically with preferredTask filter", () => {
+        const policy = {
+            dataset_id: 10,
+            bindings: [
+                {
+                    task: "instance-segmentation",
+                    label_id: null,
+                    model_registry_key: "m2f-generic",
+                },
+                {
+                    task: "cross-image-suggestion",
+                    label_id: 1,
+                    model_registry_key: "sam3-cross",
+                },
+            ],
+        };
+
+        // Default prioritization: instance-segmentation default covers 1, 2, 3
+        const allSteps = getBatchStepsFromPolicy(policy, labelsById, catalogModels);
+        expect(allSteps[1].model_registry_key).toBe("m2f-generic");
+        expect(allSteps[2].model_registry_key).toBe("m2f-generic");
+
+        // Explicit cross-image preference: label 1 gets sam3-cross, label 2 has no cross-image default/override
+        const crossSteps = getBatchStepsFromPolicy(
+            policy,
+            labelsById,
+            catalogModels,
+            "cross-image-suggestion"
+        );
+        expect(crossSteps[1].model_registry_key).toBe("sam3-cross");
+        expect(crossSteps[2]).toBeUndefined();
+    });
+});


### PR DESCRIPTION
## Summary

Implements [Issue #31](https://github.com/Iquana-tool/iquana-tool/issues/31): dataset-level, task-aware model orchestration.

- Added Model Orchestration page under Dataset Management.
- Added task defaults and per-label model overrides.
- Integrated routing with canvas and batch inference.
- Added task-specific Model Zoo favorites.
- Added Cross-Image Suggestion controls.
- Removed legacy template configuration UI.